### PR TITLE
fix: default SSE bind to 127.0.0.1, add optional auth token

### DIFF
--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -13,9 +13,10 @@ class ServerConfig(BaseModel):
     """Server configuration."""
 
     transport: Literal["stdio", "sse"] = "stdio"
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8765
     watch_files: bool = True
+    auth_token: str | None = None
 
 
 class StorageConfig(BaseModel):

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -132,6 +132,18 @@ class LithosServer:
                     media_type="text/plain",
                 )
 
+        # Simple static token auth for SSE endpoint (independent of FastMCP auth)
+        server_auth_token = self._config.server.auth_token
+        if server_auth_token is not None:
+            auth_header = request.headers.get("authorization", "")
+            expected = f"Bearer {server_auth_token}"
+            if auth_header != expected:
+                return Response(
+                    content="Authentication required",
+                    status_code=401,
+                    media_type="text/plain",
+                )
+
         if self._sse_client_count >= sse_config.max_sse_clients:
             return Response(
                 content="Too many SSE clients",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,9 +48,10 @@ class TestConfigDefaults:
         """Server config has sensible defaults."""
         config = ServerConfig()
 
-        assert config.host == "0.0.0.0"
+        assert config.host == "127.0.0.1"
         assert config.port > 0
         assert config.watch_files is True
+        assert config.auth_token is None
 
     def test_full_config_defaults(self):
         """Full config assembles all defaults."""

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -192,6 +192,7 @@ def _make_mock_request(
     tags: str | None = None,
     since: str | None = None,
     last_event_id: str | None = None,
+    authorization: str | None = None,
 ) -> Request:
     """Build a minimal Starlette Request pointing at the SSE endpoint."""
     params: list[tuple[str, str]] = []
@@ -207,6 +208,8 @@ def _make_mock_request(
     headers: list[tuple[bytes, bytes]] = []
     if last_event_id:
         headers.append((b"last-event-id", last_event_id.encode()))
+    if authorization:
+        headers.append((b"authorization", authorization.encode()))
 
     scope = {
         "type": "http",
@@ -654,5 +657,69 @@ class TestSSERouteIntegration:
 
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(_check(), timeout=2.0)
+        finally:
+            server.stop_file_watcher()
+
+
+# ---------------------------------------------------------------------------
+# Unit: Static auth_token on ServerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAuthToken:
+    @pytest.mark.asyncio
+    async def test_no_auth_token_allows_access(self, temp_dir: Path) -> None:
+        """When auth_token is not set, the SSE endpoint is open."""
+        config = _make_config(temp_dir)
+        assert config.server.auth_token is None
+        server = LithosServer(config)
+        await server.initialize()
+        try:
+            request = _make_mock_request(server)
+            response = await server._sse_endpoint(request)
+            assert response.status_code != 401
+        finally:
+            server.stop_file_watcher()
+
+    @pytest.mark.asyncio
+    async def test_auth_token_missing_header_returns_401(self, temp_dir: Path) -> None:
+        """When auth_token is set and no Authorization header is sent, return 401."""
+        config = _make_config(temp_dir)
+        config.server.auth_token = "secret"
+        server = LithosServer(config)
+        await server.initialize()
+        try:
+            request = _make_mock_request(server)
+            response = await server._sse_endpoint(request)
+            assert response.status_code == 401
+        finally:
+            server.stop_file_watcher()
+
+    @pytest.mark.asyncio
+    async def test_auth_token_wrong_token_returns_401(self, temp_dir: Path) -> None:
+        """When auth_token is set and a wrong token is sent, return 401."""
+        config = _make_config(temp_dir)
+        config.server.auth_token = "secret"
+        server = LithosServer(config)
+        await server.initialize()
+        try:
+            request = _make_mock_request(server, authorization="Bearer wrong-token")
+            response = await server._sse_endpoint(request)
+            assert response.status_code == 401
+        finally:
+            server.stop_file_watcher()
+
+    @pytest.mark.asyncio
+    async def test_auth_token_correct_token_allows_access(self, temp_dir: Path) -> None:
+        """When auth_token is set and the correct token is sent, access is granted."""
+        config = _make_config(temp_dir)
+        config.server.auth_token = "secret"
+        server = LithosServer(config)
+        await server.initialize()
+        try:
+            request = _make_mock_request(server, authorization="Bearer secret")
+            response = await server._sse_endpoint(request)
+            assert response.status_code != 401
+            assert isinstance(response, StreamingResponse)
         finally:
             server.stop_file_watcher()


### PR DESCRIPTION
## Summary

Fixes the SSE/MCP server insecure default bind address and adds optional token-based authentication.

## Changes

- `src/lithos/config.py`: Changed `ServerConfig.host` default from `"0.0.0.0"` to `"127.0.0.1"`
- `src/lithos/config.py`: Added `auth_token: str | None = None` to `ServerConfig` for optional bearer token auth
- `src/lithos/server.py`: In `_sse_endpoint`, check `Authorization: Bearer <token>` header when `auth_token` is configured; return 401 if missing/invalid
- Tests: Added coverage for the new default and auth token enforcement

## Security

Binding to `0.0.0.0` by default exposes the SSE endpoint to all network interfaces. Switching the default to `127.0.0.1` ensures local-only access unless explicitly configured otherwise. The optional `auth_token` provides an additional authentication layer when the server must be exposed on a wider interface.

Fixes agent-lore/lithos#33