### PR TITLE
fix: add version guard to graph cache

### DIFF
--- a/src/lithos/graph.py
+++ b/src/lithos/graph.py
@@ -1,6 +1,7 @@
 """Knowledge graph - NetworkX wiki-link graph operations."""
 
 import contextlib
+import logging
 import os
 import pickle
 import tempfile
@@ -12,6 +13,10 @@ import networkx as nx
 
 from lithos.config import LithosConfig, get_config
 from lithos.knowledge import KnowledgeDocument
+
+logger = logging.getLogger(__name__)
+
+GRAPH_CACHE_VERSION = 1
 
 
 @dataclass
@@ -77,11 +82,19 @@ class KnowledgeGraph:
         try:
             with open(cache_path, "rb") as f:
                 data = pickle.load(f)
-                self._graph = data.get("graph", nx.DiGraph())
-                self._id_to_node = data.get("id_to_node", {})
-                self._path_to_node = data.get("path_to_node", {})
-                self._filename_to_nodes = data.get("filename_to_nodes", {})
-                self._alias_to_node = data.get("alias_to_node", {})
+            cached_version = data.get("version")
+            if cached_version != GRAPH_CACHE_VERSION:
+                logger.warning(
+                    "Graph cache version mismatch (expected %s, got %s), triggering rebuild",
+                    GRAPH_CACHE_VERSION,
+                    cached_version,
+                )
+                return False
+            self._graph = data.get("graph", nx.DiGraph())
+            self._id_to_node = data.get("id_to_node", {})
+            self._path_to_node = data.get("path_to_node", {})
+            self._filename_to_nodes = data.get("filename_to_nodes", {})
+            self._alias_to_node = data.get("alias_to_node", {})
             return True
         except Exception:
             return False
@@ -92,6 +105,7 @@ class KnowledgeGraph:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
 
         data = {
+            "version": GRAPH_CACHE_VERSION,
             "graph": self._graph,
             "id_to_node": self._id_to_node,
             "path_to_node": self._path_to_node,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,10 @@
 """Tests for graph module - NetworkX knowledge graph."""
 
+import pickle
+
 import pytest
 
-from lithos.graph import KnowledgeGraph
+from lithos.graph import GRAPH_CACHE_VERSION, KnowledgeGraph
 from lithos.knowledge import KnowledgeManager
 
 
@@ -540,3 +542,45 @@ class TestGraphPersistence:
 
         assert rebuilt_stats["nodes"] == original_stats["nodes"]
         assert rebuilt_stats["edges"] == original_stats["edges"]
+
+
+class TestGraphCacheVersionGuard:
+    """Tests for graph cache version guard."""
+
+    def test_version_written_to_cache(self, knowledge_graph: KnowledgeGraph):
+        """save_cache writes the GRAPH_CACHE_VERSION key into the pickle."""
+        knowledge_graph.save_cache()
+        with open(knowledge_graph.graph_cache_path, "rb") as f:
+            data = pickle.load(f)
+        assert data["version"] == GRAPH_CACHE_VERSION
+
+    def test_version_mismatch_triggers_rebuild(self, knowledge_graph: KnowledgeGraph):
+        """load_cache returns False when version does not match."""
+        cache_path = knowledge_graph.graph_cache_path
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "version": 999,
+            "graph": None,
+            "id_to_node": {},
+            "path_to_node": {},
+            "filename_to_nodes": {},
+            "alias_to_node": {},
+        }
+        with open(cache_path, "wb") as f:
+            pickle.dump(data, f)
+        assert knowledge_graph.load_cache() is False
+
+    def test_missing_version_triggers_rebuild(self, knowledge_graph: KnowledgeGraph):
+        """load_cache returns False when version key is absent (old cache)."""
+        cache_path = knowledge_graph.graph_cache_path
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "graph": None,
+            "id_to_node": {},
+            "path_to_node": {},
+            "filename_to_nodes": {},
+            "alias_to_node": {},
+        }
+        with open(cache_path, "wb") as f:
+            pickle.dump(data, f)
+        assert knowledge_graph.load_cache() is False


### PR DESCRIPTION
## Summary

Adds a version field to the graph cache pickle format. On load, if the version is missing or doesn't match `GRAPH_CACHE_VERSION`, the cache is rejected and a full rebuild is triggered instead of silently loading a potentially corrupt/incompatible cache.

## Changes

- `src/lithos/graph.py`: Added `GRAPH_CACHE_VERSION = 1` constant; `save_cache()` now writes the version into the pickle dict; `load_cache()` checks for version presence and match, returning `False` (triggering rebuild) on mismatch or missing key.
- `tests/test_graph.py`: Added `TestGraphCacheVersionGuard` with three tests: version written, version mismatch returns False, missing version returns False.

## Test Results

All 5 checks pass:
- `pytest -m "not integration"`: 368 passed
- `pytest -m integration`: 209 passed
- `ruff check`: clean
- `ruff format --check`: clean
- `pyright`: 0 errors

Fixes agent-lore/lithos#39