### PR TITLE
fix: accept outcome param on lithos_task_complete (#178)

### DIFF
--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -35,7 +35,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     status TEXT DEFAULT 'open',
     created_by TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    tags JSON
+    tags JSON,
+    outcome TEXT,
+    completed_at TIMESTAMP
 );
 
 -- Claims (with automatic expiry)
@@ -104,6 +106,8 @@ class Task:
     created_by: str = ""
     created_at: datetime | None = None
     tags: list[str] = field(default_factory=list)
+    outcome: str | None = None
+    completed_at: datetime | None = None
 
 
 @dataclass
@@ -214,8 +218,28 @@ class CoordinationService:
 
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(SCHEMA)
+            await self._migrate_tasks_add_outcome(db)
+            await self._migrate_tasks_add_completed_at(db)
             await db.commit()
         logger.info("coordination service initialized: db_path=%s", self.db_path)
+
+    @staticmethod
+    async def _migrate_tasks_add_outcome(db: aiosqlite.Connection) -> None:
+        """Add outcome column to existing tasks tables (pre-outcome databases)."""
+        cursor = await db.execute("PRAGMA table_info(tasks)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "outcome" not in columns:
+            await db.execute("ALTER TABLE tasks ADD COLUMN outcome TEXT")
+            logger.info("coordination.db migration applied: added tasks.outcome")
+
+    @staticmethod
+    async def _migrate_tasks_add_completed_at(db: aiosqlite.Connection) -> None:
+        """Add completed_at column to existing tasks tables (pre-outcome databases)."""
+        cursor = await db.execute("PRAGMA table_info(tasks)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "completed_at" not in columns:
+            await db.execute("ALTER TABLE tasks ADD COLUMN completed_at TIMESTAMP")
+            logger.info("coordination.db migration applied: added tasks.completed_at")
 
     async def _get_db(self) -> aiosqlite.Connection:
         """Get database connection."""
@@ -448,6 +472,12 @@ class CoordinationService:
                 with contextlib.suppress(json.JSONDecodeError):
                     tags = json.loads(row["tags"])
 
+            # outcome/completed_at may be absent on legacy rows (pre-migration
+            # reads should not be possible, but defend against it defensively).
+            row_keys = row.keys()
+            outcome = row["outcome"] if "outcome" in row_keys else None
+            completed_at_raw = row["completed_at"] if "completed_at" in row_keys else None
+
             return Task(
                 id=row["id"],
                 title=row["title"],
@@ -456,6 +486,8 @@ class CoordinationService:
                 created_by=row["created_by"],
                 created_at=_parse_datetime(row["created_at"]),
                 tags=tags,
+                outcome=outcome,
+                completed_at=_parse_datetime(completed_at_raw),
             )
 
     @traced("lithos.coordination.update_task")
@@ -523,8 +555,20 @@ class CoordinationService:
             return updated
 
     @traced("lithos.coordination.complete_task")
-    async def complete_task(self, task_id: str, agent: str) -> bool:
+    async def complete_task(
+        self,
+        task_id: str,
+        agent: str,
+        outcome: str | None = None,
+    ) -> bool:
         """Mark task as completed and release all claims.
+
+        Args:
+            task_id: Task ID to complete.
+            agent: Agent completing the task.
+            outcome: Optional free-text completion summary persisted alongside
+                the task. Downstream consolidation (LCMA enrich) can use this
+                as the ``outcome`` slot of the frame extracted from the task.
 
         Returns:
             True if task was completed
@@ -532,11 +576,19 @@ class CoordinationService:
         lithos_metrics.coordination_ops.add(1, {"op": "complete"})
         await self.ensure_agent_known(agent)
 
+        now = _format_datetime(datetime.now(timezone.utc))
+
         async with aiosqlite.connect(self.db_path) as db:
-            # Update task status
+            # Update task status, outcome, and completed_at in a single statement
             cursor = await db.execute(
-                "UPDATE tasks SET status = 'completed' WHERE id = ? AND status = 'open'",
-                (task_id,),
+                """
+                UPDATE tasks
+                   SET status = 'completed',
+                       outcome = ?,
+                       completed_at = ?
+                 WHERE id = ? AND status = 'open'
+                """,
+                (outcome, now, task_id),
             )
             if cursor.rowcount == 0:
                 return False
@@ -548,7 +600,18 @@ class CoordinationService:
             )
 
             await db.commit()
-            logger.info("Task completed: task_id=%s agent=%s", task_id, agent)
+            logger.info(
+                "Task completed: task_id=%s agent=%s outcome_len=%d",
+                task_id,
+                agent,
+                len(outcome) if outcome else 0,
+                extra={
+                    "task_id": task_id,
+                    "agent": agent,
+                    "outcome_provided": outcome is not None,
+                    "outcome_len": len(outcome) if outcome else 0,
+                },
+            )
             return True
 
     @traced("lithos.coordination.cancel_task")

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2629,6 +2629,7 @@ class LithosServer:
         async def lithos_task_complete(
             task_id: str,
             agent: str,
+            outcome: str | None = None,
             cited_nodes: list[str] | None = None,
             misleading_nodes: list[str] | None = None,
             receipt_id: str | None = None,
@@ -2638,6 +2639,10 @@ class LithosServer:
             Args:
                 task_id: Task ID
                 agent: Agent completing the task
+                outcome: Optional free-text completion summary. Persisted on
+                    the task row and forwarded in the ``task.completed`` event
+                    payload so LCMA consolidation can use it as the frame
+                    ``outcome`` slot.
                 cited_nodes: Node IDs the agent found useful (None = no feedback)
                 misleading_nodes: Node IDs the agent found misleading (None = no feedback)
                 receipt_id: Specific receipt to bind feedback to (optional)
@@ -2645,11 +2650,14 @@ class LithosServer:
             Returns:
                 Dict with success boolean, or error envelope if task not found or not open
             """
+            outcome_len = len(outcome) if outcome else 0
             logger.info(
                 "lithos_task_complete: called",
                 extra={
                     "task_id": task_id,
                     "agent": agent,
+                    "outcome_provided": outcome is not None,
+                    "outcome_len": outcome_len,
                     "cited_count": len(cited_nodes) if cited_nodes is not None else 0,
                     "misleading_count": len(misleading_nodes)
                     if misleading_nodes is not None
@@ -2662,6 +2670,8 @@ class LithosServer:
                 span.set_attribute("lithos.tool", "lithos_task_complete")
                 span.set_attribute("lithos.agent", agent)
                 span.set_attribute("lithos.task_id", task_id)
+                span.set_attribute("lithos.outcome_provided", outcome is not None)
+                span.set_attribute("lithos.outcome_len", outcome_len)
                 # -- Validate feedback BEFORE completing the task --
                 feedback_supplied = cited_nodes is not None or misleading_nodes is not None
                 validated: dict[str, Any] | None = None
@@ -2679,6 +2689,7 @@ class LithosServer:
                 success = await self.coordination.complete_task(
                     task_id=task_id,
                     agent=agent,
+                    outcome=outcome,
                 )
                 span.set_attribute("lithos.success", success)
 
@@ -2710,6 +2721,7 @@ class LithosServer:
                         payload={
                             "task_id": task_id,
                             "agent": agent,
+                            "outcome": outcome,
                             "cited_nodes": json.dumps(cited_nodes),
                             "misleading_nodes": json.dumps(misleading_nodes),
                             "receipt_id": json.dumps(receipt_id),

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -3,8 +3,10 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 
+import aiosqlite
 import pytest
 
+from lithos.config import LithosConfig, StorageConfig
 from lithos.coordination import CoordinationService
 
 
@@ -148,6 +150,43 @@ class TestTaskLifecycle:
         assert success
         task = await coordination_service.get_task(task_id)
         assert task.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_complete_task_persists_outcome(self, coordination_service: CoordinationService):
+        """complete_task(outcome=...) persists the free-text summary and completed_at."""
+        task_id = await coordination_service.create_task(
+            title="Task with Outcome",
+            agent="agent",
+        )
+
+        outcome = "Resolved: salience weights recalibrated and smoke tested."
+        success = await coordination_service.complete_task(task_id, "agent", outcome=outcome)
+
+        assert success
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.status == "completed"
+        assert task.outcome == outcome
+        assert task.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_complete_task_outcome_defaults_none(
+        self, coordination_service: CoordinationService
+    ):
+        """Omitting outcome is backward-compatible — task.outcome is None."""
+        task_id = await coordination_service.create_task(
+            title="Task without Outcome",
+            agent="agent",
+        )
+
+        success = await coordination_service.complete_task(task_id, "agent")
+
+        assert success
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.status == "completed"
+        assert task.outcome is None
+        assert task.completed_at is not None
 
     @pytest.mark.asyncio
     async def test_complete_releases_claims(self, coordination_service: CoordinationService):
@@ -901,3 +940,59 @@ class TestTaskUpdate:
         task = await coordination_service.get_task(task_id)
         assert task is not None
         assert task.status == "open"
+
+
+class TestTaskOutcomeMigration:
+    """Verify ALTER-TABLE migrations add outcome/completed_at to pre-existing DBs."""
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_outcome_and_completed_at_columns(self, tmp_path):
+        """Simulate a pre-#178 coordination.db and confirm initialize() migrates it."""
+        db_path = tmp_path / "coordination.db"
+
+        # Build a legacy tasks table with the pre-#178 schema (no outcome/completed_at).
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT DEFAULT 'open',
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON
+                )
+                """
+            )
+            await db.execute(
+                "INSERT INTO tasks (id, title, created_by) VALUES (?, ?, ?)",
+                ("legacy-task", "Legacy", "legacy-agent"),
+            )
+            await db.commit()
+
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+        await service.initialize()
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("PRAGMA table_info(tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+
+        assert "outcome" in columns
+        assert "completed_at" in columns
+
+        # Legacy row still readable and reports None for the new fields.
+        task = await service.get_task("legacy-task")
+        assert task is not None
+        assert task.outcome is None
+        assert task.completed_at is None
+
+        # Completing the legacy task works and persists outcome on the migrated schema.
+        success = await service.complete_task("legacy-task", "legacy-agent", outcome="done")
+        assert success
+        task = await service.get_task("legacy-task")
+        assert task is not None
+        assert task.outcome == "done"
+        assert task.completed_at is not None

--- a/tests/test_event_emission.py
+++ b/tests/test_event_emission.py
@@ -239,7 +239,41 @@ class TestTaskEventEmission:
         assert event.type == TASK_COMPLETED
         assert event.agent == "test-agent"
         assert event.payload["task_id"] == task_id
+        # outcome is surfaced in the event payload; None when not supplied.
+        assert event.payload["outcome"] is None
         server.event_bus.unsubscribe(queue)
+
+    @pytest.mark.asyncio
+    async def test_lithos_task_complete_accepts_outcome(self, server: LithosServer) -> None:
+        """Regression test for #178: ``outcome`` must be an accepted parameter
+        and must flow into the persisted task + the task.completed event."""
+        result = await _call_tool(
+            server,
+            "lithos_task_create",
+            {"title": "Task with Outcome", "agent": "test-agent"},
+        )
+        task_id = result["task_id"]
+
+        queue = server.event_bus.subscribe(event_types=[TASK_COMPLETED])
+        outcome_text = "Reviewed LCMA scout architecture and filed 3 follow-ups."
+        complete_result = await _call_tool(
+            server,
+            "lithos_task_complete",
+            {"task_id": task_id, "agent": "test-agent", "outcome": outcome_text},
+        )
+        assert complete_result["success"] is True
+
+        # Event payload carries the outcome verbatim.
+        event = queue.get_nowait()
+        assert event.type == TASK_COMPLETED
+        assert event.payload["outcome"] == outcome_text
+        server.event_bus.unsubscribe(queue)
+
+        # Task row persists the outcome for later consolidation / audit.
+        task = await server.coordination.get_task(task_id)
+        assert task is not None
+        assert task.outcome == outcome_text
+        assert task.completed_at is not None
 
 
 class TestFindingEventEmission:


### PR DESCRIPTION
## Summary
- Adds the missing `outcome: str | None = None` parameter to `lithos_task_complete`, resolving the `Unexpected keyword argument` validation error reported in #178.
- Persists `outcome` + `completed_at` on the `tasks` row (with idempotent ALTER TABLE migrations so existing coordination.db files gain the columns on next startup).
- Forwards `outcome` in the `task.completed` event payload so LCMA consolidation can consume it as the frame `outcome` slot (per the LCMA design doc).
- Enriches logging and tracing on both the MCP tool and `CoordinationService.complete_task` with `outcome_provided` / `outcome_len` attributes.

## Test plan
- [x] Unit: `tests/test_coordination.py` covers outcome persistence, the `None` default, and the legacy-DB migration.
- [x] Integration: `tests/test_event_emission.py::test_lithos_task_complete_accepts_outcome` drives the MCP tool end-to-end and asserts the payload + row contain the outcome.
- [x] `make check` (ruff + pyright + unit tests) green.
- [x] `pytest tests/test_event_emission.py tests/test_coordination.py` green (66 passed).

Fixes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)