### PR TITLE
fix!: remove sort_by_confidence from lithos_cache_lookup, always sort by confidence

### DIFF
--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -884,7 +884,6 @@ class LithosServer:
             source_url: str | None = None,
             max_age_hours: float | None = None,
             min_confidence: float = 0.5,
-            sort_by_confidence: bool = False,
             limit: int = 3,
             tags: list[str] | None = None,
         ) -> dict[str, Any]:
@@ -901,15 +900,7 @@ class LithosServer:
                 min_confidence: Minimum confidence score threshold — candidates whose
                     ``metadata.confidence`` is strictly below this value are skipped
                     entirely (default: 0.5).
-                sort_by_confidence: When True, all candidates that pass the
-                    ``min_confidence`` threshold and freshness checks are ranked by
-                    ``metadata.confidence`` descending and the highest-confidence doc
-                    is returned as the hit. When False (default), the first passing
-                    candidate (in semantic-search order) is returned, preserving
-                    backward-compatible behaviour.
-                limit: Max candidate docs to evaluate (default: 3). When
-                    ``sort_by_confidence`` is True, consider increasing this value
-                    so the ranking has more candidates to choose from.
+                limit: Max candidate docs to evaluate (default: 3).
                 tags: Restrict to tagged docs (AND semantics)
 
             Returns:
@@ -986,9 +977,6 @@ class LithosServer:
                 best_hit = None
                 first_stale_id: str | None = None
                 now = datetime.now(timezone.utc)
-                # passing_docs is populated only when sort_by_confidence is True,
-                # but it is declared here unconditionally to keep the type checker
-                # happy and avoid a conditional assignment before the append below.
                 passing_docs: list[Any] = []
 
                 for doc_id in candidates:
@@ -1021,14 +1009,9 @@ class LithosServer:
                                 first_stale_id = doc_id
                             continue
 
-                    if sort_by_confidence:
-                        passing_docs.append(doc)
-                    else:
-                        # First passing candidate is the best hit
-                        best_hit = doc
-                        break
+                    passing_docs.append(doc)
 
-                if sort_by_confidence and passing_docs:
+                if passing_docs:
                     best_hit = max(passing_docs, key=lambda d: d.metadata.confidence)
 
                 span.set_attribute("cache.candidates_evaluated", candidates_evaluated)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1148,8 +1148,8 @@ class TestCacheLookup:
         assert result["hit"] is False
 
     @pytest.mark.asyncio
-    async def test_sort_by_confidence_returns_highest(self, server: LithosServer):
-        """sort_by_confidence=True returns the highest-confidence passing doc."""
+    async def test_cache_lookup_returns_highest_confidence(self, server: LithosServer):
+        """Cache lookup always returns the highest-confidence passing doc."""
         from datetime import timedelta
         from unittest.mock import patch
 
@@ -1187,60 +1187,12 @@ class TestCacheLookup:
             result = await self._call_cache_lookup(
                 server,
                 query="quantum entanglement",
-                sort_by_confidence=True,
                 min_confidence=0.5,
             )
 
         assert result["hit"] is True
         assert result["document"]["id"] == high_doc.id
         assert result["document"]["confidence"] == 0.9
-
-    @pytest.mark.asyncio
-    async def test_sort_by_confidence_false_returns_first(self, server: LithosServer):
-        """sort_by_confidence=False (default) returns the first semantic match."""
-        from datetime import timedelta
-        from unittest.mock import patch
-
-        first_doc = (
-            await server.knowledge.create(
-                title="First Match Doc",
-                content="Information about quantum entanglement basics.",
-                agent="agent",
-                confidence=0.6,
-                expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
-            )
-        ).document
-        server.search.index_document(first_doc)
-
-        second_doc = (
-            await server.knowledge.create(
-                title="Second Match Doc",
-                content="More information about quantum entanglement.",
-                agent="agent",
-                confidence=0.9,
-                expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
-            )
-        ).document
-        server.search.index_document(second_doc)
-
-        with patch.object(
-            server.search,
-            "semantic_search",
-            return_value=[
-                type("R", (), {"id": first_doc.id})(),
-                type("R", (), {"id": second_doc.id})(),
-            ],
-        ):
-            result = await self._call_cache_lookup(
-                server,
-                query="quantum entanglement",
-                sort_by_confidence=False,
-                min_confidence=0.5,
-            )
-
-        assert result["hit"] is True
-        # Without sort_by_confidence, the first candidate wins
-        assert result["document"]["id"] == first_doc.id
 
     @pytest.mark.asyncio
     async def test_max_age_hours_filter(self, server: LithosServer):


### PR DESCRIPTION
## Summary

Closes #86

### Problem

The `sort_by_confidence` boolean in `lithos_cache_lookup` leaks an internal ranking micro-optimisation knob. Agents shouldn't need to think about sort order.

### Changes

- Removed `sort_by_confidence: bool` parameter from `lithos_cache_lookup`
- Confidence-sorted results are now always-on: all passing candidates are collected and the highest-confidence doc is returned
- Removed the two tests that tested the old boolean behaviour
- Added `test_cache_lookup_returns_highest_confidence` verifying the new always-on behaviour

### Breaking Change

**Intentional pre-v1.0.** Any caller passing `sort_by_confidence=True` or `sort_by_confidence=False` will receive an unexpected-keyword-argument error and must remove that parameter.

If named ranking strategies are needed in future, that can be added as a follow-up with a proper enum/string API.