### PR TITLE
fix: surface graph cache errors, secure default host, add real-path health test (#73 #75 #93)

### DIFF
--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -13,7 +13,7 @@ class ServerConfig(BaseModel):
     """Server configuration."""
 
     transport: Literal["stdio", "sse"] = "stdio"
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8765
     watch_files: bool = True
 

--- a/src/lithos/graph.py
+++ b/src/lithos/graph.py
@@ -104,6 +104,7 @@ class KnowledgeGraph:
             self._alias_to_node = data.get("alias_to_node", {})
             return True
         except Exception:
+            logger.exception("Failed to load graph cache")
             return False
 
     def save_cache(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,7 +51,7 @@ class TestConfigDefaults:
         """Server config has sensible defaults."""
         config = ServerConfig()
 
-        assert config.host == "0.0.0.0"
+        assert config.host == "127.0.0.1"
         assert config.port > 0
         assert config.watch_files is True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1941,6 +1941,24 @@ class TestHealthEndpoint:
         assert result["components"]["kb_directory"]["error"] == "directory does not exist"
 
     @pytest.mark.asyncio
+    async def test_health_degraded_when_kb_directory_missing_real_path(
+        self, server: LithosServer, tmp_path: Path
+    ):
+        """_get_health correctly uses Path.exists() for a real non-existent directory (issue #75)."""
+        from unittest.mock import patch
+
+        nonexistent = tmp_path / "does_not_exist"
+        # Confirm the directory is genuinely absent before patching
+        assert not nonexistent.exists()
+
+        with patch.object(server.knowledge, "knowledge_path", nonexistent):
+            result = await server._get_health()
+
+        assert result["status"] == "degraded"
+        assert result["components"]["kb_directory"]["status"] == "unavailable"
+        assert result["components"]["kb_directory"]["error"] == "directory does not exist"
+
+    @pytest.mark.asyncio
     async def test_health_degraded_when_kb_list_fails(self, server: LithosServer):
         """_get_health returns degraded when knowledge base list_all raises."""
         from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## Summary

Fixes #93, fixes #73, and adds a complementary test for #75.

---

### Issue #93 — graph.py load_cache() bare except swallows errors

**File:** `src/lithos/graph.py`

Added `logger.exception("Failed to load graph cache")` inside the bare `except Exception` block in `load_cache()`. Previously the exception was silently discarded and the function returned `False`; now the full traceback is emitted at ERROR level so operators can diagnose corrupt or unreadable cache files.

---

### Issue #73 — CLI default host diverges from ServerConfig default

**File:** `src/lithos/config.py`

Changed `ServerConfig.host` default from `"0.0.0.0"` to `"127.0.0.1"`. The CLI already defaults to `127.0.0.1` in its argument parser, so this aligns the programmatic default with the CLI behaviour and makes the server secure-by-default (loopback only).

Docker Compose deployments are unaffected — `LITHOS_HOST=0.0.0.0` is already set via environment variable in the Compose file and the config loader respects it.

**Test:** Updated `tests/test_config.py` host default assertion from `"0.0.0.0"` to `"127.0.0.1"`.

---

### Issue #75 — lithos_health KB directory check (supplementary real-path test)

The logic fix and mock-based test were already merged in #109. This PR adds a complementary test `test_health_degraded_when_kb_directory_missing_real_path` that patches `knowledge_path` with a genuine `tmp_path / "does_not_exist"` `Path` object, directly exercising `Path.exists()` rather than a `MagicMock`.

---

### CI

- `ruff check` — ✅ clean
- `ruff format --check` — ✅ clean
- `pyright src/` — ✅ 0 errors
- `pytest -m "not integration"` — ✅ 425 passed
- Health endpoint tests (`-k health`) — ✅ 8 passed