### PR TITLE
Add 'lithos inspect' command group

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -391,7 +391,7 @@ def inspect_health(ctx: click.Context) -> None:
     status: dict[str, str] = {}
 
     try:
-        engine.tantivy.index  # triggers open_or_create if needed
+        _ = engine.tantivy.index  # triggers open_or_create if needed
         status["tantivy"] = "ok"
     except Exception as exc:
         status["tantivy"] = f"unavailable: {exc}"
@@ -434,9 +434,7 @@ def inspect_agents(ctx: click.Context) -> None:
 
         for agent in agents:
             last_seen = (
-                agent.last_seen_at.strftime("%Y-%m-%d %H:%M:%S")
-                if agent.last_seen_at
-                else "never"
+                agent.last_seen_at.strftime("%Y-%m-%d %H:%M:%S") if agent.last_seen_at else "never"
             )
             click.echo(f"  {agent.id}")
             click.echo(f"    name:      {agent.name or '—'}")
@@ -500,7 +498,7 @@ def inspect_doc(ctx: click.Context, identifier: str, content: bool) -> None:
                 doc, truncated = await knowledge.read(path=identifier)
         except Exception as exc:
             click.echo(f"Error: {exc}", err=True)
-            raise SystemExit(1)
+            raise SystemExit(1) from exc
 
         click.echo(f"Document: {doc.title}")
         click.echo("=" * 50)


### PR DESCRIPTION
## What

Adds a new `lithos inspect` command group with four subcommands for drilling into live system state:

```
lithos inspect health   # backend availability (exits 1 if any backend is down)
lithos inspect agents   # registered agents with name, type, last-seen timestamp
lithos inspect tasks    # open coordination tasks and their active claims
lithos inspect doc <id|path>  # doc frontmatter + metadata; --content for full body
```

## Why

The existing `lithos stats` command gives aggregate counts but no drill-down. When debugging agent behaviour or diagnosing issues, you need to see which agents are active, what tasks are open and claimed, and what's in a specific document — without reading raw files or querying SQLite directly.

`inspect health` also provides a scriptable health-check (exit code 0 = all ok, 1 = degraded) useful for Docker healthchecks or monitoring.

## Tests

Full suite: **135 passed**. No existing tests broken.

The commands were validated manually against a live data directory:
- `inspect health` correctly reports ✓ for both backends
- `inspect agents` and `inspect tasks` return clean empty-state messages on a fresh instance
- `inspect doc` resolves by both UUID and path