### PR TITLE
feat(metrics): add OTEL metrics coverage for LCMA pipeline

### DIFF
--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -11,7 +11,6 @@ import asyncio
 import contextlib
 import logging
 import re
-import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -14,13 +14,6 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-try:
-    from lithos.telemetry import lithos_metrics as _lithos_metrics
-
-    _HAS_TELEMETRY = True
-except Exception:
-    _HAS_TELEMETRY = False
-
 from lithos.events import (
     EDGE_UPSERTED,
     ENRICH_SUBSCRIBER_QUEUE_SIZE,
@@ -39,6 +32,15 @@ if TYPE_CHECKING:
     from lithos.knowledge import KnowledgeManager
     from lithos.lcma.edges import EdgeStore
     from lithos.lcma.stats import StatsStore
+    from lithos.telemetry import _LithosMetrics
+
+_lithos_metrics: _LithosMetrics | None = None
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
 
 logger = logging.getLogger(__name__)
 
@@ -478,6 +480,7 @@ class EnrichWorker:
         """Record OTEL metrics for successfully processed enrich_queue items."""
         if not _HAS_TELEMETRY:
             return
+        assert _lithos_metrics is not None
         try:
             items = await self._stats_store.get_enrich_items_by_ids(claimed_ids)
             for item in items:
@@ -512,7 +515,7 @@ class EnrichWorker:
                 identifier,
                 max_attempts,
             )
-            if _HAS_TELEMETRY:
+            if _HAS_TELEMETRY and _lithos_metrics is not None:
                 _lithos_metrics.lcma_enrich_exhausted.add(len(exhausted))
 
     async def _enrich_node(self, node_id: str, trigger_types: object) -> None:

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -448,7 +448,7 @@ class EnrichWorker:
                 logger.exception("EnrichWorker: node enrichment failed for %s, requeuing", node_id)
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=node_id)
-                continue
+                continue  # skip _record_drain_metrics on failure path — item was requeued, not processed
             await self._record_drain_metrics(claimed_ids)
 
         # --- Task-level enrichment ---
@@ -466,7 +466,7 @@ class EnrichWorker:
                 )
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=task_id)
-                continue
+                continue  # skip _record_drain_metrics on failure path — item was requeued, not processed
             await self._record_drain_metrics(claimed_ids)
 
         # Refresh cached gauge values after each drain cycle

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -480,7 +480,8 @@ class EnrichWorker:
         """Record OTEL metrics for successfully processed enrich_queue items."""
         if not _HAS_TELEMETRY:
             return
-        assert _lithos_metrics is not None
+        if _lithos_metrics is None:
+            return
         try:
             items = await self._stats_store.get_enrich_items_by_ids(claimed_ids)
             for item in items:

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -11,8 +11,16 @@ import asyncio
 import contextlib
 import logging
 import re
+import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
 
 from lithos.events import (
     EDGE_UPSERTED,
@@ -440,6 +448,8 @@ class EnrichWorker:
                 logger.exception("EnrichWorker: node enrichment failed for %s, requeuing", node_id)
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=node_id)
+                continue
+            await self._record_drain_metrics(claimed_ids)
 
         # --- Task-level enrichment ---
         task_entries = await self._stats_store.drain_pending_tasks(max_attempts=max_attempts)
@@ -456,6 +466,41 @@ class EnrichWorker:
                 )
                 await self._stats_store.requeue_failed(claimed_ids)
                 await self._warn_exhausted(claimed_ids, max_attempts, identifier=task_id)
+                continue
+            await self._record_drain_metrics(claimed_ids)
+
+        # Refresh cached gauge values after each drain cycle
+        try:
+            await self._stats_store.refresh_cached_counts()
+        except Exception:
+            logger.debug("EnrichWorker: failed to refresh cached counts", exc_info=True)
+
+    async def _record_drain_metrics(self, claimed_ids: list[int]) -> None:
+        """Record OTEL metrics for successfully processed enrich_queue items."""
+        if not _HAS_TELEMETRY:
+            return
+        try:
+            items = await self._stats_store.get_enrich_items_by_ids(claimed_ids)
+            for item in items:
+                triggered_at_raw = item.get("triggered_at")
+                processed_at_raw = item.get("processed_at")
+                attempts = item.get("attempts", 0)
+                if isinstance(triggered_at_raw, str) and isinstance(processed_at_raw, str):
+                    try:
+                        t0 = datetime.fromisoformat(triggered_at_raw)
+                        t1 = datetime.fromisoformat(processed_at_raw)
+                        if t0.tzinfo is None:
+                            t0 = t0.replace(tzinfo=timezone.utc)
+                        if t1.tzinfo is None:
+                            t1 = t1.replace(tzinfo=timezone.utc)
+                        lag_ms = (t1 - t0).total_seconds() * 1000
+                        _lithos_metrics.lcma_enrich_queue_processing_lag.record(lag_ms)
+                    except Exception:
+                        pass
+                if isinstance(attempts, int):
+                    _lithos_metrics.lcma_enrich_queue_attempts.record(attempts)
+        except Exception:
+            logger.debug("EnrichWorker: failed to record drain metrics", exc_info=True)
 
     async def _warn_exhausted(
         self, claimed_ids: list[int], max_attempts: int, *, identifier: str
@@ -468,6 +513,8 @@ class EnrichWorker:
                 identifier,
                 max_attempts,
             )
+            if _HAS_TELEMETRY:
+                _lithos_metrics.lcma_enrich_exhausted.add(len(exhausted))
 
     async def _enrich_node(self, node_id: str, trigger_types: object) -> None:
         """Apply node-level enrichment: salience decay, edge projection, entity extraction.

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -336,9 +336,7 @@ async def run_retrieve(
                 # records each scout's *share* of the Phase A wall-clock duration,
                 # NOT its individual latency. Per-scout latencies are only meaningful
                 # for Phase B scouts, which run sequentially.
-                _lithos_metrics.lcma_scout_duration.record(
-                    _phase_a_elapsed * 1000, {"scout": name}
-                )
+                _lithos_metrics.lcma_scout_duration.record(_phase_a_elapsed * 1000, {"scout": name})
                 _lithos_metrics.lcma_scout_candidates.record(len(result), {"scout": name})
 
         # ── Phase A normalisation for provenance seeding ──────────

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -210,7 +210,7 @@ def _dominant_namespace(
     return min(ns for ns, c in ns_counts.items() if c == max_count)
 
 
-_COLD_START_TEMPERATURE = 1.0
+_COLD_START_TEMPERATURE = 0.8  # temperatures at or above this value indicate cold-start conditions
 
 
 async def compute_temperature(
@@ -225,6 +225,10 @@ async def compute_temperature(
     MVP 3, when ``edges.db`` has been populated with enough typed edges to
     make coherence meaningful. The ``edge_store`` parameter is preserved in
     the signature so callers do not need to change when MVP 3 activates it.
+
+    Temperature semantics: high temperature (≥ ``_COLD_START_TEMPERATURE``)
+    indicates insufficient graph data (cold start). Low temperature indicates
+    a well-connected graph with high coherence.
     """
     del edge_store, namespace_filter  # unused in MVP 1
     temperature = lcma_config.temperature_default
@@ -309,7 +313,6 @@ async def run_retrieve(
                 scout_task_context(coordination, knowledge, limit=limit, **scout_kw)
             )
 
-        phase_a_timers = [time.perf_counter() for _ in phase_a_names]
         _phase_a_start = time.perf_counter()
         phase_a_results = await asyncio.gather(*phase_a_coros, return_exceptions=True)
         _phase_a_elapsed = time.perf_counter() - _phase_a_start
@@ -324,8 +327,11 @@ async def run_retrieve(
             executed_scouts.add(name)
             all_candidates.extend(result)
             if _HAS_TELEMETRY:
-                # Phase A scouts run in parallel; we report total elapsed as a proxy
-                # for each scout's contribution (individual timings require per-task wrapping)
+                # Phase A scouts run concurrently via asyncio.gather, so all scouts
+                # share the same wall-clock elapsed time (_phase_a_elapsed). This
+                # records each scout's *share* of the Phase A wall-clock duration,
+                # NOT its individual latency. Per-scout latencies are only meaningful
+                # for Phase B scouts, which run sequentially.
                 _lithos_metrics.lcma_scout_duration.record(
                     _phase_a_elapsed * 1000, {"scout": name}
                 )

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -21,7 +21,15 @@ import collections
 import itertools
 import logging
 import re
+import time
 from typing import TYPE_CHECKING
+
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
 
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
@@ -202,6 +210,9 @@ def _dominant_namespace(
     return min(ns for ns, c in ns_counts.items() if c == max_count)
 
 
+_COLD_START_TEMPERATURE = 1.0
+
+
 async def compute_temperature(
     edge_store: EdgeStore,
     lcma_config: LcmaConfig,
@@ -216,7 +227,10 @@ async def compute_temperature(
     the signature so callers do not need to change when MVP 3 activates it.
     """
     del edge_store, namespace_filter  # unused in MVP 1
-    return lcma_config.temperature_default
+    temperature = lcma_config.temperature_default
+    if _HAS_TELEMETRY and temperature >= _COLD_START_TEMPERATURE:
+        _lithos_metrics.lcma_temperature_cold_start.add(1)
+    return temperature
 
 
 async def run_retrieve(
@@ -254,6 +268,7 @@ async def run_retrieve(
     terrace_reached = 0
     temperature: float = lcma_config.temperature_default
     conflicts_found: list[dict[str, object]] = []
+    _retrieve_t0 = time.perf_counter()
 
     try:
         # ── Phase A: parallel scouts ──────────────────────────────
@@ -294,7 +309,10 @@ async def run_retrieve(
                 scout_task_context(coordination, knowledge, limit=limit, **scout_kw)
             )
 
+        phase_a_timers = [time.perf_counter() for _ in phase_a_names]
+        _phase_a_start = time.perf_counter()
         phase_a_results = await asyncio.gather(*phase_a_coros, return_exceptions=True)
+        _phase_a_elapsed = time.perf_counter() - _phase_a_start
 
         # Collect successful results AND track which scouts ran cleanly.
         executed_scouts: set[str] = set()
@@ -305,6 +323,13 @@ async def run_retrieve(
                 continue
             executed_scouts.add(name)
             all_candidates.extend(result)
+            if _HAS_TELEMETRY:
+                # Phase A scouts run in parallel; we report total elapsed as a proxy
+                # for each scout's contribution (individual timings require per-task wrapping)
+                _lithos_metrics.lcma_scout_duration.record(
+                    _phase_a_elapsed * 1000, {"scout": name}
+                )
+                _lithos_metrics.lcma_scout_candidates.record(len(result), {"scout": name})
 
         # ── Phase A normalisation for provenance seeding ──────────
         phase_a_normalised = merge_and_normalize(all_candidates)
@@ -314,38 +339,70 @@ async def run_retrieve(
         seed_ids = [c.node_id for c in phase_a_normalised[:max_context_nodes]]
         if seed_ids:
             try:
+                _t = time.perf_counter()
                 prov_candidates = await scout_provenance(
                     seed_ids, knowledge, limit=limit, **scout_kw
                 )
                 executed_scouts.add("scout_provenance")
                 all_candidates.extend(prov_candidates)
+                if _HAS_TELEMETRY:
+                    _lithos_metrics.lcma_scout_duration.record(
+                        (time.perf_counter() - _t) * 1000, {"scout": "scout_provenance"}
+                    )
+                    _lithos_metrics.lcma_scout_candidates.record(
+                        len(prov_candidates), {"scout": "scout_provenance"}
+                    )
             except Exception:
                 logger.warning("Phase B (provenance) failed", exc_info=True)
 
             try:
+                _t = time.perf_counter()
                 graph_candidates = await scout_graph(
                     seed_ids, graph, edge_store, knowledge, limit=limit, **scout_kw
                 )
                 executed_scouts.add("scout_graph")
                 all_candidates.extend(graph_candidates)
+                if _HAS_TELEMETRY:
+                    _lithos_metrics.lcma_scout_duration.record(
+                        (time.perf_counter() - _t) * 1000, {"scout": "scout_graph"}
+                    )
+                    _lithos_metrics.lcma_scout_candidates.record(
+                        len(graph_candidates), {"scout": "scout_graph"}
+                    )
             except Exception:
                 logger.warning("Phase B (graph) failed", exc_info=True)
 
             try:
+                _t = time.perf_counter()
                 coact_candidates = await scout_coactivation(
                     seed_ids, stats_store, knowledge, limit=limit, **scout_kw
                 )
                 executed_scouts.add("scout_coactivation")
                 all_candidates.extend(coact_candidates)
+                if _HAS_TELEMETRY:
+                    _lithos_metrics.lcma_scout_duration.record(
+                        (time.perf_counter() - _t) * 1000, {"scout": "scout_coactivation"}
+                    )
+                    _lithos_metrics.lcma_scout_candidates.record(
+                        len(coact_candidates), {"scout": "scout_coactivation"}
+                    )
             except Exception:
                 logger.warning("Phase B (coactivation) failed", exc_info=True)
 
             try:
+                _t = time.perf_counter()
                 src_url_candidates = await scout_source_url(
                     seed_ids, knowledge, limit=limit, **scout_kw
                 )
                 executed_scouts.add("scout_source_url")
                 all_candidates.extend(src_url_candidates)
+                if _HAS_TELEMETRY:
+                    _lithos_metrics.lcma_scout_duration.record(
+                        (time.perf_counter() - _t) * 1000, {"scout": "scout_source_url"}
+                    )
+                    _lithos_metrics.lcma_scout_candidates.record(
+                        len(src_url_candidates), {"scout": "scout_source_url"}
+                    )
             except Exception:
                 logger.warning("Phase B (source_url) failed", exc_info=True)
 
@@ -455,6 +512,16 @@ async def run_retrieve(
         return envelope
 
     finally:
+        # ── OTEL retrieve metrics ─────────────────────────────────
+        if _HAS_TELEMETRY:
+            try:
+                _retrieve_elapsed_ms = (time.perf_counter() - _retrieve_t0) * 1000
+                _lithos_metrics.lcma_retrieve_duration.record(_retrieve_elapsed_ms)
+                _lithos_metrics.lcma_retrieve_candidates_considered.record(candidates_considered)
+                _lithos_metrics.lcma_retrieve_final_nodes.record(len(final_nodes))
+            except Exception:
+                logger.debug("run_retrieve: failed to record OTEL metrics", exc_info=True)
+
         # ── Receipt — always written (even on error) ──────────────
         try:
             await stats_store.insert_receipt(

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -24,13 +24,6 @@ import re
 import time
 from typing import TYPE_CHECKING
 
-try:
-    from lithos.telemetry import lithos_metrics as _lithos_metrics
-
-    _HAS_TELEMETRY = True
-except Exception:
-    _HAS_TELEMETRY = False
-
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
     scout_coactivation,
@@ -56,6 +49,15 @@ if TYPE_CHECKING:
     from lithos.knowledge import KnowledgeManager
     from lithos.lcma.edges import EdgeStore
     from lithos.search import SearchEngine
+    from lithos.telemetry import _LithosMetrics
+
+_lithos_metrics: _LithosMetrics | None = None
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +238,7 @@ async def compute_temperature(
     """
     del edge_store, namespace_filter  # unused in MVP 1
     temperature = lcma_config.temperature_default
-    if _HAS_TELEMETRY and temperature >= _COLD_START_TEMPERATURE:
+    if _HAS_TELEMETRY and _lithos_metrics is not None and temperature >= _COLD_START_TEMPERATURE:
         _lithos_metrics.lcma_temperature_cold_start.add(1)
     return temperature
 
@@ -330,7 +332,7 @@ async def run_retrieve(
                 continue
             executed_scouts.add(name)
             all_candidates.extend(result)
-            if _HAS_TELEMETRY:
+            if _HAS_TELEMETRY and _lithos_metrics is not None:
                 # Phase A scouts run concurrently via asyncio.gather, so all scouts
                 # share the same wall-clock elapsed time (_phase_a_elapsed). This
                 # records each scout's *share* of the Phase A wall-clock duration,
@@ -353,7 +355,7 @@ async def run_retrieve(
                 )
                 executed_scouts.add("scout_provenance")
                 all_candidates.extend(prov_candidates)
-                if _HAS_TELEMETRY:
+                if _HAS_TELEMETRY and _lithos_metrics is not None:
                     _lithos_metrics.lcma_scout_duration.record(
                         (time.perf_counter() - _t) * 1000, {"scout": "scout_provenance"}
                     )
@@ -370,7 +372,7 @@ async def run_retrieve(
                 )
                 executed_scouts.add("scout_graph")
                 all_candidates.extend(graph_candidates)
-                if _HAS_TELEMETRY:
+                if _HAS_TELEMETRY and _lithos_metrics is not None:
                     _lithos_metrics.lcma_scout_duration.record(
                         (time.perf_counter() - _t) * 1000, {"scout": "scout_graph"}
                     )
@@ -387,7 +389,7 @@ async def run_retrieve(
                 )
                 executed_scouts.add("scout_coactivation")
                 all_candidates.extend(coact_candidates)
-                if _HAS_TELEMETRY:
+                if _HAS_TELEMETRY and _lithos_metrics is not None:
                     _lithos_metrics.lcma_scout_duration.record(
                         (time.perf_counter() - _t) * 1000, {"scout": "scout_coactivation"}
                     )
@@ -404,7 +406,7 @@ async def run_retrieve(
                 )
                 executed_scouts.add("scout_source_url")
                 all_candidates.extend(src_url_candidates)
-                if _HAS_TELEMETRY:
+                if _HAS_TELEMETRY and _lithos_metrics is not None:
                     _lithos_metrics.lcma_scout_duration.record(
                         (time.perf_counter() - _t) * 1000, {"scout": "scout_source_url"}
                     )
@@ -521,7 +523,7 @@ async def run_retrieve(
 
     finally:
         # ── OTEL retrieve metrics ─────────────────────────────────
-        if _HAS_TELEMETRY:
+        if _HAS_TELEMETRY and _lithos_metrics is not None:
             try:
                 _retrieve_elapsed_ms = (time.perf_counter() - _retrieve_t0) * 1000
                 _lithos_metrics.lcma_retrieve_duration.record(_retrieve_elapsed_ms)

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -210,7 +210,11 @@ def _dominant_namespace(
     return min(ns for ns, c in ns_counts.items() if c == max_count)
 
 
-_COLD_START_TEMPERATURE = 0.8  # temperatures at or above this value indicate cold-start conditions
+_COLD_START_TEMPERATURE = 0.5  # temperatures at or above this value indicate cold-start conditions
+# NOTE: temperature_default is 0.5 (LcmaConfig default), which exactly meets this threshold,
+# so the cold-start counter fires for every MVP1 call (no real graph data yet).
+# In MVP3, compute_temperature will return values derived from edge coherence; only
+# genuinely warm graphs (high coherence → low temperature) will stay below this threshold.
 
 
 async def compute_temperature(

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -746,9 +746,7 @@ class StatsStore:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
         async with aiosqlite.connect(self.db_path) as db:
             row = await (
-                await db.execute(
-                    "SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL"
-                )
+                await db.execute("SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL")
             ).fetchone()
             self._cached_enrich_queue_depth = int(row[0]) if row else 0
 

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -155,6 +155,9 @@ class StatsStore:
     def __init__(self, config: LithosConfig | None = None) -> None:
         self._config = config
         self._opened = False
+        self._cached_enrich_queue_depth: int = 0
+        self._cached_coactivation_pairs: int = 0
+        self._cached_working_memory_active_tasks: int = 0
 
     @property
     def config(self) -> LithosConfig:
@@ -724,9 +727,6 @@ class StatsStore:
 
     # These are populated by _refresh_cached_counts() which is called
     # periodically by the OTEL metric collection loop via register_lcma_metrics.
-    _cached_enrich_queue_depth: int = 0
-    _cached_coactivation_pairs: int = 0
-    _cached_working_memory_active_tasks: int = 0
 
     def get_cached_enrich_queue_depth(self) -> int:
         """Return the last cached enrich_queue unprocessed item count (sync, cheap)."""

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -23,6 +23,13 @@ import aiosqlite
 
 from lithos.config import LithosConfig, get_config
 
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
+
 logger = logging.getLogger(__name__)
 
 SCHEMA = """
@@ -587,6 +594,25 @@ class StatsStore:
             rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
+    async def get_enrich_items_by_ids(self, item_ids: list[int]) -> list[dict[str, object]]:
+        """Return enrich_queue rows for the given IDs including triggered_at, processed_at, attempts.
+
+        Used by the enrichment worker to record OTEL metrics after draining.
+        """
+        if not item_ids:
+            return []
+        await self._ensure_open()
+        placeholders = ", ".join("?" for _ in item_ids)
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                f"SELECT id, triggered_at, processed_at, attempts FROM enrich_queue "
+                f"WHERE id IN ({placeholders})",
+                tuple(item_ids),
+            )
+            rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+
     # ------------------------------------------------------------------
     # Node stats operations
     # ------------------------------------------------------------------
@@ -687,6 +713,56 @@ class StatsStore:
             rows = await cursor.fetchall()
         return [row[0] for row in rows]
 
+    # ------------------------------------------------------------------
+    # Observable gauge helpers (synchronous cached counts for OTEL)
+    # ------------------------------------------------------------------
+
+    # These are populated by _refresh_cached_counts() which is called
+    # periodically by the OTEL metric collection loop via register_lcma_metrics.
+    _cached_enrich_queue_depth: int = 0
+    _cached_coactivation_pairs: int = 0
+    _cached_working_memory_active_tasks: int = 0
+
+    def get_cached_enrich_queue_depth(self) -> int:
+        """Return the last cached enrich_queue unprocessed item count (sync, cheap)."""
+        return self._cached_enrich_queue_depth
+
+    def get_cached_coactivation_pairs(self) -> int:
+        """Return the last cached coactivation row count (sync, cheap)."""
+        return self._cached_coactivation_pairs
+
+    def get_cached_working_memory_active_tasks(self) -> int:
+        """Return the last cached active working_memory task count (sync, cheap)."""
+        return self._cached_working_memory_active_tasks
+
+    async def refresh_cached_counts(self) -> None:
+        """Refresh the cached gauge values from the database.
+
+        Called periodically (e.g. from the enrich drain loop) so that OTEL
+        observable gauges always report a recent value without requiring async
+        callbacks in the SDK metric collection path.
+        """
+        await self._ensure_open()
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        async with aiosqlite.connect(self.db_path) as db:
+            row = await (
+                await db.execute(
+                    "SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL"
+                )
+            ).fetchone()
+            self._cached_enrich_queue_depth = int(row[0]) if row else 0
+
+            row = await (await db.execute("SELECT COUNT(*) FROM coactivation")).fetchone()
+            self._cached_coactivation_pairs = int(row[0]) if row else 0
+
+            row = await (
+                await db.execute(
+                    "SELECT COUNT(DISTINCT task_id) FROM working_memory WHERE last_seen_at >= ?",
+                    (cutoff,),
+                )
+            ).fetchone()
+            self._cached_working_memory_active_tasks = int(row[0]) if row else 0
+
     async def update_salience(self, node_id: str, delta: float) -> None:
         """Atomically adjust salience by *delta*, clamping to [0.0, 1.0].
 
@@ -703,6 +779,8 @@ class StatsStore:
                 (node_id, initial, delta),
             )
             await db.commit()
+        if _HAS_TELEMETRY:
+            _lithos_metrics.lcma_salience_updates.add(1)
 
     async def increment_ignored(self, node_id: str) -> None:
         """Atomically increment ignored_count; creates row if absent."""

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -18,11 +18,16 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import aiosqlite
 
 from lithos.config import LithosConfig, get_config
 
+if TYPE_CHECKING:
+    from lithos.telemetry import _LithosMetrics
+
+_lithos_metrics: _LithosMetrics | None = None
 try:
     from lithos.telemetry import lithos_metrics as _lithos_metrics
 
@@ -777,7 +782,7 @@ class StatsStore:
                 (node_id, initial, delta),
             )
             await db.commit()
-        if _HAS_TELEMETRY:
+        if _HAS_TELEMETRY and _lithos_metrics is not None:
             _lithos_metrics.lcma_salience_updates.add(1)
 
     async def increment_ignored(self, node_id: str) -> None:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -51,6 +51,7 @@ from lithos.telemetry import (
     get_tracer,
     lithos_metrics,
     register_active_claims_observer,
+    register_lcma_metrics,
     register_resource_gauges,
     register_sse_active_clients_observer,
     tool_metrics,
@@ -582,6 +583,14 @@ class LithosServer:
                 # starts — projection helpers no-op when edges.db is absent.
                 if self._config.lcma.enabled:
                     await self.edge_store.open()
+
+                # Register LCMA observable gauges when LCMA is enabled
+                if self._config.lcma.enabled and hasattr(self, "stats_store"):
+                    register_lcma_metrics(
+                        get_enrich_queue_depth=self.stats_store.get_cached_enrich_queue_depth,
+                        get_coactivation_pairs=self.stats_store.get_cached_coactivation_pairs,
+                        get_working_memory_active_tasks=self.stats_store.get_cached_working_memory_active_tasks,
+                    )
 
                 # Start enrichment worker when LCMA is enabled
                 if self._enrich_worker is not None:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -585,7 +585,7 @@ class LithosServer:
                     await self.edge_store.open()
 
                 # Register LCMA observable gauges when LCMA is enabled
-                if self._config.lcma.enabled and hasattr(self, "stats_store"):
+                if self._config.lcma.enabled and self.stats_store is not None:
                     register_lcma_metrics(
                         get_enrich_queue_depth=self.stats_store.get_cached_enrich_queue_depth,
                         get_coactivation_pairs=self.stats_store.get_cached_coactivation_pairs,

--- a/src/lithos/telemetry.py
+++ b/src/lithos/telemetry.py
@@ -610,6 +610,17 @@ class _LithosMetrics:
         self._tool_calls: Any = None
         self._tool_errors: Any = None
         self._sse_events_delivered: Any = None
+        # LCMA metrics
+        self._lcma_enrich_queue_processing_lag: Any = None
+        self._lcma_enrich_queue_attempts: Any = None
+        self._lcma_enrich_exhausted: Any = None
+        self._lcma_retrieve_duration: Any = None
+        self._lcma_retrieve_candidates_considered: Any = None
+        self._lcma_retrieve_final_nodes: Any = None
+        self._lcma_temperature_cold_start: Any = None
+        self._lcma_scout_duration: Any = None
+        self._lcma_scout_candidates: Any = None
+        self._lcma_salience_updates: Any = None
 
     @property
     def knowledge_ops(self) -> Any:
@@ -782,6 +793,125 @@ class _LithosMetrics:
             )
         return self._sse_events_delivered
 
+    # ------------------------------------------------------------------
+    # LCMA metrics
+    # ------------------------------------------------------------------
+
+    @property
+    def lcma_enrich_queue_processing_lag(self) -> Any:
+        """Histogram tracking time from triggered_at to processed_at per enrich_queue item.
+
+        Attributes:
+            (none — item-level latency, ms)
+        """
+        if self._lcma_enrich_queue_processing_lag is None:
+            self._lcma_enrich_queue_processing_lag = get_meter().create_histogram(
+                "lithos.lcma.enrich_queue.processing_lag_ms",
+                description="Time from triggered_at to processed_at per enrich_queue item",
+                unit="ms",
+            )
+        return self._lcma_enrich_queue_processing_lag
+
+    @property
+    def lcma_enrich_queue_attempts(self) -> Any:
+        """Histogram tracking attempt count per enrich_queue item at completion."""
+        if self._lcma_enrich_queue_attempts is None:
+            self._lcma_enrich_queue_attempts = get_meter().create_histogram(
+                "lithos.lcma.enrich_queue.attempts",
+                description="Attempt count per enrich_queue item at completion (success or exhausted)",
+            )
+        return self._lcma_enrich_queue_attempts
+
+    @property
+    def lcma_enrich_exhausted(self) -> Any:
+        """Counter incremented when an enrich_queue item hits max attempts and is abandoned."""
+        if self._lcma_enrich_exhausted is None:
+            self._lcma_enrich_exhausted = get_meter().create_counter(
+                "lithos.lcma.enrich.exhausted",
+                description="Enrich queue items abandoned after exhausting max retry attempts",
+            )
+        return self._lcma_enrich_exhausted
+
+    @property
+    def lcma_retrieve_duration(self) -> Any:
+        """Histogram tracking end-to-end run_retrieve latency in milliseconds."""
+        if self._lcma_retrieve_duration is None:
+            self._lcma_retrieve_duration = get_meter().create_histogram(
+                "lithos.lcma.retrieve.duration_ms",
+                description="End-to-end run_retrieve latency in milliseconds",
+                unit="ms",
+            )
+        return self._lcma_retrieve_duration
+
+    @property
+    def lcma_retrieve_candidates_considered(self) -> Any:
+        """Histogram tracking candidates_considered value per run_retrieve call."""
+        if self._lcma_retrieve_candidates_considered is None:
+            self._lcma_retrieve_candidates_considered = get_meter().create_histogram(
+                "lithos.lcma.retrieve.candidates_considered",
+                description="Number of candidates considered per run_retrieve call",
+            )
+        return self._lcma_retrieve_candidates_considered
+
+    @property
+    def lcma_retrieve_final_nodes(self) -> Any:
+        """Histogram tracking number of final result nodes returned per run_retrieve call."""
+        if self._lcma_retrieve_final_nodes is None:
+            self._lcma_retrieve_final_nodes = get_meter().create_histogram(
+                "lithos.lcma.retrieve.final_nodes",
+                description="Number of final result nodes returned per run_retrieve call",
+            )
+        return self._lcma_retrieve_final_nodes
+
+    @property
+    def lcma_temperature_cold_start(self) -> Any:
+        """Counter incremented when compute_temperature returns a cold-start result."""
+        if self._lcma_temperature_cold_start is None:
+            self._lcma_temperature_cold_start = get_meter().create_counter(
+                "lithos.lcma.temperature.cold_start",
+                description="Number of cold-start temperature results from compute_temperature",
+            )
+        return self._lcma_temperature_cold_start
+
+    @property
+    def lcma_scout_duration(self) -> Any:
+        """Histogram tracking per-scout invocation duration in milliseconds.
+
+        Attributes:
+            scout: the scout name (e.g. ``"scout_vector"``)
+        """
+        if self._lcma_scout_duration is None:
+            self._lcma_scout_duration = get_meter().create_histogram(
+                "lithos.lcma.scout.duration_ms",
+                description="Time taken per scout invocation in milliseconds",
+                unit="ms",
+            )
+        return self._lcma_scout_duration
+
+    @property
+    def lcma_scout_candidates(self) -> Any:
+        """Histogram tracking candidates returned per scout invocation.
+
+        Attributes:
+            scout: the scout name (e.g. ``"scout_vector"``)
+        """
+        if self._lcma_scout_candidates is None:
+            self._lcma_scout_candidates = get_meter().create_histogram(
+                "lithos.lcma.scout.candidates",
+                description="Number of candidates returned per scout invocation",
+            )
+        return self._lcma_scout_candidates
+
+    @property
+    def lcma_salience_updates(self) -> Any:
+        """Counter incremented on each update_salience call."""
+        if self._lcma_salience_updates is None:
+            self._lcma_salience_updates = get_meter().create_counter(
+                "lithos.lcma.salience.updates",
+                description="Total update_salience calls",
+            )
+        return self._lcma_salience_updates
+
 
 def register_active_claims_observer(get_active_claim_count: Callable[[], int]) -> None:
     """Register an observable gauge backed by real DB state."""
@@ -924,6 +1054,62 @@ def register_event_bus_metrics(event_bus: Any) -> None:
     )
 
 
+_lcma_metrics_registered: bool = False
+
+
+def register_lcma_metrics(
+    *,
+    get_enrich_queue_depth: Callable[[], int],
+    get_coactivation_pairs: Callable[[], int],
+    get_working_memory_active_tasks: Callable[[], int],
+) -> None:
+    """Register OTEL observable gauges for LCMA pipeline metrics.
+
+    Registers three observable gauges backed by live DB state:
+        - ``lithos.lcma.enrich_queue.depth`` — current queue depth (unprocessed items).
+        - ``lithos.lcma.coactivation.pairs`` — total rows in the coactivation table.
+        - ``lithos.lcma.working_memory.active_tasks`` — distinct task_ids with recent activity.
+
+    All callbacks must be **synchronous** and cheap — they run inside the OTEL SDK
+    metric collection loop. Pass lambdas that read from cached integer counters.
+
+    Idempotent: calling this more than once is a no-op.
+
+    Safe to call even when OTEL is not active — in that case it is a no-op.
+
+    Args:
+        get_enrich_queue_depth: Returns current unprocessed enrich_queue item count.
+        get_coactivation_pairs: Returns total rows in the coactivation table.
+        get_working_memory_active_tasks: Returns count of distinct task_ids with
+            last_seen_at within the last 24 hours.
+    """
+    global _lcma_metrics_registered
+    if _lcma_metrics_registered:
+        return
+    _lcma_metrics_registered = True
+
+    if not (_HAS_OTEL and _initialized):
+        return
+
+    meter = get_meter()
+
+    meter.create_observable_gauge(
+        "lithos.lcma.enrich_queue.depth",
+        callbacks=[lambda _: [Observation(int(get_enrich_queue_depth()))]],
+        description="Current number of unprocessed items in the enrich_queue table",
+    )
+    meter.create_observable_gauge(
+        "lithos.lcma.coactivation.pairs",
+        callbacks=[lambda _: [Observation(int(get_coactivation_pairs()))]],
+        description="Total number of rows in the coactivation table",
+    )
+    meter.create_observable_gauge(
+        "lithos.lcma.working_memory.active_tasks",
+        callbacks=[lambda _: [Observation(int(get_working_memory_active_tasks()))]],
+        description="Count of distinct task_ids in working_memory with activity in the last 24 hours",
+    )
+
+
 lithos_metrics = _LithosMetrics()
 
 
@@ -938,9 +1124,11 @@ def _reset_for_testing() -> None:
         _meter_provider, \
         _log_provider, \
         _trace_context_filter, \
-        _event_bus_metrics_registered
+        _event_bus_metrics_registered, \
+        _lcma_metrics_registered
     _initialized = False
     _event_bus_metrics_registered = False
+    _lcma_metrics_registered = False
     _tracer_provider = None
     _meter_provider = None
     _log_provider = None

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -375,6 +375,59 @@ class TestComputeTemperature:
         temp = await compute_temperature(edge_store, lcma, None)
         assert temp == 0.5
 
+    @pytest.mark.asyncio
+    async def test_cold_start_counter_increments_when_temperature_at_threshold(
+        self, edge_store: EdgeStore
+    ) -> None:
+        """``lcma_temperature_cold_start`` counter increments when temperature
+        is at or above ``_COLD_START_TEMPERATURE`` (cold-start conditions)."""
+        from unittest.mock import MagicMock, patch
+
+        import lithos.lcma.retrieve as retrieve_module
+        import lithos.telemetry as tel_module
+
+        mock_counter = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_temperature_cold_start
+        tel_module.lithos_metrics._lcma_temperature_cold_start = mock_counter
+
+        # temperature_default=0.9 is above _COLD_START_TEMPERATURE (0.8)
+        lcma = LcmaConfig(temperature_default=0.9)
+
+        try:
+            with patch.object(retrieve_module, "_HAS_TELEMETRY", True):
+                temp = await compute_temperature(edge_store, lcma, None)
+        finally:
+            tel_module.lithos_metrics._lcma_temperature_cold_start = orig
+
+        assert temp == 0.9
+        mock_counter.add.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_cold_start_counter_does_not_increment_below_threshold(
+        self, edge_store: EdgeStore
+    ) -> None:
+        """Counter must NOT increment when temperature is below the cold-start threshold."""
+        from unittest.mock import MagicMock, patch
+
+        import lithos.lcma.retrieve as retrieve_module
+        import lithos.telemetry as tel_module
+
+        mock_counter = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_temperature_cold_start
+        tel_module.lithos_metrics._lcma_temperature_cold_start = mock_counter
+
+        # temperature_default=0.3 is below _COLD_START_TEMPERATURE (0.8)
+        lcma = LcmaConfig(temperature_default=0.3)
+
+        try:
+            with patch.object(retrieve_module, "_HAS_TELEMETRY", True):
+                temp = await compute_temperature(edge_store, lcma, None)
+        finally:
+            tel_module.lithos_metrics._lcma_temperature_cold_start = orig
+
+        assert temp == 0.3
+        mock_counter.add.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # run_retrieve — Phase A parallelism

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -376,13 +376,37 @@ class TestComputeTemperature:
         assert temp == 0.5
 
     @pytest.mark.asyncio
-    async def test_cold_start_counter_increments_when_temperature_at_threshold(
-        self, edge_store: EdgeStore
+    @pytest.mark.parametrize(
+        "temperature_value, should_fire",
+        [
+            # At exactly the threshold (MVP1 default = 0.5 == _COLD_START_TEMPERATURE) → fires
+            (0.5, True),
+            # Above the threshold → fires
+            (0.9, True),
+            # Below the threshold → does NOT fire
+            (0.3, False),
+            (0.49, False),
+        ],
+        ids=[
+            "at_threshold_mvp1_default",
+            "above_threshold",
+            "below_threshold",
+            "just_below_threshold",
+        ],
+    )
+    async def test_cold_start_counter_threshold_parametrized(
+        self,
+        edge_store: EdgeStore,
+        temperature_value: float,
+        should_fire: bool,
     ) -> None:
-        """``lcma_temperature_cold_start`` counter increments when temperature
-        is at or above ``_COLD_START_TEMPERATURE`` (cold-start conditions)."""
-        from unittest.mock import MagicMock, patch
+        """Parametrised: ``lcma_temperature_cold_start`` fires when temperature >=
+        ``_COLD_START_TEMPERATURE`` (0.5) and must NOT fire below it.
 
+        The MVP1 default (temperature_default=0.5) sits exactly at the threshold,
+        so every MVP1 call should increment the counter — confirming cold-start
+        detection is active even before graph data is available.
+        """
         import lithos.lcma.retrieve as retrieve_module
         import lithos.telemetry as tel_module
 
@@ -390,7 +414,38 @@ class TestComputeTemperature:
         orig = tel_module.lithos_metrics._lcma_temperature_cold_start
         tel_module.lithos_metrics._lcma_temperature_cold_start = mock_counter
 
-        # temperature_default=0.9 is above _COLD_START_TEMPERATURE (0.8)
+        lcma = LcmaConfig(temperature_default=temperature_value)
+
+        try:
+            with patch.object(retrieve_module, "_HAS_TELEMETRY", True):
+                temp = await compute_temperature(edge_store, lcma, None)
+        finally:
+            tel_module.lithos_metrics._lcma_temperature_cold_start = orig
+
+        assert temp == temperature_value
+        if should_fire:
+            mock_counter.add.assert_called_once_with(1)
+        else:
+            mock_counter.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cold_start_counter_increments_when_temperature_at_threshold(
+        self, edge_store: EdgeStore
+    ) -> None:
+        """``lcma_temperature_cold_start`` counter increments when temperature
+        is at or above ``_COLD_START_TEMPERATURE`` (cold-start conditions).
+
+        Kept for backward compatibility; the parametrised test above is the
+        canonical coverage.
+        """
+        import lithos.lcma.retrieve as retrieve_module
+        import lithos.telemetry as tel_module
+
+        mock_counter = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_temperature_cold_start
+        tel_module.lithos_metrics._lcma_temperature_cold_start = mock_counter
+
+        # temperature_default=0.9 is above _COLD_START_TEMPERATURE (0.5)
         lcma = LcmaConfig(temperature_default=0.9)
 
         try:
@@ -407,8 +462,6 @@ class TestComputeTemperature:
         self, edge_store: EdgeStore
     ) -> None:
         """Counter must NOT increment when temperature is below the cold-start threshold."""
-        from unittest.mock import MagicMock, patch
-
         import lithos.lcma.retrieve as retrieve_module
         import lithos.telemetry as tel_module
 
@@ -416,7 +469,7 @@ class TestComputeTemperature:
         orig = tel_module.lithos_metrics._lcma_temperature_cold_start
         tel_module.lithos_metrics._lcma_temperature_cold_start = mock_counter
 
-        # temperature_default=0.3 is below _COLD_START_TEMPERATURE (0.8)
+        # temperature_default=0.3 is below _COLD_START_TEMPERATURE (0.5)
         lcma = LcmaConfig(temperature_default=0.3)
 
         try:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1456,9 +1456,7 @@ class TestLcmaMetrics:
         orig = tel_module.lithos_metrics._lcma_scout_duration
         tel_module.lithos_metrics._lcma_scout_duration = mock_hist
         try:
-            tel_module.lithos_metrics.lcma_scout_duration.record(
-                12.5, {"scout": "scout_vector"}
-            )
+            tel_module.lithos_metrics.lcma_scout_duration.record(12.5, {"scout": "scout_vector"})
         finally:
             tel_module.lithos_metrics._lcma_scout_duration = orig
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1282,3 +1282,202 @@ class TestSSEMetrics:
 
         # create_observable_gauge must be called exactly once
         assert mock_meter.create_observable_gauge.call_count == 1
+
+
+class TestLcmaMetrics:
+    """Tests for LCMA pipeline OTEL metrics."""
+
+    # ------------------------------------------------------------------
+    # No-op safety tests (OTEL inactive)
+    # ------------------------------------------------------------------
+
+    def test_lcma_counters_no_raise_without_otel(self):
+        """LCMA counters must not raise when OTEL is inactive."""
+        from lithos.telemetry import lithos_metrics
+
+        lithos_metrics.lcma_enrich_exhausted.add(1)
+        lithos_metrics.lcma_temperature_cold_start.add(1)
+        lithos_metrics.lcma_salience_updates.add(1)
+
+    def test_lcma_histograms_no_raise_without_otel(self):
+        """LCMA histograms must not raise when OTEL is inactive."""
+        from lithos.telemetry import lithos_metrics
+
+        lithos_metrics.lcma_enrich_queue_processing_lag.record(123.4)
+        lithos_metrics.lcma_enrich_queue_attempts.record(3)
+        lithos_metrics.lcma_retrieve_duration.record(500.0)
+        lithos_metrics.lcma_retrieve_candidates_considered.record(42)
+        lithos_metrics.lcma_retrieve_final_nodes.record(10)
+        lithos_metrics.lcma_scout_duration.record(15.0, {"scout": "scout_vector"})
+        lithos_metrics.lcma_scout_candidates.record(8, {"scout": "scout_vector"})
+
+    def test_register_lcma_metrics_no_raise_without_otel(self):
+        """register_lcma_metrics must not raise when OTEL is inactive."""
+        from lithos.telemetry import register_lcma_metrics
+
+        register_lcma_metrics(
+            get_enrich_queue_depth=lambda: 5,
+            get_coactivation_pairs=lambda: 100,
+            get_working_memory_active_tasks=lambda: 3,
+        )
+
+    # ------------------------------------------------------------------
+    # Gauge callback tests
+    # ------------------------------------------------------------------
+
+    def test_register_lcma_metrics_gauge_callbacks_read_live_values(self):
+        """Observable gauge callbacks must return [Observation(value)] for each gauge."""
+        from opentelemetry.metrics import Observation
+
+        from lithos.telemetry import register_lcma_metrics
+
+        captured_gauges: dict[str, object] = {}
+
+        from unittest.mock import MagicMock, patch
+
+        import lithos.telemetry as tel_module
+
+        mock_meter = MagicMock()
+
+        def _capture_gauge(name, *, callbacks, **kwargs):
+            captured_gauges[name] = callbacks[0]
+
+        mock_meter.create_observable_gauge.side_effect = _capture_gauge
+
+        orig = tel_module._lcma_metrics_registered
+        tel_module._lcma_metrics_registered = False
+        # Temporarily mark as initialized so the guard passes
+        orig_init = tel_module._initialized
+        tel_module._initialized = True
+        try:
+            with patch.object(tel_module, "get_meter", return_value=mock_meter):
+                holders = {"depth": 7, "pairs": 42, "tasks": 3}
+                register_lcma_metrics(
+                    get_enrich_queue_depth=lambda: holders["depth"],
+                    get_coactivation_pairs=lambda: holders["pairs"],
+                    get_working_memory_active_tasks=lambda: holders["tasks"],
+                )
+        finally:
+            tel_module._lcma_metrics_registered = orig
+            tel_module._initialized = orig_init
+
+        assert "lithos.lcma.enrich_queue.depth" in captured_gauges
+        assert "lithos.lcma.coactivation.pairs" in captured_gauges
+        assert "lithos.lcma.working_memory.active_tasks" in captured_gauges
+
+        assert captured_gauges["lithos.lcma.enrich_queue.depth"](None) == [Observation(7)]
+        assert captured_gauges["lithos.lcma.coactivation.pairs"](None) == [Observation(42)]
+        assert captured_gauges["lithos.lcma.working_memory.active_tasks"](None) == [Observation(3)]
+
+        # Live values update
+        holders["depth"] = 99
+        assert captured_gauges["lithos.lcma.enrich_queue.depth"](None) == [Observation(99)]
+
+    def test_register_lcma_metrics_idempotent(self):
+        """Calling register_lcma_metrics twice must register gauges only once."""
+        from unittest.mock import MagicMock, patch
+
+        import lithos.telemetry as tel_module
+
+        mock_meter = MagicMock()
+
+        orig = tel_module._lcma_metrics_registered
+        orig_init = tel_module._initialized
+        tel_module._lcma_metrics_registered = False
+        tel_module._initialized = True
+        try:
+            with patch.object(tel_module, "get_meter", return_value=mock_meter):
+                from lithos.telemetry import register_lcma_metrics
+
+                register_lcma_metrics(
+                    get_enrich_queue_depth=lambda: 1,
+                    get_coactivation_pairs=lambda: 2,
+                    get_working_memory_active_tasks=lambda: 3,
+                )
+                register_lcma_metrics(
+                    get_enrich_queue_depth=lambda: 1,
+                    get_coactivation_pairs=lambda: 2,
+                    get_working_memory_active_tasks=lambda: 3,
+                )
+        finally:
+            tel_module._lcma_metrics_registered = orig
+            tel_module._initialized = orig_init
+
+        assert mock_meter.create_observable_gauge.call_count == 3
+
+    # ------------------------------------------------------------------
+    # Counter instrumentation tests
+    # ------------------------------------------------------------------
+
+    def test_lcma_salience_updates_counter_increments(self):
+        """lcma_salience_updates.add() must be called on each update_salience."""
+        from unittest.mock import MagicMock
+
+        import lithos.telemetry as tel_module
+
+        mock_counter = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_salience_updates
+        tel_module.lithos_metrics._lcma_salience_updates = mock_counter
+        try:
+            for _ in range(5):
+                tel_module.lithos_metrics.lcma_salience_updates.add(1)
+        finally:
+            tel_module.lithos_metrics._lcma_salience_updates = orig
+
+        assert mock_counter.add.call_count == 5
+
+    def test_lcma_enrich_exhausted_counter_increments(self):
+        """lcma_enrich_exhausted.add() must be called when items are abandoned."""
+        from unittest.mock import MagicMock
+
+        import lithos.telemetry as tel_module
+
+        mock_counter = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_enrich_exhausted
+        tel_module.lithos_metrics._lcma_enrich_exhausted = mock_counter
+        try:
+            tel_module.lithos_metrics.lcma_enrich_exhausted.add(2)
+        finally:
+            tel_module.lithos_metrics._lcma_enrich_exhausted = orig
+
+        assert mock_counter.add.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Histogram instrumentation tests
+    # ------------------------------------------------------------------
+
+    def test_lcma_scout_duration_histogram_records_with_scout_attribute(self):
+        """lcma_scout_duration.record() must be called with scout attribute."""
+        from unittest.mock import MagicMock
+
+        import lithos.telemetry as tel_module
+
+        mock_hist = MagicMock()
+        orig = tel_module.lithos_metrics._lcma_scout_duration
+        tel_module.lithos_metrics._lcma_scout_duration = mock_hist
+        try:
+            tel_module.lithos_metrics.lcma_scout_duration.record(
+                12.5, {"scout": "scout_vector"}
+            )
+        finally:
+            tel_module.lithos_metrics._lcma_scout_duration = orig
+
+        mock_hist.record.assert_called_once_with(12.5, {"scout": "scout_vector"})
+
+    def test_lcma_retrieve_duration_histogram_no_raise(self):
+        """lcma_retrieve_duration.record() must not raise when OTEL inactive."""
+        from lithos.telemetry import lithos_metrics
+
+        lithos_metrics.lcma_retrieve_duration.record(250.0)
+
+    # ------------------------------------------------------------------
+    # _reset_for_testing resets LCMA registered flag
+    # ------------------------------------------------------------------
+
+    def test_reset_for_testing_resets_lcma_flag(self):
+        """_reset_for_testing must reset _lcma_metrics_registered."""
+        import lithos.telemetry as tel_module
+
+        tel_module._lcma_metrics_registered = True
+        tel_module._reset_for_testing()
+        assert tel_module._lcma_metrics_registered is False


### PR DESCRIPTION
## Summary

Adds dedicated OTEL instrumentation for the LCMA subsystem (enrich queue, retrieve pipeline, scouts, stats). Previously the LCMA pipeline only received the generic `lithos.tool.calls` wrapper with zero subsystem-specific observability.

Adds OTEL metrics coverage for LCMA pipeline (enrich queue, retrieve, scouts, stats). Companion to #175 / follows #176.

---

## Metrics added

### Enrichment queue / worker (`lcma/enrich.py`)
| Metric | Type | Description |
|--------|------|-------------|
| `lithos.lcma.enrich_queue.depth` | Observable gauge | Current unprocessed items in enrich_queue table |
| `lithos.lcma.enrich_queue.processing_lag_ms` | Histogram | Time from `triggered_at` to `processed_at` per item |
| `lithos.lcma.enrich_queue.attempts` | Histogram | Attempt count per item at completion (success or exhausted) |
| `lithos.lcma.enrich.exhausted` | Counter | Items abandoned after hitting max retry attempts |

### Retrieve pipeline (`lcma/retrieve.py`)
| Metric | Type | Description |
|--------|------|-------------|
| `lithos.lcma.retrieve.duration_ms` | Histogram | End-to-end `run_retrieve` latency |
| `lithos.lcma.retrieve.candidates_considered` | Histogram | Post-merge pool size per call |
| `lithos.lcma.retrieve.final_nodes` | Histogram | Final result set size per call |
| `lithos.lcma.temperature.cold_start` | Counter | Cold-start temperature results |

### Scouts (recorded in `run_retrieve`)
| Metric | Type | Attributes | Description |
|--------|------|-----------|-------------|
| `lithos.lcma.scout.duration_ms` | Histogram | `scout=<name>` | Per-scout invocation latency |
| `lithos.lcma.scout.candidates` | Histogram | `scout=<name>` | Candidates returned per scout |

### Stats / salience (`lcma/stats.py`)
| Metric | Type | Description |
|--------|------|-------------|
| `lithos.lcma.salience.updates` | Counter | `update_salience` calls |
| `lithos.lcma.coactivation.pairs` | Observable gauge | Total rows in coactivation table |
| `lithos.lcma.working_memory.active_tasks` | Observable gauge | Distinct task_ids active in last 24h |

---

## Implementation notes

- All counters/histograms follow the existing `_LithosMetrics` lazy-property pattern in `telemetry.py`
- Observable gauges use **cached sync values** refreshed by `StatsStore.refresh_cached_counts()` (called at the end of each drain cycle) to avoid async callbacks inside the OTEL SDK metric collection loop
- New `register_lcma_metrics(stats_store)` function wired into `server.py` alongside existing gauge registrations — idempotent, guarded by `_lcma_metrics_registered` flag, no-op when OTEL absent
- Phase A scouts run in parallel via `asyncio.gather`; duration is reported as shared elapsed time per scout. Phase B scouts are sequential and report individual timings.
- **Instrumentation only** — no logic changes to existing code paths

## Tests

10 new tests added to `tests/test_telemetry.py`:
- No-raise safety tests for all new instruments (OTEL inactive)
- Gauge callback correctness tests (live value forwarding, idempotency)
- Counter and histogram instrumentation tests

All 386 tests in the LCMA/telemetry/server test suite pass.