### PR TITLE
feat: add lithos_task_cancel lifecycle state (#79)

### DIFF
--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -432,6 +432,32 @@ class CoordinationService:
             await db.commit()
             return True
 
+    @traced("lithos.coordination.cancel_task")
+    async def cancel_task(self, task_id: str, agent: str, reason: str | None = None) -> bool:
+        """Mark task as cancelled and release all claims.
+
+        Returns:
+            True if task was cancelled
+        """
+        lithos_metrics.coordination_ops.add(1, {"op": "cancel"})
+        await self.ensure_agent_known(agent)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "UPDATE tasks SET status = 'cancelled' WHERE id = ? AND status = 'open'",
+                (task_id,),
+            )
+            if cursor.rowcount == 0:
+                return False
+
+            await db.execute(
+                "DELETE FROM claims WHERE task_id = ?",
+                (task_id,),
+            )
+
+            await db.commit()
+            return True
+
     async def get_task_status(
         self,
         task_id: str | None = None,

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -35,6 +35,7 @@ TASK_CREATED = "task.created"
 TASK_CLAIMED = "task.claimed"
 TASK_RELEASED = "task.released"
 TASK_COMPLETED = "task.completed"
+TASK_CANCELLED = "task.cancelled"
 
 FINDING_POSTED = "finding.posted"
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -26,6 +26,7 @@ from lithos.events import (
     NOTE_CREATED,
     NOTE_DELETED,
     NOTE_UPDATED,
+    TASK_CANCELLED,
     TASK_CLAIMED,
     TASK_COMPLETED,
     TASK_CREATED,
@@ -1561,6 +1562,46 @@ class LithosServer:
                             type=TASK_COMPLETED,
                             agent=agent,
                             payload={"task_id": task_id, "agent": agent},
+                        )
+                    )
+
+                return {"success": success}
+
+        @self.mcp.tool()
+        async def lithos_task_cancel(
+            task_id: str,
+            agent: str,
+            reason: str | None = None,
+        ) -> dict[str, bool]:
+            """Cancel a task, releasing all claims.
+
+            Args:
+                task_id: Task ID
+                agent: Agent cancelling the task
+                reason: Optional reason for cancellation
+
+            Returns:
+                Dict with success boolean
+            """
+            logger.info("lithos_task_cancel task=%s agent=%s reason=%s", task_id, agent, reason)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_cancel") as span:
+                span.set_attribute("lithos.tool", "lithos_task_cancel")
+                span.set_attribute("lithos.agent", agent)
+                span.set_attribute("lithos.task_id", task_id)
+                success = await self.coordination.cancel_task(
+                    task_id=task_id,
+                    agent=agent,
+                    reason=reason,
+                )
+                span.set_attribute("lithos.success", success)
+
+                if success:
+                    await self._emit(
+                        LithosEvent(
+                            type=TASK_CANCELLED,
+                            agent=agent,
+                            payload={"task_id": task_id, "agent": agent, "reason": reason},
                         )
                     )
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -184,6 +184,67 @@ class TestTaskLifecycle:
         assert not success
 
     @pytest.mark.asyncio
+    async def test_cancel_task(self, coordination_service: CoordinationService):
+        """Cancel a task."""
+        task_id = await coordination_service.create_task(
+            title="Cancellable Task",
+            agent="agent",
+        )
+
+        success = await coordination_service.cancel_task(task_id, "agent")
+
+        assert success
+        task = await coordination_service.get_task(task_id)
+        assert task.status == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_releases_claims(self, coordination_service: CoordinationService):
+        """Cancelling task releases all claims."""
+        task_id = await coordination_service.create_task(
+            title="Task with Claims",
+            agent="agent",
+        )
+        await coordination_service.claim_task(task_id, "research", "agent-1")
+        await coordination_service.claim_task(task_id, "implementation", "agent-2")
+
+        await coordination_service.cancel_task(task_id, "agent")
+
+        statuses = await coordination_service.get_task_status(task_id)
+        assert len(statuses[0].claims) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_already_cancelled_fails(self, coordination_service: CoordinationService):
+        """Cannot cancel already cancelled task."""
+        task_id = await coordination_service.create_task(
+            title="Already Cancelled",
+            agent="agent",
+        )
+
+        await coordination_service.cancel_task(task_id, "agent")
+        success = await coordination_service.cancel_task(task_id, "agent")
+
+        assert not success
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_task_fails(self, coordination_service: CoordinationService):
+        """Cannot cancel a task that does not exist."""
+        success = await coordination_service.cancel_task("nonexistent-id", "agent")
+        assert not success
+
+    @pytest.mark.asyncio
+    async def test_cancel_completed_task_fails(self, coordination_service: CoordinationService):
+        """Cannot cancel an already completed task."""
+        task_id = await coordination_service.create_task(
+            title="Done Task",
+            agent="agent",
+        )
+        await coordination_service.complete_task(task_id, "agent")
+
+        success = await coordination_service.cancel_task(task_id, "agent")
+
+        assert not success
+
+    @pytest.mark.asyncio
     async def test_get_task_status(self, coordination_service: CoordinationService):
         """Get task status with claims."""
         task_id = await coordination_service.create_task(


### PR DESCRIPTION
## Summary

Resolves #79.

Agents with stale or irrelevant tasks had no way to express cancellation. `lithos_task_complete` implies success, and abandoning a task leaves it open with expired claims cluttering the task list.

## Changes

### `src/lithos/coordination.py`
- Added `cancel_task(task_id, agent, reason=None)` method:
  - Sets task `status` to `"cancelled"`
  - Deletes all claims for the task (releasing them)
  - Returns `False` if task not found or already not open

### `src/lithos/events.py`
- Added `task.cancelled` to the event type registry

### `src/lithos/server.py`
- Added `lithos_task_cancel` MCP tool with parameters: `task_id` (str), `agent` (str), `reason` (str|None)
- Emits a `task.cancelled` event with payload `{task_id, agent, reason}`

### `tests/test_coordination.py`
- Added unit tests: cancel open task, cancel already-completed task (should return False), cancel non-existent task

## Checklist
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Pyright clean