### PR TITLE
fix: prime OTEL gauge caches at startup (#181)

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -147,6 +147,7 @@ def serve(
         click.echo("\nShutting down...")
         logger.info("lithos server shutting down (KeyboardInterrupt)")
         server.stop_file_watcher()
+        asyncio.run(server.stop_coordination_stats_refresh())
         asyncio.run(server.stop_enrich_worker())
         logger.info("lithos server stopped")
     finally:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -3,6 +3,7 @@
 import asyncio
 import collections
 import concurrent.futures
+import contextlib
 import hashlib
 import json
 import logging
@@ -101,9 +102,19 @@ class LithosServer:
                 coordination=self.coordination,
             )
 
-        # Cached count fields for synchronous OTEL observable gauge callbacks
+        # Cached count fields for synchronous OTEL observable gauge callbacks.
+        # Primed at startup by _refresh_coordination_stats_cache() and kept fresh
+        # by _coordination_stats_refresh_loop() so the gauges don't report 0
+        # until the first lithos_stats call (see #181).
         self._cached_active_claims: int = 0
         self._cached_agent_count: int = 0
+
+        # How often the background task refreshes _cached_agent_count /
+        # _cached_active_claims from the coordination DB. Small enough that
+        # observability dashboards stay in sync with reality; large enough
+        # that it's not a measurable load on the DB.
+        self._coordination_stats_refresh_seconds: float = 30.0
+        self._coordination_stats_refresh_task: asyncio.Task[None] | None = None
 
         # Background tasks (kept to prevent garbage collection)
         self._background_tasks: set[asyncio.Task[None]] = set()
@@ -530,6 +541,16 @@ class LithosServer:
                 # Initialize coordination database
                 await self.coordination.initialize()
 
+                # Prime the coordination stats cache BEFORE registering OTEL
+                # gauges — otherwise the first scrape would read the initial
+                # zero values, masking real agent/claim counts on dashboards
+                # (see #181).
+                await self._refresh_coordination_stats_cache()
+
+                # Start periodic background refresh so agent counts etc. stay
+                # in sync without requiring an explicit lithos_stats call.
+                self._start_coordination_stats_refresh()
+
                 # Register active claims gauge observer
                 register_active_claims_observer(lambda: self._cached_active_claims)
 
@@ -586,6 +607,19 @@ class LithosServer:
 
                 # Register LCMA observable gauges when LCMA is enabled
                 if self._config.lcma.enabled and self.stats_store is not None:
+                    # Prime the LCMA stats cache BEFORE OTEL gauge registration
+                    # for the same reason we prime coordination stats (#181):
+                    # EnrichWorker refreshes the cache after each drain cycle,
+                    # but the first drain is 5 minutes out by default — until
+                    # then the gauges would report zero on a populated DB.
+                    try:
+                        await self.stats_store.refresh_cached_counts()
+                    except Exception:
+                        logger.warning(
+                            "LCMA stats cache priming failed; gauges will "
+                            "start at zero until the first EnrichWorker drain.",
+                            exc_info=True,
+                        )
                     register_lcma_metrics(
                         get_enrich_queue_depth=self.stats_store.get_cached_enrich_queue_depth,
                         get_coactivation_pairs=self.stats_store.get_cached_coactivation_pairs,
@@ -605,6 +639,90 @@ class LithosServer:
                 elapsed_ms = (time.perf_counter() - _init_start) * 1000
                 lithos_metrics.startup_duration.record(elapsed_ms)
                 span.set_attribute("lithos.startup_duration", elapsed_ms)
+
+    async def _refresh_coordination_stats_cache(self) -> None:
+        """Refresh cached coordination counts that back the OTEL gauges.
+
+        OTEL observable-gauge callbacks must be synchronous and cheap; they
+        therefore read from ``self._cached_agent_count`` and
+        ``self._cached_active_claims`` rather than hitting the coordination DB
+        inside the metric collection loop. This coroutine is the single place
+        that refreshes those fields (called once at startup and then
+        periodically from :meth:`_coordination_stats_refresh_loop`, and also
+        opportunistically from the ``lithos_stats`` tool).
+
+        Regression for #181: without this priming step the gauge callbacks
+        reported 0 until the first ``lithos_stats`` call — so dashboards
+        showed "0 registered agents" on a cold server even when many agents
+        had registered.
+        """
+        try:
+            coord_stats = await self.coordination.get_stats()
+        except Exception:
+            logger.warning(
+                "Coordination stats refresh failed — OTEL gauges will keep "
+                "stale values until next successful refresh.",
+                exc_info=True,
+            )
+            return
+
+        prev_agents = self._cached_agent_count
+        prev_claims = self._cached_active_claims
+        self._cached_agent_count = coord_stats.get("agents", 0)
+        self._cached_active_claims = coord_stats.get("open_claims", 0)
+        logger.debug(
+            "Coordination stats cache refreshed",
+            extra={
+                "agents": self._cached_agent_count,
+                "open_claims": self._cached_active_claims,
+                "agents_delta": self._cached_agent_count - prev_agents,
+                "claims_delta": self._cached_active_claims - prev_claims,
+            },
+        )
+
+    def _start_coordination_stats_refresh(self) -> None:
+        """Spawn the periodic stats-refresh background task, idempotently."""
+        if (
+            self._coordination_stats_refresh_task is not None
+            and not self._coordination_stats_refresh_task.done()
+        ):
+            return
+        task = asyncio.create_task(self._coordination_stats_refresh_loop())
+        self._coordination_stats_refresh_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        logger.info(
+            "Started coordination stats refresh loop",
+            extra={"interval_seconds": self._coordination_stats_refresh_seconds},
+        )
+
+    async def _coordination_stats_refresh_loop(self) -> None:
+        """Background task: periodically refresh the coordination stats cache.
+
+        Exits cleanly on cancellation. Swallows per-iteration exceptions so a
+        transient DB hiccup doesn't kill the whole refresh loop — the next
+        tick retries.
+        """
+        interval = self._coordination_stats_refresh_seconds
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                await self._refresh_coordination_stats_cache()
+        except asyncio.CancelledError:
+            logger.info("Coordination stats refresh loop cancelled")
+            raise
+
+    async def stop_coordination_stats_refresh(self) -> None:
+        """Cancel the periodic stats-refresh task, if any."""
+        task = self._coordination_stats_refresh_task
+        if task is None or task.done():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            # Cancellation is expected; any other exception has already been
+            # logged from inside the loop.
+            await task
+        self._coordination_stats_refresh_task = None
 
     def _safe_tantivy_count(self) -> int:
         """Return Tantivy document count, 0 on any error."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ async def server(test_config: LithosConfig) -> AsyncGenerator[LithosServer, None
     srv = LithosServer(test_config)
     await srv.initialize()
     yield srv
+    await srv.stop_coordination_stats_refresh()
     await srv.stop_enrich_worker()
     srv.stop_file_watcher()
 

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -325,6 +325,9 @@ class TestCLIContracts:
             async def stop_enrich_worker(self):
                 return None
 
+            async def stop_coordination_stats_refresh(self):
+                return None
+
         monkeypatch.setattr("lithos.server.create_server", lambda _cfg: _DummyServer())
 
         _first_call = {"value": True}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,6 +27,60 @@ class TestServerInitialization:
         assert server.coordination is not None
 
     @pytest.mark.asyncio
+    async def test_agent_count_cache_primed_at_startup(self, server: LithosServer):
+        """Regression for #181: _cached_agent_count must reflect reality
+        *before* any lithos_stats call — otherwise the OTEL gauge reports 0
+        until somebody happens to call lithos_stats, even on a server with
+        many registered agents. The fixture already runs server.initialize(),
+        so priming should have happened via _refresh_coordination_stats_cache."""
+        # Register three agents through the coordination service directly.
+        for agent_id in ("alpha", "beta", "gamma"):
+            await server.coordination.register_agent(agent_id=agent_id)
+
+        # Force a refresh so the cache reflects the newly registered agents.
+        await server._refresh_coordination_stats_cache()
+
+        assert server._cached_agent_count >= 3, (
+            "Coordination stats cache did not reflect registered agents — "
+            f"got {server._cached_agent_count}, expected >= 3."
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_coordination_stats_cache_updates_claims(self, server: LithosServer):
+        """_cached_active_claims is refreshed alongside _cached_agent_count."""
+        task_id = await server.coordination.create_task(title="T", agent="a")
+        await server.coordination.claim_task(task_id, aspect="x", agent="a")
+        # Pre-refresh value may be stale; force a refresh and verify.
+        await server._refresh_coordination_stats_cache()
+        assert server._cached_active_claims >= 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_survives_coordination_failure(
+        self, server: LithosServer, caplog: pytest.LogCaptureFixture
+    ):
+        """If coordination.get_stats raises, the refresh logs a warning and
+        leaves the cached values unchanged (no crash, no zeroing)."""
+        server._cached_agent_count = 42
+        server._cached_active_claims = 7
+        with (
+            patch.object(
+                server.coordination, "get_stats", AsyncMock(side_effect=RuntimeError("db down"))
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            await server._refresh_coordination_stats_cache()
+        assert server._cached_agent_count == 42
+        assert server._cached_active_claims == 7
+        assert any("Coordination stats refresh failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_stop_coordination_stats_refresh_is_idempotent(self, server: LithosServer):
+        """Stopping twice (or when no task exists) must not raise."""
+        await server.stop_coordination_stats_refresh()
+        await server.stop_coordination_stats_refresh()
+        assert server._coordination_stats_refresh_task is None
+
+    @pytest.mark.asyncio
     async def test_server_registers_tools(self, server: LithosServer):
         """Server registers all MCP tools."""
         # The server should have registered tools


### PR DESCRIPTION
## Summary
Dashboards in the observability stack were reporting **0 registered agents** even when the coordination DB held ~12. Root cause: `lithos.agents.active_count` is backed by `LithosServer._cached_agent_count`, which is initialised to 0 and only refreshed *inside the `lithos_stats` MCP tool handler*. OTEL scrapes that land before anyone calls `lithos_stats` therefore see zero.

**Scope expanded per request** — audited all cached-gauge callbacks and found the same pattern on the LCMA side. `stats_store.refresh_cached_counts()` is only called from the EnrichWorker drain loop (default 5 min), so `lithos.lcma.enrich_queue_depth`, `lithos.lcma.coactivation_pairs`, and `lithos.lcma.working_memory_active_tasks` would also read zero for up to 5 minutes after startup even on a populated DB.

Resource gauges (document_count, graph nodes/edges) and `_sse_client_count` read from live in-memory state, so they do not have this issue.

## Changes
- Prime `_cached_agent_count` / `_cached_active_claims` via new `_refresh_coordination_stats_cache()` at startup, **before** `register_resource_gauges` — first scrape sees real values.
- Background task `_coordination_stats_refresh_loop` refreshes the cache every 30 s so counts stay fresh without requiring a `lithos_stats` call.
- Prime LCMA stats cache via `stats_store.refresh_cached_counts()` at startup before `register_lcma_metrics`.
- Clean shutdown: `stop_coordination_stats_refresh()` cancels the background task; wired into the CLI `KeyboardInterrupt` handler and the test `server` fixture.
- Enriched logging: DEBUG per-refresh delta; WARNING when a refresh fails (cached values preserved rather than zeroed).

## Test plan
- [x] `make check` green (lint, pyright, 990 unit tests pass).
- [x] New integration test: registering agents + forced refresh updates the cached count (#181 regression).
- [x] New: refresh survives a `coordination.get_stats` failure — cache preserved, WARNING logged, no crash.
- [x] New: `stop_coordination_stats_refresh` is idempotent.

Fixes #181.

## Follow-up / not in this PR
The observability dashboard repo (`lithos-observability`) panel definitions were not touched — this PR only fixes the metric source. If the dashboard panel still shows 0 after this ships, that's a dashboard query issue tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)