### PR TITLE
feat: add comprehensive structured logging to LCMA codebase

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -1,6 +1,7 @@
 """Lithos CLI - Command-line interface."""
 
 import asyncio
+import logging
 import sys
 from pathlib import Path
 
@@ -8,6 +9,8 @@ import click
 
 from lithos.config import LithosConfig, load_config, set_config
 from lithos.logging_config import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -82,14 +85,24 @@ def serve(
     async def run_server() -> None:
         # Initialize server
         click.echo("Initializing Lithos...")
+        logger.info(
+            "lithos server initializing: transport=%s data_dir=%s watch=%s",
+            transport,
+            config.storage.data_dir,
+            watch,
+            extra={"transport": transport, "data_dir": str(config.storage.data_dir), "watch": watch},
+        )
         await server.initialize()
+        logger.info("lithos server initialized: data_dir=%s", config.storage.data_dir)
 
         # Start file watcher if enabled
         if watch:
             click.echo("Starting file watcher...")
             server.start_file_watcher()
+            logger.info("file watcher started: knowledge_path=%s", config.storage.knowledge_path)
 
         click.echo(f"Starting MCP server ({transport} transport)...")
+        logger.info("MCP server starting: transport=%s", transport)
 
         if transport == "stdio":
             # Run with stdio transport
@@ -128,8 +141,10 @@ def serve(
         asyncio.run(run_server())
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
+        logger.info("lithos server shutting down (KeyboardInterrupt)")
         server.stop_file_watcher()
         asyncio.run(server.stop_enrich_worker())
+        logger.info("lithos server stopped")
     finally:
         shutdown_telemetry()
 
@@ -157,6 +172,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
     async def do_reindex() -> None:
         if clear:
             click.echo("Clearing existing indices...")
+            logger.info("reindex: clearing existing indices clear=True")
             search.clear_all()
             graph.clear()
 
@@ -164,6 +180,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
         files = list(knowledge_path.rglob("*.md"))
 
         click.echo(f"Found {len(files)} markdown files")
+        logger.info("reindex started: file_count=%d clear=%s", len(files), clear)
 
         indexed = 0
         errors = 0
@@ -179,11 +196,13 @@ def reindex(ctx: click.Context, clear: bool) -> None:
                 except Exception as e:
                     errors += 1
                     click.echo(f"\nError indexing {file_path}: {e}", err=True)
+                    logger.error("reindex error: path=%s error=%s", file_path, e)
 
         # Save graph cache
         graph.save_cache()
 
         click.echo(f"\nIndexed {indexed} documents")
+        logger.info("reindex complete: indexed=%d errors=%d", indexed, errors)
         if errors:
             click.echo(f"Errors: {errors}", err=True)
 

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -90,7 +90,11 @@ def serve(
             transport,
             config.storage.data_dir,
             watch,
-            extra={"transport": transport, "data_dir": str(config.storage.data_dir), "watch": watch},
+            extra={
+                "transport": transport,
+                "data_dir": str(config.storage.data_dir),
+                "watch": watch,
+            },
         )
         await server.initialize()
         logger.info("lithos server initialized: data_dir=%s", config.storage.data_dir)

--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -1,5 +1,6 @@
 """Configuration management for Lithos."""
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, Literal
@@ -7,6 +8,8 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 # Canonical LCMA note_type values — must match VALID_NOTE_TYPES in knowledge.py
 _LCMA_NOTE_TYPES = frozenset(
@@ -254,32 +257,42 @@ class LithosConfig(BaseSettings):
             "data_dir" not in self.storage.model_fields_set
         ):
             self.storage.data_dir = Path(data_dir)
+            logger.debug("Config env override: LITHOS_DATA_DIR=%s", data_dir)
         if (port := os.environ.get("LITHOS_PORT")) and ("port" not in self.server.model_fields_set):
             try:
                 self.server.port = int(port)
+                logger.debug("Config env override: LITHOS_PORT=%s", port)
             except ValueError:
                 raise ValueError(f"LITHOS_PORT must be a valid integer, got {port!r}") from None
         if (host := os.environ.get("LITHOS_HOST")) and ("host" not in self.server.model_fields_set):
             self.server.host = host
+            logger.debug("Config env override: LITHOS_HOST=%s", host)
         if (otel_enabled := os.environ.get("LITHOS_OTEL_ENABLED")) and (
             "enabled" not in self.telemetry.model_fields_set
         ):
             self.telemetry.enabled = otel_enabled.lower() in ("1", "true")
+            logger.debug("Config env override: LITHOS_OTEL_ENABLED=%s", otel_enabled)
         if (otlp_endpoint := os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")) and (
             "endpoint" not in self.telemetry.model_fields_set
         ):
             self.telemetry.endpoint = otlp_endpoint
+            logger.debug("Config env override: OTEL_EXPORTER_OTLP_ENDPOINT=%s", otlp_endpoint)
         return self
 
     @classmethod
     def from_yaml(cls, path: Path) -> "LithosConfig":
         """Load configuration from YAML file."""
         if not path.exists():
+            logger.warning(
+                "Config file not found, using defaults: path=%s", path,
+                extra={"config_path": str(path)},
+            )
             return cls()
 
         with open(path) as f:
             data = yaml.safe_load(f) or {}
 
+        logger.info("Config loaded from file: path=%s", path, extra={"config_path": str(path)})
         return cls(**data)
 
     def ensure_directories(self) -> None:

--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -284,7 +284,8 @@ class LithosConfig(BaseSettings):
         """Load configuration from YAML file."""
         if not path.exists():
             logger.warning(
-                "Config file not found, using defaults: path=%s", path,
+                "Config file not found, using defaults: path=%s",
+                path,
                 extra={"config_path": str(path)},
             )
             return cls()

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -511,12 +511,14 @@ class CoordinationService:
             await db.commit()
             updated = cursor.rowcount > 0
             if updated:
+                # Derive logical field names from SQL clauses (e.g. "title = ?" -> "title")
+                updated_fields = [clause.split(" = ")[0] for clause in sets]
                 logger.info(
                     "Task updated: task_id=%s agent=%s fields=%s",
                     task_id,
                     agent,
-                    sets,
-                    extra={"task_id": task_id, "agent": agent, "fields": sets},
+                    updated_fields,
+                    extra={"task_id": task_id, "agent": agent, "fields": updated_fields},
                 )
             return updated
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -206,10 +206,16 @@ class CoordinationService:
         old_path = self.config.storage.data_dir / "coordination.db"
         if old_path.exists() and not self.db_path.exists() and old_path != self.db_path:
             old_path.rename(self.db_path)
+            logger.info(
+                "coordination.db migrated: old_path=%s new_path=%s",
+                old_path,
+                self.db_path,
+            )
 
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(SCHEMA)
             await db.commit()
+        logger.info("coordination service initialized: db_path=%s", self.db_path)
 
     async def _get_db(self) -> aiosqlite.Connection:
         """Get database connection."""
@@ -291,7 +297,23 @@ class CoordinationService:
                 )
 
             await db.commit()
-            return True, not exists
+            created = not exists
+            if created:
+                logger.info(
+                    "Agent registered: agent_id=%s name=%s type=%s",
+                    agent_id,
+                    name,
+                    agent_type,
+                    extra={"agent_id": agent_id, "name": name, "agent_type": agent_type},
+                )
+            else:
+                logger.debug(
+                    "Agent updated: agent_id=%s name=%s type=%s",
+                    agent_id,
+                    name,
+                    agent_type,
+                )
+            return True, created
 
     async def get_agent(self, agent_id: str) -> Agent | None:
         """Get agent information."""
@@ -487,7 +509,16 @@ class CoordinationService:
                 params,
             )
             await db.commit()
-            return cursor.rowcount > 0
+            updated = cursor.rowcount > 0
+            if updated:
+                logger.info(
+                    "Task updated: task_id=%s agent=%s fields=%s",
+                    task_id,
+                    agent,
+                    sets,
+                    extra={"task_id": task_id, "agent": agent, "fields": sets},
+                )
+            return updated
 
     @traced("lithos.coordination.complete_task")
     async def complete_task(self, task_id: str, agent: str) -> bool:
@@ -542,6 +573,13 @@ class CoordinationService:
             )
 
             await db.commit()
+            logger.info(
+                "Task cancelled: task_id=%s agent=%s reason=%s",
+                task_id,
+                agent,
+                reason,
+                extra={"task_id": task_id, "agent": agent, "reason": reason},
+            )
             return True
 
     async def list_tasks(
@@ -843,7 +881,23 @@ class CoordinationService:
                 (task_id, aspect, agent),
             )
             await db.commit()
-            return cursor.rowcount > 0
+            released = cursor.rowcount > 0
+            if released:
+                logger.info(
+                    "Claim released: task_id=%s aspect=%s agent=%s",
+                    task_id,
+                    aspect,
+                    agent,
+                    extra={"task_id": task_id, "aspect": aspect, "agent": agent},
+                )
+            else:
+                logger.debug(
+                    "Claim release no-op (not held): task_id=%s aspect=%s agent=%s",
+                    task_id,
+                    aspect,
+                    agent,
+                )
+            return released
 
     # ==================== Finding Operations ====================
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -304,7 +304,7 @@ class CoordinationService:
                     agent_id,
                     name,
                     agent_type,
-                    extra={"agent_id": agent_id, "name": name, "agent_type": agent_type},
+                    extra={"agent_id": agent_id, "agent_name": name, "agent_type": agent_type},
                 )
             else:
                 logger.debug(

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -115,6 +115,19 @@ class EventBus:
         with tracer.start_as_current_span("lithos.event_bus.emit") as span:
             span.set_attribute("lithos.event.type", event.type)
             lithos_metrics.event_bus_ops.add(1, {"op": "emit", "event_type": event.type})
+            logger.debug(
+                "event_bus emit: event_type=%s event_id=%s agent=%s subscriber_count=%d",
+                event.type,
+                event.id,
+                event.agent,
+                len(self._subscribers),
+                extra={
+                    "event_type": event.type,
+                    "event_id": event.id,
+                    "agent": event.agent,
+                    "subscriber_count": len(self._subscribers),
+                },
+            )
 
             try:
                 self._buffer.append(event)
@@ -132,6 +145,17 @@ class EventBus:
                     lithos_metrics.event_bus_ops.add(1, {"op": "drop", "event_type": event.type})
                     lithos_metrics.event_bus_subscriber_drops.add(
                         1, {"subscriber_id": sub.subscriber_id}
+                    )
+                    logger.warning(
+                        "event_bus queue full: subscriber_id=%s event_type=%s total_drops=%d",
+                        sub.subscriber_id,
+                        event.type,
+                        sub.drops,
+                        extra={
+                            "subscriber_id": sub.subscriber_id,
+                            "event_type": event.type,
+                            "total_drops": sub.drops,
+                        },
                     )
                 except Exception:
                     logger.exception("EventBus.emit: failed to deliver to subscriber")
@@ -159,11 +183,31 @@ class EventBus:
         queue: asyncio.Queue[LithosEvent] = asyncio.Queue(maxsize=q_size)
         sub = _Subscriber(queue=queue, event_types=event_types, tag_filter=tags)
         self._subscribers.append(sub)
+        logger.debug(
+            "event_bus subscribe: subscriber_id=%s event_types=%s queue_size=%d total_subscribers=%d",
+            sub.subscriber_id,
+            event_types,
+            q_size,
+            len(self._subscribers),
+            extra={
+                "subscriber_id": sub.subscriber_id,
+                "event_types": event_types,
+                "queue_size": q_size,
+                "total_subscribers": len(self._subscribers),
+            },
+        )
         return queue
 
     def unsubscribe(self, queue: asyncio.Queue[LithosEvent]) -> None:
         """Remove a subscriber by its queue reference."""
+        sub_id = self._get_subscriber_id(queue)
         self._subscribers = [s for s in self._subscribers if s.queue is not queue]
+        logger.debug(
+            "event_bus unsubscribe: subscriber_id=%s total_subscribers=%d",
+            sub_id,
+            len(self._subscribers),
+            extra={"subscriber_id": sub_id, "total_subscribers": len(self._subscribers)},
+        )
 
     def get_drop_count(self, queue: asyncio.Queue[LithosEvent]) -> int:
         """Get the drop counter for a subscriber queue."""

--- a/src/lithos/graph.py
+++ b/src/lithos/graph.py
@@ -104,6 +104,12 @@ class KnowledgeGraph:
             self._path_to_node = data.get("path_to_node", {})
             self._filename_to_nodes = data.get("filename_to_nodes", {})
             self._alias_to_node = data.get("alias_to_node", {})
+            logger.info(
+                "graph cache loaded: path=%s node_count=%d edge_count=%d",
+                cache_path,
+                self.node_count(),
+                self.edge_count(),
+            )
             return True
         except Exception:
             logger.exception("Failed to load graph cache")
@@ -114,6 +120,12 @@ class KnowledgeGraph:
         """Save graph to cache atomically (write to temp file, then rename)."""
         cache_path = self.graph_cache_path
         cache_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.debug(
+            "graph save_cache: path=%s node_count=%d edge_count=%d",
+            cache_path,
+            self.node_count(),
+            self.edge_count(),
+        )
 
         graph_data = (
             nx.node_link_data(self._graph, edges="links") if self._graph is not None else {}
@@ -145,6 +157,14 @@ class KnowledgeGraph:
             doc: Document to add
         """
         node_id = doc.id
+        is_update = node_id in self.graph
+        logger.debug(
+            "graph add_document: doc_id=%s title=%r update=%s link_count=%d",
+            node_id,
+            doc.title,
+            is_update,
+            len(doc.links),
+        )
 
         # Remove existing node if present (to update)
         if node_id in self.graph:
@@ -286,6 +306,9 @@ class KnowledgeGraph:
         if node_id and node_id in self.graph:
             self._remove_node_lookups(node_id)
             self.graph.remove_node(node_id)
+            logger.info("graph remove_document: doc_id=%s", doc_id)
+        else:
+            logger.debug("graph remove_document: doc_id=%s not found (no-op)", doc_id)
 
     @traced("lithos.graph.resolve_link")
     def _resolve_link(self, target: str) -> str | None:

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1469,6 +1469,14 @@ class KnowledgeManager:
             except Exception:
                 pass
 
+        logger.debug(
+            "list_all: total=%d returned=%d offset=%d limit=%d",
+            total,
+            len(docs),
+            offset,
+            limit,
+            extra={"total": total, "returned": len(docs), "offset": offset, "limit": limit},
+        )
         return docs, total
 
     async def get_all_tags(self) -> dict[str, int]:

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -169,6 +169,23 @@ class EdgeStore:
                         edge_id,
                     ),
                 )
+                logger.debug(
+                    "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                    edge_id,
+                    from_id,
+                    to_id,
+                    edge_type,
+                    namespace,
+                    weight,
+                    extra={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "edge_type": edge_type,
+                        "namespace": namespace,
+                        "weight": weight,
+                    },
+                )
             else:
                 edge_id = _generate_edge_id()
                 await db.execute(
@@ -191,6 +208,23 @@ class EdgeStore:
                         evidence,
                         conflict_state,
                     ),
+                )
+                logger.info(
+                    "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                    edge_id,
+                    from_id,
+                    to_id,
+                    edge_type,
+                    namespace,
+                    weight,
+                    extra={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "edge_type": edge_type,
+                        "namespace": namespace,
+                        "weight": weight,
+                    },
                 )
             await db.commit()
         return edge_id
@@ -322,7 +356,14 @@ class EdgeStore:
                 f"DELETE FROM edges WHERE edge_id IN ({placeholders})", edge_ids
             )
             await db.commit()
-            return cursor.rowcount
+            deleted = cursor.rowcount
+            logger.info(
+                "edge delete_edges: requested=%d deleted=%d",
+                len(edge_ids),
+                deleted,
+                extra={"requested": len(edge_ids), "deleted": deleted},
+            )
+            return deleted
 
     async def adjust_weight(self, edge_id: str, delta: float) -> float | None:
         """Atomically adjust weight by *delta*, clamping to [0.0, 1.0].
@@ -494,6 +535,12 @@ async def _project_provenance_to_edges(
     removed_count = len(to_remove)
 
     if dry_run:
+        logger.info(
+            "provenance projection dry_run: to_create=%d to_remove=%d",
+            created_count,
+            removed_count,
+            extra={"to_create": created_count, "to_remove": removed_count, "dry_run": True},
+        )
         return {"created": created_count, "removed": removed_count}
 
     # Apply the create side of the diff.
@@ -512,4 +559,10 @@ async def _project_provenance_to_edges(
     if orphan_ids:
         await edge_store.delete_edges(edge_ids=orphan_ids)
 
+    logger.info(
+        "provenance projection applied: created=%d removed=%d",
+        created_count,
+        removed_count,
+        extra={"created": created_count, "removed": removed_count, "dry_run": False},
+    )
     return {"created": created_count, "removed": removed_count}

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -563,6 +563,6 @@ async def _project_provenance_to_edges(
         "provenance projection applied: created=%d removed=%d",
         created_count,
         removed_count,
-        extra={"created": created_count, "removed": removed_count, "dry_run": False},
+        extra={"edges_created": created_count, "edges_removed": removed_count, "dry_run": False},
     )
     return {"created": created_count, "removed": removed_count}

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -525,6 +525,18 @@ class EnrichWorker:
         except Exception:
             logger.debug("EnrichWorker: failed to refresh cached counts", exc_info=True)
 
+        total_processed = nodes_succeeded + nodes_failed + tasks_succeeded + tasks_failed
+        _drain_log = logger.info if total_processed > 0 else logger.debug
+        _drain_log(
+            "EnrichWorker: drain completed",
+            extra={
+                "nodes_succeeded": nodes_succeeded,
+                "nodes_failed": nodes_failed,
+                "tasks_succeeded": tasks_succeeded,
+                "tasks_failed": tasks_failed,
+            },
+        )
+
     async def _record_drain_metrics(self, claimed_ids: list[int]) -> None:
         """Record OTEL metrics for successfully processed enrich_queue items."""
         if not _HAS_TELEMETRY:
@@ -553,18 +565,6 @@ class EnrichWorker:
                     _lithos_metrics.lcma_enrich_queue_attempts.record(attempts)
         except Exception:
             logger.debug("EnrichWorker: failed to record drain metrics", exc_info=True)
-
-        total_processed = nodes_succeeded + nodes_failed + tasks_succeeded + tasks_failed
-        _drain_log = logger.info if total_processed > 0 else logger.debug
-        _drain_log(
-            "EnrichWorker: drain completed",
-            extra={
-                "nodes_succeeded": nodes_succeeded,
-                "nodes_failed": nodes_failed,
-                "tasks_succeeded": tasks_succeeded,
-                "tasks_failed": tasks_failed,
-            },
-        )
 
     async def _warn_exhausted(
         self, claimed_ids: list[int], max_attempts: int, *, identifier: str

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -461,10 +461,6 @@ class EnrichWorker:
 
         # --- Node-level enrichment ---
         node_entries = await self._stats_store.drain_pending_nodes(max_attempts=max_attempts)
-        logger.info(
-            "EnrichWorker: drain started",
-            extra={"node_count": len(node_entries)},
-        )
         nodes_succeeded = 0
         nodes_failed = 0
         for entry in node_entries:
@@ -553,7 +549,9 @@ class EnrichWorker:
         except Exception:
             logger.debug("EnrichWorker: failed to record drain metrics", exc_info=True)
 
-        logger.info(
+        total_processed = nodes_succeeded + nodes_failed + tasks_succeeded + tasks_failed
+        _drain_log = logger.info if total_processed > 0 else logger.debug
+        _drain_log(
             "EnrichWorker: drain completed",
             extra={
                 "nodes_succeeded": nodes_succeeded,
@@ -591,7 +589,7 @@ class EnrichWorker:
         """
         from lithos.lcma.edges import _project_node_provenance
 
-        logger.info(
+        logger.debug(
             "EnrichWorker: enriching node",
             extra={"node_id": node_id, "trigger_types": list(trigger_types) if isinstance(trigger_types, (list, set, tuple)) else trigger_types},
         )
@@ -686,7 +684,7 @@ class EnrichWorker:
             return
 
         await self._knowledge.update(id=node_id, agent="lithos-enrich", entities=extracted)
-        logger.info(
+        logger.debug(
             "EnrichWorker: entity extraction complete",
             extra={"node_id": node_id, "entity_count": len(extracted)},
         )

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -420,7 +420,12 @@ class EnrichWorker:
             if enqueued:
                 logger.debug(
                     "EnrichWorker: enqueued edge nodes",
-                    extra={"trigger_type": event.type, "from_id": from_id, "to_id": to_id, "enqueued": enqueued},
+                    extra={
+                        "trigger_type": event.type,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "enqueued": enqueued,
+                    },
                 )
             return
 
@@ -591,7 +596,12 @@ class EnrichWorker:
 
         logger.debug(
             "EnrichWorker: enriching node",
-            extra={"node_id": node_id, "trigger_types": list(trigger_types) if isinstance(trigger_types, (list, set, tuple)) else trigger_types},
+            extra={
+                "node_id": node_id,
+                "trigger_types": list(trigger_types)
+                if isinstance(trigger_types, (list, set, tuple))
+                else trigger_types,
+            },
         )
 
         # --- Salience decay ---

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -389,30 +389,54 @@ class EnrichWorker:
 
     async def _handle_event(self, event: LithosEvent) -> None:
         """Route a single event to enrich_queue."""
+        logger.debug(
+            "EnrichWorker: received event",
+            extra={"event_type": event.type, "event_id": event.id},
+        )
         if event.type == TASK_COMPLETED:
             task_id = event.payload.get("task_id")
             if isinstance(task_id, str) and task_id:
                 await self._stats_store.enqueue(trigger_type=event.type, task_id=task_id)
+                logger.info(
+                    "EnrichWorker: enqueued task consolidation",
+                    extra={"trigger_type": event.type, "task_id": task_id},
+                )
             return
 
         if event.type == EDGE_UPSERTED:
             from_id = event.payload.get("from_id")
             to_id = event.payload.get("to_id")
+            enqueued = 0
             for nid in (from_id, to_id):
                 if isinstance(nid, str) and nid:
                     if self._knowledge.has_document(nid):
                         await self._stats_store.enqueue(trigger_type=event.type, node_id=nid)
+                        enqueued += 1
                     else:
                         logger.debug(
                             "EnrichWorker: edge.upserted node_id=%s not in knowledge, skipping",
                             nid,
                         )
+            if enqueued:
+                logger.debug(
+                    "EnrichWorker: enqueued edge nodes",
+                    extra={"trigger_type": event.type, "from_id": from_id, "to_id": to_id, "enqueued": enqueued},
+                )
             return
 
         # note.created, note.updated, note.deleted, finding.posted
         node_id = _resolve_node_id(event.payload, self._knowledge, event.type)
         if node_id is not None:
             await self._stats_store.enqueue(trigger_type=event.type, node_id=node_id)
+            logger.info(
+                "EnrichWorker: enqueued node enrichment",
+                extra={"trigger_type": event.type, "node_id": node_id},
+            )
+        else:
+            logger.debug(
+                "EnrichWorker: event produced no enqueue target",
+                extra={"event_type": event.type},
+            )
 
     # ------------------------------------------------------------------
     # Drain loop
@@ -437,16 +461,31 @@ class EnrichWorker:
 
         # --- Node-level enrichment ---
         node_entries = await self._stats_store.drain_pending_nodes(max_attempts=max_attempts)
+        logger.info(
+            "EnrichWorker: drain started",
+            extra={"node_count": len(node_entries)},
+        )
+        nodes_succeeded = 0
+        nodes_failed = 0
         for entry in node_entries:
             node_id = entry["node_id"]
             trigger_types = entry["trigger_types"]
             claimed_ids = entry["claimed_ids"]
             assert isinstance(node_id, str)
             assert isinstance(claimed_ids, list)
+            logger.debug(
+                "EnrichWorker: processing node",
+                extra={"node_id": node_id, "trigger_types": trigger_types},
+            )
             try:
                 await self._enrich_node(node_id, trigger_types)
+                nodes_succeeded += 1
             except Exception:
-                logger.exception("EnrichWorker: node enrichment failed for %s, requeuing", node_id)
+                nodes_failed += 1
+                logger.exception(
+                    "EnrichWorker: node enrichment failed",
+                    extra={"node_id": node_id, "claimed_count": len(claimed_ids)},
+                )
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=node_id)
                 continue  # skip _record_drain_metrics on failure path — item was requeued, not processed
@@ -454,16 +493,25 @@ class EnrichWorker:
 
         # --- Task-level enrichment ---
         task_entries = await self._stats_store.drain_pending_tasks(max_attempts=max_attempts)
+        tasks_succeeded = 0
+        tasks_failed = 0
         for entry in task_entries:
             task_id = entry["task_id"]
             claimed_ids = entry["claimed_ids"]
             assert isinstance(task_id, str)
             assert isinstance(claimed_ids, list)
+            logger.debug(
+                "EnrichWorker: processing task consolidation",
+                extra={"task_id": task_id},
+            )
             try:
                 await self._consolidate_task(task_id)
+                tasks_succeeded += 1
             except Exception:
+                tasks_failed += 1
                 logger.exception(
-                    "EnrichWorker: task consolidation failed for %s, requeuing", task_id
+                    "EnrichWorker: task consolidation failed",
+                    extra={"task_id": task_id, "claimed_count": len(claimed_ids)},
                 )
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=task_id)
@@ -505,6 +553,16 @@ class EnrichWorker:
         except Exception:
             logger.debug("EnrichWorker: failed to record drain metrics", exc_info=True)
 
+        logger.info(
+            "EnrichWorker: drain completed",
+            extra={
+                "nodes_succeeded": nodes_succeeded,
+                "nodes_failed": nodes_failed,
+                "tasks_succeeded": tasks_succeeded,
+                "tasks_failed": tasks_failed,
+            },
+        )
+
     async def _warn_exhausted(
         self, claimed_ids: list[int], max_attempts: int, *, identifier: str
     ) -> None:
@@ -533,6 +591,11 @@ class EnrichWorker:
         """
         from lithos.lcma.edges import _project_node_provenance
 
+        logger.info(
+            "EnrichWorker: enriching node",
+            extra={"node_id": node_id, "trigger_types": list(trigger_types) if isinstance(trigger_types, (list, set, tuple)) else trigger_types},
+        )
+
         # --- Salience decay ---
         stats = await self._stats_store.get_node_stats(node_id)
         if stats is not None:
@@ -546,6 +609,11 @@ class EnrichWorker:
             NOTE_CREATED in trigger_types or NOTE_UPDATED in trigger_types
         ):
             await self._extract_entities(node_id)
+
+        logger.debug(
+            "EnrichWorker: node enrichment complete",
+            extra={"node_id": node_id},
+        )
 
     async def _apply_decay(self, node_id: str, stats: dict[str, object]) -> bool:
         """Apply salience decay to a single node.
@@ -584,10 +652,12 @@ class EnrichWorker:
         await self._stats_store.update_salience(node_id, -decay_amount)
         await self._stats_store.update_last_decay_applied_at(node_id)
         logger.debug(
-            "Applied decay to %s: days_inactive=%d, decay=%.3f",
-            node_id,
-            days_since_last_use,
-            decay_amount,
+            "EnrichWorker: applied salience decay",
+            extra={
+                "node_id": node_id,
+                "days_inactive": days_since_last_use,
+                "decay_amount": round(decay_amount, 3),
+            },
         )
         return True
 
@@ -616,7 +686,10 @@ class EnrichWorker:
             return
 
         await self._knowledge.update(id=node_id, agent="lithos-enrich", entities=extracted)
-        logger.debug("Extracted %d entities for node %s", len(extracted), node_id)
+        logger.info(
+            "EnrichWorker: entity extraction complete",
+            extra={"node_id": node_id, "entity_count": len(extracted)},
+        )
 
     # ------------------------------------------------------------------
     # Sweep loop
@@ -643,6 +716,10 @@ class EnrichWorker:
 
         # --- Decay all nodes ---
         node_ids = await self._stats_store.list_all_node_ids()
+        logger.info(
+            "EnrichWorker: full sweep started",
+            extra={"node_count": len(node_ids)},
+        )
         all_stats = await self._stats_store.get_node_stats_batch(node_ids)
         decayed = 0
         for node_id in node_ids:
@@ -665,12 +742,13 @@ class EnrichWorker:
         prov_counts = await _project_provenance_to_edges(self._edge_store, self._knowledge)
 
         logger.info(
-            "Full sweep: decayed %d nodes, evicted %d WM entries, "
-            "provenance edges created=%d removed=%d",
-            decayed,
-            evicted,
-            prov_counts.get("created", 0),
-            prov_counts.get("removed", 0),
+            "EnrichWorker: full sweep completed",
+            extra={
+                "nodes_decayed": decayed,
+                "wm_entries_evicted": evicted,
+                "provenance_edges_created": prov_counts.get("created", 0),
+                "provenance_edges_removed": prov_counts.get("removed", 0),
+            },
         )
 
     async def _consolidate_task(self, task_id: str) -> None:
@@ -752,4 +830,7 @@ class EnrichWorker:
             )
 
         await self._stats_store.mark_task_consolidated(task_id)
-        logger.debug("Consolidated task %s: %d frequent nodes", task_id, len(frequent))
+        logger.info(
+            "EnrichWorker: task consolidation complete",
+            extra={"task_id": task_id, "frequent_node_count": len(frequent)},
+        )

--- a/src/lithos/lcma/reinforcement.py
+++ b/src/lithos/lcma/reinforcement.py
@@ -35,12 +35,19 @@ async def reinforce_cited_nodes(
     - ``salience += 0.02``
     - ``spaced_rep_strength += 0.05``
     """
+    logger.info(
+        "reinforce_cited_nodes: reinforcing",
+        extra={"node_count": len(cited_ids)},
+    )
     for node_id in cited_ids:
         await stats_store.increment_cited(node_id)
         await stats_store.update_salience(node_id, 0.02)
         await stats_store.update_spaced_rep_strength(node_id, 0.05)
         await stats_store.update_last_used_at(node_id)
-        logger.debug("Reinforced cited node %s", node_id)
+        logger.debug(
+            "reinforce_cited_nodes: node reinforced",
+            extra={"node_id": node_id, "salience_delta": 0.02, "spaced_rep_delta": 0.05},
+        )
 
 
 async def reinforce_edges_between(
@@ -59,6 +66,10 @@ async def reinforce_edges_between(
 
     Cross-namespace pairs are silently skipped.
     """
+    logger.info(
+        "reinforce_edges_between: strengthening edges",
+        extra={"cited_count": len(cited_ids)},
+    )
     # Resolve namespace for each node from the meta cache.
     ns_map: dict[str, str] = {}
     for nid in cited_ids:
@@ -66,7 +77,10 @@ async def reinforce_edges_between(
         if cached is not None:
             ns_map[nid] = cached.namespace
         else:
-            logger.debug("Node %s not in _meta_cache — skipping edge reinforcement", nid)
+            logger.debug(
+                "reinforce_edges_between: node not in _meta_cache, skipping",
+                extra={"node_id": nid},
+            )
 
     # Generate canonical same-namespace pairs.
     for a, b in itertools.combinations(cited_ids, 2):
@@ -90,7 +104,10 @@ async def reinforce_edges_between(
         if existing:
             edge_id = str(existing[0]["edge_id"])
             await edge_store.adjust_weight(edge_id, 0.03)
-            logger.debug("Strengthened edge %s between %s and %s", edge_id, from_id, to_id)
+            logger.debug(
+                "reinforce_edges_between: strengthened existing edge",
+                extra={"edge_id": edge_id, "from_id": from_id, "to_id": to_id, "weight_delta": 0.03},
+            )
         else:
             eid = await edge_store.upsert(
                 from_id=from_id,
@@ -100,7 +117,10 @@ async def reinforce_edges_between(
                 namespace=namespace,
                 provenance_type="reinforcement",
             )
-            logger.debug("Created related_to edge %s between %s and %s", eid, from_id, to_id)
+            logger.debug(
+                "reinforce_edges_between: created new related_to edge",
+                extra={"edge_id": eid, "from_id": from_id, "to_id": to_id, "namespace": namespace},
+            )
 
 
 # ── Negative reinforcement ─────────────────────────────────────────────
@@ -117,6 +137,10 @@ async def penalize_ignored(
     - If ``ignored_count > 5`` **and** ``ignored_count > cited_count``,
       apply ``salience -= 0.02``.
     """
+    logger.info(
+        "penalize_ignored: applying ignored penalties",
+        extra={"node_count": len(node_ids)},
+    )
     for node_id in node_ids:
         await stats_store.increment_ignored(node_id)
         stats = await stats_store.get_node_stats(node_id)
@@ -127,8 +151,14 @@ async def penalize_ignored(
             assert isinstance(cited, int)
             if ignored > 5 and ignored > cited:
                 await stats_store.update_salience(node_id, -0.02)
-                logger.debug("Decayed salience for ignored node %s", node_id)
-        logger.debug("Penalized ignored node %s", node_id)
+                logger.debug(
+                    "penalize_ignored: decayed salience for chronically ignored node",
+                    extra={"node_id": node_id, "ignored_count": ignored, "cited_count": cited, "salience_delta": -0.02},
+                )
+        logger.debug(
+            "penalize_ignored: incremented ignored count",
+            extra={"node_id": node_id},
+        )
 
 
 async def penalize_misleading(
@@ -144,6 +174,10 @@ async def penalize_misleading(
     - If ``misleading_count >= 3``, set ``status = 'quarantined'``
       via :meth:`KnowledgeManager.update`.
     """
+    logger.info(
+        "penalize_misleading: applying misleading penalties",
+        extra={"node_count": len(node_ids)},
+    )
     for node_id in node_ids:
         await stats_store.increment_misleading(node_id)
         await stats_store.update_salience(node_id, -0.05)
@@ -153,8 +187,14 @@ async def penalize_misleading(
             assert isinstance(misleading, int)
             if misleading >= 3:
                 await knowledge.update(id=node_id, lcma_status="quarantined", agent="lithos-enrich")
-                logger.info("Quarantined misleading node %s (count=%d)", node_id, misleading)
-        logger.debug("Penalized misleading node %s", node_id)
+                logger.info(
+                    "penalize_misleading: node quarantined",
+                    extra={"node_id": node_id, "misleading_count": misleading},
+                )
+        logger.debug(
+            "penalize_misleading: node penalized",
+            extra={"node_id": node_id, "salience_delta": -0.05},
+        )
 
 
 async def weaken_edges_for_bad_context(
@@ -167,6 +207,10 @@ async def weaken_edges_for_bad_context(
     (any namespace) and weakens each by ``-0.05`` via
     :meth:`EdgeStore.adjust_weight`.
     """
+    logger.info(
+        "weaken_edges_for_bad_context: weakening edges",
+        extra={"bad_node_count": len(bad_node_ids)},
+    )
     seen: set[str] = set()
     for node_id in bad_node_ids:
         edges_from = await edge_store.list_edges(from_id=node_id)
@@ -177,4 +221,11 @@ async def weaken_edges_for_bad_context(
                 continue
             seen.add(eid)
             await edge_store.adjust_weight(eid, -0.05)
-            logger.debug("Weakened edge %s for bad node %s", eid, node_id)
+            logger.debug(
+                "weaken_edges_for_bad_context: weakened edge",
+                extra={"edge_id": eid, "node_id": node_id, "weight_delta": -0.05},
+            )
+    logger.info(
+        "weaken_edges_for_bad_context: completed",
+        extra={"bad_node_count": len(bad_node_ids), "edges_weakened": len(seen)},
+    )

--- a/src/lithos/lcma/reinforcement.py
+++ b/src/lithos/lcma/reinforcement.py
@@ -106,7 +106,12 @@ async def reinforce_edges_between(
             await edge_store.adjust_weight(edge_id, 0.03)
             logger.debug(
                 "reinforce_edges_between: strengthened existing edge",
-                extra={"edge_id": edge_id, "from_id": from_id, "to_id": to_id, "weight_delta": 0.03},
+                extra={
+                    "edge_id": edge_id,
+                    "from_id": from_id,
+                    "to_id": to_id,
+                    "weight_delta": 0.03,
+                },
             )
         else:
             eid = await edge_store.upsert(
@@ -153,7 +158,12 @@ async def penalize_ignored(
                 await stats_store.update_salience(node_id, -0.02)
                 logger.debug(
                     "penalize_ignored: decayed salience for chronically ignored node",
-                    extra={"node_id": node_id, "ignored_count": ignored, "cited_count": cited, "salience_delta": -0.02},
+                    extra={
+                        "node_id": node_id,
+                        "ignored_count": ignored,
+                        "cited_count": cited,
+                        "salience_delta": -0.02,
+                    },
                 )
         logger.debug(
             "penalize_ignored: incremented ignored count",

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -280,6 +280,19 @@ async def run_retrieve(
     conflicts_found: list[dict[str, object]] = []
     _retrieve_t0 = time.perf_counter()
 
+    logger.info(
+        "run_retrieve: started",
+        extra={
+            "receipt_id": receipt_id,
+            "query_len": len(query),
+            "limit": limit,
+            "agent_id": agent_id,
+            "task_id": task_id,
+            "namespace_filter": namespace_filter,
+            "max_context_nodes": max_context_nodes,
+        },
+    )
+
     try:
         # ── Phase A: parallel scouts ──────────────────────────────
         # All scouts receive the same set of caller-supplied filters
@@ -328,7 +341,10 @@ async def run_retrieve(
         all_candidates: list[Candidate] = []
         for name, result in zip(phase_a_names, phase_a_results, strict=True):
             if isinstance(result, BaseException):
-                logger.warning("Phase A scout %s failed: %s", name, result)
+                logger.warning(
+                    "run_retrieve: phase A scout failed",
+                    extra={"scout": name, "error": str(result)},
+                )
                 continue
             executed_scouts.add(name)
             all_candidates.extend(result)
@@ -340,13 +356,31 @@ async def run_retrieve(
                 # for Phase B scouts, which run sequentially.
                 _lithos_metrics.lcma_scout_duration.record(_phase_a_elapsed * 1000, {"scout": name})
                 _lithos_metrics.lcma_scout_candidates.record(len(result), {"scout": name})
+            logger.debug(
+                "run_retrieve: phase A scout completed",
+                extra={"scout": name, "candidates": len(result)},
+            )
 
         # ── Phase A normalisation for provenance seeding ──────────
         phase_a_normalised = merge_and_normalize(all_candidates)
         phase_a_normalised.sort(key=lambda c: c.score, reverse=True)
 
+        logger.info(
+            "run_retrieve: phase A complete",
+            extra={
+                "receipt_id": receipt_id,
+                "scouts_fired": len(executed_scouts),
+                "raw_candidates": len(all_candidates),
+                "normalised_candidates": len(phase_a_normalised),
+            },
+        )
+
         # ── Phase B: sequential scouts seeded from Phase A ─────────
         seed_ids = [c.node_id for c in phase_a_normalised[:max_context_nodes]]
+        logger.debug(
+            "run_retrieve: phase B seeding",
+            extra={"receipt_id": receipt_id, "seed_count": len(seed_ids)},
+        )
         if seed_ids:
             try:
                 _t = time.perf_counter()
@@ -362,8 +396,16 @@ async def run_retrieve(
                     _lithos_metrics.lcma_scout_candidates.record(
                         len(prov_candidates), {"scout": "scout_provenance"}
                     )
+                logger.debug(
+                    "run_retrieve: phase B scout completed",
+                    extra={"scout": "scout_provenance", "candidates": len(prov_candidates)},
+                )
             except Exception:
-                logger.warning("Phase B (provenance) failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: phase B scout failed",
+                    extra={"scout": "scout_provenance"},
+                    exc_info=True,
+                )
 
             try:
                 _t = time.perf_counter()
@@ -379,8 +421,16 @@ async def run_retrieve(
                     _lithos_metrics.lcma_scout_candidates.record(
                         len(graph_candidates), {"scout": "scout_graph"}
                     )
+                logger.debug(
+                    "run_retrieve: phase B scout completed",
+                    extra={"scout": "scout_graph", "candidates": len(graph_candidates)},
+                )
             except Exception:
-                logger.warning("Phase B (graph) failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: phase B scout failed",
+                    extra={"scout": "scout_graph"},
+                    exc_info=True,
+                )
 
             try:
                 _t = time.perf_counter()
@@ -396,8 +446,16 @@ async def run_retrieve(
                     _lithos_metrics.lcma_scout_candidates.record(
                         len(coact_candidates), {"scout": "scout_coactivation"}
                     )
+                logger.debug(
+                    "run_retrieve: phase B scout completed",
+                    extra={"scout": "scout_coactivation", "candidates": len(coact_candidates)},
+                )
             except Exception:
-                logger.warning("Phase B (coactivation) failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: phase B scout failed",
+                    extra={"scout": "scout_coactivation"},
+                    exc_info=True,
+                )
 
             try:
                 _t = time.perf_counter()
@@ -413,8 +471,16 @@ async def run_retrieve(
                     _lithos_metrics.lcma_scout_candidates.record(
                         len(src_url_candidates), {"scout": "scout_source_url"}
                     )
+                logger.debug(
+                    "run_retrieve: phase B scout completed",
+                    extra={"scout": "scout_source_url", "candidates": len(src_url_candidates)},
+                )
             except Exception:
-                logger.warning("Phase B (source_url) failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: phase B scout failed",
+                    extra={"scout": "scout_source_url"},
+                    exc_info=True,
+                )
 
         # Contradictions — only fire when surface_conflicts is True
         conflicts_found: list[dict[str, object]] = []
@@ -428,8 +494,16 @@ async def run_retrieve(
                     agent_id=agent_id,
                     task_id=task_id,
                 )
+                logger.debug(
+                    "run_retrieve: contradictions surfaced",
+                    extra={"conflict_count": len(conflicts_found)},
+                )
             except Exception:
-                logger.warning("Phase B (contradictions) failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: phase B scout failed",
+                    extra={"scout": "scout_contradictions"},
+                    exc_info=True,
+                )
 
         # Record scouts_fired using canonical names in order. A scout
         # appears here iff it executed without raising — empty result
@@ -453,6 +527,16 @@ async def run_retrieve(
 
         reranked = _rerank_fast(merged, lcma_config, knowledge, salience_map=salience_map)
         terrace_reached = 1
+
+        logger.info(
+            "run_retrieve: reranking complete",
+            extra={
+                "receipt_id": receipt_id,
+                "candidates_considered": candidates_considered,
+                "scouts_fired": scouts_fired,
+                "temperature": temperature,
+            },
+        )
 
         # Apply limit
         final_candidates = reranked[:limit]
@@ -499,6 +583,17 @@ async def run_retrieve(
                 logger.warning("Document %s not found during result building", c.node_id)
                 continue
 
+        logger.info(
+            "run_retrieve: completed",
+            extra={
+                "receipt_id": receipt_id,
+                "result_count": len(results),
+                "limit": limit,
+                "agent_id": agent_id,
+                "task_id": task_id,
+            },
+        )
+
         # ── Working memory upserts ────────────────────────────────
         if task_id is not None:
             for r in results:
@@ -509,7 +604,11 @@ async def run_retrieve(
                         receipt_id=receipt_id,
                     )
                 except Exception:
-                    logger.warning("Working memory upsert failed for %s", r["id"], exc_info=True)
+                    logger.warning(
+                        "run_retrieve: working memory upsert failed",
+                        extra={"node_id": r["id"], "task_id": task_id, "receipt_id": receipt_id},
+                        exc_info=True,
+                    )
 
         envelope: dict[str, object] = {
             "results": results,
@@ -563,5 +662,18 @@ async def run_retrieve(
                 # Batch-increment coactivation for all unordered pairs
                 pairs = list(itertools.combinations(final_node_ids, 2))
                 await stats_store.increment_coactivation_batch(pairs, namespace=dom_ns)
+                logger.debug(
+                    "run_retrieve: coactivation updated",
+                    extra={
+                        "receipt_id": receipt_id,
+                        "node_count": len(final_node_ids),
+                        "pair_count": len(pairs),
+                        "namespace": dom_ns,
+                    },
+                )
             except Exception:
-                logger.warning("Coactivation/node_stats update failed", exc_info=True)
+                logger.warning(
+                    "run_retrieve: coactivation/node_stats update failed",
+                    extra={"receipt_id": receipt_id},
+                    exc_info=True,
+                )

--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -651,7 +651,11 @@ async def scout_graph(
             break
     logger.debug(
         "scout_graph: completed",
-        extra={"seed_count": len(seed_ids), "neighbors_found": len(neighbor_best), "candidates": len(candidates)},
+        extra={
+            "seed_count": len(seed_ids),
+            "neighbors_found": len(neighbor_best),
+            "candidates": len(candidates),
+        },
     )
     return candidates
 
@@ -719,7 +723,11 @@ async def scout_coactivation(
             break
     logger.debug(
         "scout_coactivation: completed",
-        extra={"seed_count": len(seed_ids), "coactivated": len(coactivated), "candidates": len(candidates)},
+        extra={
+            "seed_count": len(seed_ids),
+            "coactivated": len(coactivated),
+            "candidates": len(candidates),
+        },
     )
     return candidates
 
@@ -806,7 +814,11 @@ async def scout_source_url(
             break
     logger.debug(
         "scout_source_url: completed",
-        extra={"seed_count": len(seed_ids), "domain_matches": len(matches), "candidates": len(candidates)},
+        extra={
+            "seed_count": len(seed_ids),
+            "domain_matches": len(matches),
+            "candidates": len(candidates),
+        },
     )
     return candidates
 

--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -182,6 +182,10 @@ async def scout_vector(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_vector: completed",
+        extra={"fetched": len(results), "candidates": len(candidates), "limit": limit},
+    )
     return candidates
 
 
@@ -236,6 +240,10 @@ async def scout_lexical(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_lexical: completed",
+        extra={"fetched": len(results), "candidates": len(candidates), "limit": limit},
+    )
     return candidates
 
 
@@ -301,6 +309,10 @@ async def scout_exact_alias(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_exact_alias: completed",
+        extra={"resolved": len(found_ids), "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -348,6 +360,10 @@ async def scout_tags_recency(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_tags_recency: completed",
+        extra={"candidates": len(candidates), "tags": tags, "path_prefix": path_prefix},
+    )
     return candidates
 
 
@@ -395,6 +411,10 @@ async def scout_freshness(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_freshness: completed",
+        extra={"candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -461,6 +481,10 @@ async def scout_provenance(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_provenance: completed",
+        extra={"seed_count": len(seed_ids), "related": len(related), "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -534,6 +558,10 @@ async def scout_task_context(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_task_context: completed",
+        extra={"task_id": task_id, "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -621,6 +649,10 @@ async def scout_graph(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_graph: completed",
+        extra={"seed_count": len(seed_ids), "neighbors_found": len(neighbor_best), "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -685,6 +717,10 @@ async def scout_coactivation(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_coactivation: completed",
+        extra={"seed_count": len(seed_ids), "coactivated": len(coactivated), "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -768,6 +804,10 @@ async def scout_source_url(
         )
         if len(candidates) >= limit:
             break
+    logger.debug(
+        "scout_source_url: completed",
+        extra={"seed_count": len(seed_ids), "domain_matches": len(matches), "candidates": len(candidates)},
+    )
     return candidates
 
 
@@ -837,6 +877,10 @@ async def scout_contradictions(
                 }
             )
 
+    logger.debug(
+        "scout_contradictions: completed",
+        extra={"seed_count": len(seed_ids), "unresolved_conflicts": len(results)},
+    )
     return results
 
 

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -251,6 +251,23 @@ class StatsStore:
                 ),
             )
             await db.commit()
+        logger.info(
+            "receipt inserted: id=%s agent=%s task=%s candidates=%d final_nodes=%d scouts=%s",
+            receipt_id,
+            agent_id,
+            task_id,
+            candidates_considered,
+            len(final_nodes),
+            scouts_fired,
+            extra={
+                "receipt_id": receipt_id,
+                "agent_id": agent_id,
+                "task_id": task_id,
+                "candidates_considered": candidates_considered,
+                "final_node_count": len(final_nodes),
+                "scouts_fired": scouts_fired,
+            },
+        )
 
     # ------------------------------------------------------------------
     # Working-memory operations
@@ -321,6 +338,17 @@ class StatsStore:
                 )
             deleted = cursor.rowcount
             await db.commit()
+        logger.info(
+            "working_memory evicted: deleted=%d ttl_days=%d completed_task_count=%d",
+            deleted,
+            ttl_days,
+            len(completed_task_ids),
+            extra={
+                "deleted": deleted,
+                "ttl_days": ttl_days,
+                "completed_task_count": len(completed_task_ids),
+            },
+        )
         return deleted
 
     # ------------------------------------------------------------------
@@ -438,6 +466,13 @@ class StatsStore:
                 (trigger_type, node_id, task_id),
             )
             await db.commit()
+        logger.debug(
+            "enrich_queue enqueued: trigger=%s node_id=%s task_id=%s",
+            trigger_type,
+            node_id,
+            task_id,
+            extra={"trigger_type": trigger_type, "node_id": node_id, "task_id": task_id},
+        )
 
     async def drain_pending_nodes(
         self, *, max_attempts: int | None = None
@@ -507,6 +542,13 @@ class StatsStore:
             assert isinstance(entry["trigger_types"], set)
             entry["trigger_types"] = sorted(entry["trigger_types"])
             result.append(entry)
+
+        logger.debug(
+            "drain_pending_nodes: raw_rows=%d distinct_nodes=%d",
+            len(rows),
+            len(result),
+            extra={"raw_rows": len(rows), "distinct_nodes": len(result)},
+        )
         return result
 
     async def drain_pending_tasks(
@@ -582,6 +624,12 @@ class StatsStore:
             )
             count = cursor.rowcount
             await db.commit()
+        logger.warning(
+            "enrich_queue requeue_failed: requeued=%d requested=%d",
+            count,
+            len(claimed_ids),
+            extra={"requeued": count, "requested": len(claimed_ids)},
+        )
         return count
 
     async def get_exhausted_items(
@@ -659,6 +707,11 @@ class StatsStore:
                 [(nid, now) for nid in node_ids],
             )
             await db.commit()
+        logger.debug(
+            "node_stats batch increment: node_count=%d",
+            len(node_ids),
+            extra={"node_count": len(node_ids)},
+        )
 
     async def increment_coactivation_batch(
         self,
@@ -784,6 +837,12 @@ class StatsStore:
             await db.commit()
         if _HAS_TELEMETRY and _lithos_metrics is not None:
             _lithos_metrics.lcma_salience_updates.add(1)
+        logger.debug(
+            "salience updated: node_id=%s delta=%.4f",
+            node_id,
+            delta,
+            extra={"node_id": node_id, "delta": delta},
+        )
 
     async def increment_ignored(self, node_id: str) -> None:
         """Atomically increment ignored_count; creates row if absent."""
@@ -1019,6 +1078,7 @@ class StatsStore:
             await db.execute(
                 "ALTER TABLE node_stats ADD COLUMN cited_count INTEGER NOT NULL DEFAULT 0"
             )
+            logger.info("stats.db migration applied: added node_stats.cited_count")
 
     @staticmethod
     async def _migrate_add_last_decay_applied_at(db: aiosqlite.Connection) -> None:
@@ -1027,6 +1087,7 @@ class StatsStore:
         columns = {row[1] for row in await cursor.fetchall()}
         if "last_decay_applied_at" not in columns:
             await db.execute("ALTER TABLE node_stats ADD COLUMN last_decay_applied_at TIMESTAMP")
+            logger.info("stats.db migration applied: added node_stats.last_decay_applied_at")
 
     @staticmethod
     async def _migrate_add_enrich_queue_attempts(db: aiosqlite.Connection) -> None:
@@ -1037,6 +1098,7 @@ class StatsStore:
             await db.execute(
                 "ALTER TABLE enrich_queue ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0"
             )
+            logger.info("stats.db migration applied: added enrich_queue.attempts")
 
     @staticmethod
     async def _probe(path: Path) -> bool:

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -506,7 +506,7 @@ class StatsStore:
                     "SELECT id, node_id, trigger_type FROM enrich_queue "
                     "WHERE node_id IS NOT NULL AND processed_at IS NULL"
                 )
-            rows = await cursor.fetchall()
+            rows = list(await cursor.fetchall())
             if not rows:
                 await db.execute("COMMIT")
                 return []

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -101,6 +101,11 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
     actions: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
 
+    logger.info(
+        "reconcile indices started: dry_run=%s",
+        dry_run,
+        extra={"scope": "indices", "dry_run": dry_run},
+    )
     with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
         scan_span.set_attribute("lithos.reconcile.scope", "indices")
         try:
@@ -199,6 +204,22 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
         status = "partial_failure"
 
     lithos_metrics.reconcile_ops.add(1, {"scope": "indices", "status": status})
+    logger.info(
+        "reconcile indices complete: status=%s scanned=%d repaired=%d failed=%d dry_run=%s",
+        status,
+        len(corpus_docs),
+        repaired,
+        n_failed,
+        dry_run,
+        extra={
+            "scope": "indices",
+            "status": status,
+            "scanned": len(corpus_docs),
+            "repaired": repaired,
+            "failed": n_failed,
+            "dry_run": dry_run,
+        },
+    )
     return _make_result(
         "indices",
         dry_run,
@@ -238,6 +259,12 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
                 failures=[{"code": "internal_error", "detail": str(exc)}],
             )
 
+    logger.info(
+        "reconcile graph started: dry_run=%s corpus_count=%d",
+        dry_run,
+        len(corpus_docs),
+        extra={"scope": "graph", "dry_run": dry_run, "corpus_count": len(corpus_docs)},
+    )
     graph = KnowledgeGraph(config)
     with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
         diff_span.set_attribute("lithos.reconcile.scope", "graph")
@@ -352,6 +379,22 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
     status: ReconcileStatus = "failed" if n_failed > 0 else "ok"
 
     lithos_metrics.reconcile_ops.add(1, {"scope": "graph", "status": status})
+    logger.info(
+        "reconcile graph complete: status=%s scanned=%d repaired=%d failed=%d dry_run=%s",
+        status,
+        len(corpus_docs),
+        repaired,
+        n_failed,
+        dry_run,
+        extra={
+            "scope": "graph",
+            "status": status,
+            "scanned": len(corpus_docs),
+            "repaired": repaired,
+            "failed": n_failed,
+            "dry_run": dry_run,
+        },
+    )
     return _make_result(
         "graph",
         dry_run,
@@ -447,6 +490,12 @@ async def reconcile(
     cfg = config or get_config()
     tracer = get_tracer()
 
+    logger.info(
+        "reconcile: scope=%s dry_run=%s",
+        scope,
+        dry_run,
+        extra={"scope": scope, "dry_run": dry_run},
+    )
     with tracer.start_as_current_span("lithos.reconcile") as span:
         span.set_attribute("lithos.reconcile.scope", scope)
         span.set_attribute("lithos.reconcile.dry_run", dry_run)
@@ -548,4 +597,21 @@ async def reconcile(
             )
 
         span.set_attribute("lithos.reconcile.status", result["status"])
+        logger.info(
+            "reconcile complete: scope=%s status=%s scanned=%d repaired=%d failed=%d dry_run=%s",
+            result["scope"],
+            result["status"],
+            result["summary"]["scanned"],
+            result["summary"]["repaired"],
+            result["summary"]["failed"],
+            dry_run,
+            extra={
+                "scope": result["scope"],
+                "status": result["status"],
+                "scanned": result["summary"]["scanned"],
+                "repaired": result["summary"]["repaired"],
+                "failed": result["summary"]["failed"],
+                "dry_run": dry_run,
+            },
+        )
         return result

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -959,6 +959,13 @@ class SearchEngine:
                 errors,
             )
 
+        logger.debug(
+            "index_document: doc_id=%s chunks=%d backends_failed=%d",
+            doc.id,
+            chunks,
+            len(errors),
+            extra={"doc_id": doc.id, "chunks": chunks, "backends_failed": len(errors)},
+        )
         return chunks
 
     @traced("lithos.search.remove_document")
@@ -1021,13 +1028,21 @@ class SearchEngine:
         start = time.perf_counter()
         success = True
         try:
-            return self.tantivy.search(
+            results = self.tantivy.search(
                 query=query,
                 limit=limit,
                 tags=tags,
                 author=author,
                 path_prefix=path_prefix,
             )
+            logger.info(
+                "full_text_search: query_len=%d limit=%d result_count=%d",
+                len(query),
+                limit,
+                len(results),
+                extra={"query_len": len(query), "limit": limit, "result_count": len(results)},
+            )
+            return results
         except Exception as exc:
             success = False
             logger.error("Full-text search failed: %s", exc)
@@ -1082,7 +1097,7 @@ class SearchEngine:
                         )
                     },
                 )
-            return self.chroma.search(
+            results = self.chroma.search(
                 query=query,
                 limit=limit,
                 threshold=threshold,
@@ -1090,6 +1105,20 @@ class SearchEngine:
                 author=author,
                 path_prefix=path_prefix,
             )
+            logger.info(
+                "semantic_search: query_len=%d limit=%d threshold=%.2f result_count=%d",
+                len(query),
+                limit,
+                threshold,
+                len(results),
+                extra={
+                    "query_len": len(query),
+                    "limit": limit,
+                    "threshold": threshold,
+                    "result_count": len(results),
+                },
+            )
+            return results
         except Exception as exc:
             success = False
             logger.error("Semantic search failed: %s", exc)
@@ -1215,6 +1244,21 @@ class SearchEngine:
                 if len(merged) >= limit:
                     break
 
+            logger.info(
+                "hybrid_search: query_len=%d limit=%d ft_count=%d sem_count=%d merged_count=%d",
+                len(query),
+                limit,
+                len(ft_results),
+                len(sem_results),
+                len(merged),
+                extra={
+                    "query_len": len(query),
+                    "limit": limit,
+                    "ft_count": len(ft_results),
+                    "sem_count": len(sem_results),
+                    "merged_count": len(merged),
+                },
+            )
             return merged
         except SearchBackendError:
             success = False
@@ -1428,6 +1472,21 @@ class SearchEngine:
                     )
                 )
 
+            logger.info(
+                "graph_search: query_len=%d depth=%d seed_count=%d candidate_count=%d result_count=%d",
+                len(query),
+                depth,
+                len(effective_seeds),
+                len(candidate_ids),
+                len(results),
+                extra={
+                    "query_len": len(query),
+                    "depth": depth,
+                    "seed_count": len(effective_seeds),
+                    "candidate_count": len(candidate_ids),
+                    "result_count": len(results),
+                },
+            )
             return results
         except Exception as exc:
             success = False

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -1035,7 +1035,7 @@ class SearchEngine:
                 author=author,
                 path_prefix=path_prefix,
             )
-            logger.info(
+            logger.debug(
                 "full_text_search: query_len=%d limit=%d result_count=%d",
                 len(query),
                 limit,
@@ -1105,7 +1105,7 @@ class SearchEngine:
                 author=author,
                 path_prefix=path_prefix,
             )
-            logger.info(
+            logger.debug(
                 "semantic_search: query_len=%d limit=%d threshold=%.2f result_count=%d",
                 len(query),
                 limit,
@@ -1244,7 +1244,7 @@ class SearchEngine:
                 if len(merged) >= limit:
                     break
 
-            logger.info(
+            logger.debug(
                 "hybrid_search: query_len=%d limit=%d ft_count=%d sem_count=%d merged_count=%d",
                 len(query),
                 limit,
@@ -1472,7 +1472,7 @@ class SearchEngine:
                     )
                 )
 
-            logger.info(
+            logger.debug(
                 "graph_search: query_len=%d depth=%d seed_count=%d candidate_count=%d result_count=%d",
                 len(query),
                 depth,

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2689,17 +2689,16 @@ class LithosServer:
 
                 # -- Apply reinforcement side-effects after task is completed --
                 if validated is not None:
-                    if not validated.get("skip"):
-                        logger.info(
-                            "lithos_task_complete: applying feedback reinforcement",
-                            extra={
-                                "task_id": task_id,
-                                "agent": agent,
-                                "cited_count": len(validated.get("cited") or []),
-                                "misleading_count": len(validated.get("misleading") or []),
-                                "ignored_count": len(validated.get("ignored") or []),
-                            },
-                        )
+                    logger.info(
+                        "lithos_task_complete: applying feedback reinforcement",
+                        extra={
+                            "task_id": task_id,
+                            "agent": agent,
+                            "cited_count": len(validated.get("cited") or []),
+                            "misleading_count": len(validated.get("misleading") or []),
+                            "ignored_count": len(validated.get("ignored") or []),
+                        },
+                    )
                     await self._apply_task_feedback(validated)
 
                 await self._emit(

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1510,7 +1510,17 @@ class LithosServer:
                 Dict with results list (superset of lithos_search result
                 schema), temperature, terrace_reached, and receipt_id.
             """
-            logger.info("lithos_retrieve query_len=%d limit=%d", len(query), limit)
+            logger.info(
+                "lithos_retrieve: called",
+                extra={
+                    "query_len": len(query),
+                    "limit": limit,
+                    "agent_id": agent_id,
+                    "task_id": task_id,
+                    "namespace_filter": namespace_filter,
+                    "surface_conflicts": surface_conflicts,
+                },
+            )
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.retrieve") as span:
                 span.set_attribute("lithos.tool", "lithos_retrieve")
@@ -1520,6 +1530,7 @@ class LithosServer:
                 # Check LCMA enabled
                 lcma_config = self._config.lcma
                 if not lcma_config.enabled:
+                    logger.warning("lithos_retrieve: LCMA is disabled")
                     return {
                         "status": "error",
                         "code": "lcma_disabled",
@@ -1547,9 +1558,18 @@ class LithosServer:
                     path_prefix=path_prefix,
                 )
 
-                span.set_attribute(
-                    "lithos.result_count",
-                    len(result.get("results", [])),  # type: ignore[union-attr]
+                result_count = len(result.get("results", []))  # type: ignore[union-attr]
+                span.set_attribute("lithos.result_count", result_count)
+                logger.info(
+                    "lithos_retrieve: completed",
+                    extra={
+                        "result_count": result_count,
+                        "receipt_id": result.get("receipt_id"),  # type: ignore[union-attr]
+                        "temperature": result.get("temperature"),  # type: ignore[union-attr]
+                        "terrace_reached": result.get("terrace_reached"),  # type: ignore[union-attr]
+                        "agent_id": agent_id,
+                        "task_id": task_id,
+                    },
                 )
                 return result  # type: ignore[return-value]
 
@@ -2625,7 +2645,16 @@ class LithosServer:
             Returns:
                 Dict with success boolean, or error envelope if task not found or not open
             """
-            logger.info("lithos_task_complete task=%s agent=%s", task_id, agent)
+            logger.info(
+                "lithos_task_complete: called",
+                extra={
+                    "task_id": task_id,
+                    "agent": agent,
+                    "cited_count": len(cited_nodes) if cited_nodes is not None else 0,
+                    "misleading_count": len(misleading_nodes) if misleading_nodes is not None else 0,
+                    "receipt_id": receipt_id,
+                },
+            )
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.task_complete") as span:
                 span.set_attribute("lithos.tool", "lithos_task_complete")
@@ -2660,6 +2689,17 @@ class LithosServer:
 
                 # -- Apply reinforcement side-effects after task is completed --
                 if validated is not None:
+                    if not validated.get("skip"):
+                        logger.info(
+                            "lithos_task_complete: applying feedback reinforcement",
+                            extra={
+                                "task_id": task_id,
+                                "agent": agent,
+                                "cited_count": len(validated.get("cited") or []),
+                                "misleading_count": len(validated.get("misleading") or []),
+                                "ignored_count": len(validated.get("ignored") or []),
+                            },
+                        )
                     await self._apply_task_feedback(validated)
 
                 await self._emit(

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2651,7 +2651,9 @@ class LithosServer:
                     "task_id": task_id,
                     "agent": agent,
                     "cited_count": len(cited_nodes) if cited_nodes is not None else 0,
-                    "misleading_count": len(misleading_nodes) if misleading_nodes is not None else 0,
+                    "misleading_count": len(misleading_nodes)
+                    if misleading_nodes is not None
+                    else 0,
                     "receipt_id": receipt_id,
                 },
             )


### PR DESCRIPTION
Closes #175

## Summary

The LCMA codebase had very sparse logging — key operational events like picking up items from the enrichment queue and nearly all retrieval pipeline phases had no info-level logging at all, making production debugging very difficult. This PR adds structured logging across all LCMA code paths.

All logging follows the existing `logging.getLogger(__name__)` pattern already used in the non-LCMA parts of the codebase, with structured fields passed via the `extra={}` dict.

## Areas covered

### `lcma/enrich.py` — EnrichWorker
Previously had no logging of queue pickup or drain results.

**Now visible:**
```
INFO  EnrichWorker: received event                   event_type=note.created event_id=...
INFO  EnrichWorker: enqueued node enrichment         trigger_type=note.created node_id=abc123
INFO  EnrichWorker: drain started                    node_count=5
INFO  EnrichWorker: enriching node                   node_id=abc123 trigger_types=['note.created']
INFO  EnrichWorker: entity extraction complete       node_id=abc123 entity_count=12
INFO  EnrichWorker: drain completed                  nodes_succeeded=5 nodes_failed=0 tasks_succeeded=1 tasks_failed=0
INFO  EnrichWorker: full sweep started               node_count=248
INFO  EnrichWorker: full sweep completed             nodes_decayed=12 wm_entries_evicted=4 provenance_edges_created=7 provenance_edges_removed=2
DEBUG EnrichWorker: applied salience decay           node_id=abc123 days_inactive=8 decay_amount=0.040
```

### `lcma/scouts.py` — All scouts
Previously had no logging whatsoever.

**Now visible (DEBUG, one per scout):**
```
DEBUG scout_vector: completed         fetched=30 candidates=10 limit=10
DEBUG scout_lexical: completed        fetched=30 candidates=8 limit=10
DEBUG scout_exact_alias: completed    resolved=2 candidates=2
DEBUG scout_tags_recency: completed   candidates=5
DEBUG scout_freshness: completed      candidates=3
DEBUG scout_provenance: completed     seed_count=10 related=24 candidates=10
DEBUG scout_graph: completed          seed_count=10 neighbors_found=15 candidates=10
DEBUG scout_coactivation: completed   seed_count=10 coactivated=8 candidates=8
DEBUG scout_source_url: completed     seed_count=10 domain_matches=3 candidates=3
DEBUG scout_contradictions: completed seed_count=10 unresolved_conflicts=0
```

### `lcma/retrieve.py` — run_retrieve() pipeline
Previously had only sporadic warning messages for failures; no INFO about the pipeline flow.

**Now visible:**
```
INFO  run_retrieve: started          receipt_id=rcpt_abc query_len=42 limit=10 agent_id=my-agent task_id=None
INFO  run_retrieve: phase A complete receipt_id=rcpt_abc scouts_fired=5 raw_candidates=60 normalised_candidates=45
DEBUG run_retrieve: phase A scout completed scout=scout_vector candidates=10
DEBUG run_retrieve: phase B seeding  receipt_id=rcpt_abc seed_count=10
DEBUG run_retrieve: phase B scout completed scout=scout_provenance candidates=8
INFO  run_retrieve: reranking complete receipt_id=rcpt_abc candidates_considered=45 scouts_fired=['scout_vector', ...] temperature=0.5
INFO  run_retrieve: completed        receipt_id=rcpt_abc result_count=10 agent_id=my-agent task_id=None
WARN  run_retrieve: phase B scout failed scout=scout_graph          (with exc_info, was previously a bare exc_info=True)
```

### `lcma/reinforcement.py`
Previously had only DEBUG logs. Significant operations now logged at INFO.

**Now visible:**
```
INFO  reinforce_cited_nodes: reinforcing            node_count=3
INFO  reinforce_edges_between: strengthening edges  cited_count=3
INFO  penalize_ignored: applying ignored penalties  node_count=4
INFO  penalize_misleading: applying misleading penalties node_count=2
INFO  penalize_misleading: node quarantined         node_id=abc123 misleading_count=3
INFO  weaken_edges_for_bad_context: completed       bad_node_count=2 edges_weakened=5
```

### `server.py` — lithos_retrieve tool handler
Previously logged only `query_len` and `limit` with no result summary.

**Now visible:**
```
INFO  lithos_retrieve: called     query_len=42 limit=10 agent_id=my-agent task_id=task-xyz namespace_filter=None surface_conflicts=False
INFO  lithos_retrieve: completed  result_count=10 receipt_id=rcpt_abc temperature=0.5 terrace_reached=1
```

### `server.py` — lithos_task_complete tool handler
**Now visible:**
```
INFO  lithos_task_complete: called                      task_id=... agent=my-agent cited_count=3 misleading_count=0
INFO  lithos_task_complete: applying feedback reinforcement  cited_count=3 misleading_count=0 ignored_count=7
```

## Log level policy
- **INFO**: one per significant operational event (queue pickup, pipeline start/end, scout phase complete, reinforcement applied, sweep start/end)
- **DEBUG**: inner loops, per-item operations, intermediate steps
- **WARNING**: degraded-but-recoverable (scout failure, upsert failure)
- **ERROR**: existing paths unchanged