### PR TITLE
fix: rebalance rerank weights so lexical >= vector (#179)

### DIFF
--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -16,10 +16,16 @@ _LCMA_NOTE_TYPES = frozenset(
     {"observation", "agent_finding", "summary", "concept", "task_record", "hypothesis"}
 )
 
-# Default rerank weights keyed by scout name (minus scout_ prefix)
+# Default rerank weights keyed by scout name (minus scout_ prefix).
+#
+# Lexical is weighted at or above vector so exact-term-match notes are not
+# structurally dominated by semantically-adjacent vector hits on a cold KB
+# (see #179). Previously vector=0.25, lexical=0.18 which gave vector-only
+# candidates a built-in edge of ~0.07 on top of any normalisation noise.
+# Weights must sum to 1.0 — enforced by LcmaConfig validator.
 _DEFAULT_RERANK_WEIGHTS: dict[str, float] = {
-    "vector": 0.25,
-    "lexical": 0.18,
+    "vector": 0.21,
+    "lexical": 0.22,
     "exact_alias": 0.10,
     "tags_recency": 0.07,
     "freshness": 0.04,

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -149,6 +149,7 @@ def _rerank_fast(
     rerank_weights = lcma_config.rerank_weights
     note_type_priors = lcma_config.note_type_priors
 
+    debug_rows: list[dict[str, object]] = []
     scored: list[tuple[float, Candidate]] = []
     for c in candidates:
         # Weighted scout contribution — average weight across all contributing scouts
@@ -161,10 +162,12 @@ def _rerank_fast(
 
         # Note-type prior from metadata cache
         note_type_prior = 0.5
+        resolved_note_type = "unknown"  # for calibration logging only
         cached = knowledge._meta_cache.get(c.node_id)
         if cached:
             note_type = getattr(cached, "note_type", None) or "observation"
             note_type_prior = note_type_priors.get(note_type, 0.5)
+            resolved_note_type = note_type
 
         # Salience: read from StatsStore via pre-fetched map when available,
         # otherwise fall back to normalised score (pre-reinforcement path).
@@ -183,9 +186,51 @@ def _rerank_fast(
                 ),
             )
         )
+        # Capture per-candidate score breakdown for calibration debugging (#179).
+        # Only collected when DEBUG is enabled to avoid overhead on the hot path.
+        if logger.isEnabledFor(logging.DEBUG):
+            debug_rows.append(
+                {
+                    "node_id": c.node_id,
+                    "scouts": list(c.scouts),
+                    "base_score": round(c.score, 4),
+                    "scout_weight": round(scout_weight, 4),
+                    "note_type": resolved_note_type,
+                    "note_type_prior": round(note_type_prior, 4),
+                    "salience": round(salience, 4),
+                    "final": round(final, 4),
+                }
+            )
 
     scored.sort(key=lambda t: t[0], reverse=True)
     ranked = [c for _, c in scored]
+
+    # Emit calibration breakdown at DEBUG (per-candidate) and a top-N summary
+    # at INFO so over-ranking regressions like #179 are observable in prod
+    # without requiring DEBUG.
+    if debug_rows:
+        debug_rows.sort(key=lambda r: r["final"], reverse=True)  # type: ignore[arg-type,return-value]
+        logger.debug(
+            "_rerank_fast: per-candidate score breakdown",
+            extra={"candidates": debug_rows[:50]},
+        )
+    if ranked:
+        top_summary = [
+            {
+                "node_id": c.node_id,
+                "scouts": list(c.scouts),
+                "final": round(c.score, 4),
+            }
+            for c in ranked[:10]
+        ]
+        logger.info(
+            "_rerank_fast: ranked top-N",
+            extra={
+                "num_candidates": len(ranked),
+                "top": top_summary,
+            },
+        )
+
     return _mmr_diversify(ranked, knowledge)
 
 

--- a/tests/test_lcma_config.py
+++ b/tests/test_lcma_config.py
@@ -30,6 +30,17 @@ class TestLcmaConfigDefaults:
         cfg = LcmaConfig()
         assert abs(sum(cfg.rerank_weights.values()) - 1.0) < 1e-9
 
+    def test_lexical_weight_not_below_vector(self) -> None:
+        """Regression for #179: cold-KB calibration.
+
+        With lexical < vector, a scout_vector-only candidate structurally
+        outscored a scout_lexical exact-term match of equal normalised score.
+        The default must keep lexical at or above vector so exact-term hits
+        are not pre-empted by semantically-adjacent vector hits on a cold KB.
+        """
+        cfg = LcmaConfig()
+        assert cfg.rerank_weights["lexical"] >= cfg.rerank_weights["vector"]
+
     def test_default_note_type_priors(self) -> None:
         cfg = LcmaConfig()
         assert cfg.note_type_priors == _DEFAULT_NOTE_TYPE_PRIORS
@@ -74,7 +85,10 @@ class TestLcmaConfigRerankWeights:
 
     def test_default_key_values(self) -> None:
         cfg = LcmaConfig()
-        assert cfg.rerank_weights["vector"] == 0.25
+        # vector/lexical rebalanced in #179 so lexical ≥ vector. Other scouts
+        # are unchanged.
+        assert cfg.rerank_weights["vector"] == 0.21
+        assert cfg.rerank_weights["lexical"] == 0.22
         assert cfg.rerank_weights["graph"] == 0.13
         assert cfg.rerank_weights["coactivation"] == 0.10
         assert cfg.rerank_weights["source_url"] == 0.05

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -267,6 +267,29 @@ class TestRerankFast:
         assert result_without[0].node_id == result_default[0].node_id
         assert result_without[1].node_id == result_default[1].node_id
 
+    def test_lexical_not_dominated_by_vector_at_equal_normalised_score(
+        self, seeded_km: KnowledgeManager
+    ) -> None:
+        """Regression for #179: under default weights and cold-KB (uniform
+        salience), a scout_lexical candidate must not be ranked below a
+        scout_vector candidate of equal normalised score purely due to
+        lexical < vector calibration. With the rebalanced defaults
+        (lexical=0.22, vector=0.21) the lexical candidate ranks first."""
+        candidates = [
+            # Vector scout exact-match normalised score.
+            Candidate(node_id=_ID1, score=1.0, reasons=["vec"], scouts=["scout_vector"]),
+            # Lexical scout exact-match normalised score (same).
+            Candidate(node_id=_ID2, score=1.0, reasons=["lex"], scouts=["scout_lexical"]),
+        ]
+        # Uniform salience simulates a cold KB where no signal differentiates.
+        salience_map = {_ID1: 0.5, _ID2: 0.5}
+        result = _rerank_fast(candidates, LcmaConfig(), seeded_km, salience_map=salience_map)
+        # Lexical must rank first (or at least not lower than vector).
+        assert result[0].node_id == _ID2, (
+            "Expected scout_lexical to rank first under rebalanced default "
+            f"weights; got ranking: {[c.node_id for c in result]}"
+        )
+
 
 class TestStoredSalienceAffectsRetrieval:
     """Verify that salience stored in StatsStore flows through run_retrieve."""


### PR DESCRIPTION
## Summary
- Rebalances the default LCMA rerank weights so a scout_lexical exact-term hit is no longer structurally dominated by a scout_vector hit of equal normalised score. Previously `vector=0.25, lexical=0.18` — this gave vector-only candidates a built-in ~0.07 advantage. Now `vector=0.21, lexical=0.22` (still sums to 1.0, all other scouts unchanged).
- Enriches `_rerank_fast` logging: per-candidate DEBUG breakdown (base_score, scout_weight, note_type_prior, salience, final) and an INFO-level top-N summary on every rerank call. Calibration regressions like #179 are now observable in production logs without needing a debug mode.
- Two regression tests: config asserts `lexical >= vector`; `_rerank_fast` asserts the lexical candidate wins at equal normalised score under defaults + uniform salience.

## Context
Reported in #179: query `"spaced repetition salience decay agent knowledge"` surfaced a vector-adjacent article above a note that literally contained the query terms. Root cause was the rerank weight gap — the reporter identified it as their leading hypothesis in the issue.

## Out of scope / follow-up
- The issue also flagged per-scout min-max normalisation (cause #2). That is a broader design change — a single-element scout group still maps its top to 1.0 regardless of absolute score quality. Tracking separately; this PR intentionally stays narrow for release readiness.

## Test plan
- [x] `make check` green (lint, pyright, 992 unit tests pass).
- [x] New: `test_lexical_weight_not_below_vector` (config regression).
- [x] New: `test_lexical_not_dominated_by_vector_at_equal_normalised_score` (rerank regression).
- [x] Updated: `test_default_key_values` to reflect rebalanced weights.

Addresses #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)