### PR TITLE
fix: harden setup_logging + evict handler between tests (#173)

### DIFF
--- a/src/lithos/logging_config.py
+++ b/src/lithos/logging_config.py
@@ -112,10 +112,33 @@ def setup_logging(level: int = logging.INFO, stream: Any = None) -> None:
     """
     root = logging.getLogger()
 
-    # Idempotency guard: if we already installed our handler, skip.
+    # Idempotency guard with closed-stream recovery.
+    #
+    # If a Lithos-marked handler already exists *and* its stream is still
+    # usable, skip — this is the normal re-entrant call from tests or
+    # repeated CLI invocations.
+    #
+    # But: if the stream has been closed underneath us (for example when a
+    # prior Click ``CliRunner.invoke`` call captured ``sys.stderr`` into a
+    # buffer that the runner then closed), the pinned handler will raise
+    # ``ValueError: I/O operation on closed file`` on the very next log
+    # record. In that case we drop the stale handler and install a fresh
+    # one. See #173 for the repro.
+    survivors: list[logging.Handler] = []
+    replace = False
     for handler in root.handlers:
         if getattr(handler, _HANDLER_MARKER, False):
-            return
+            handler_stream = getattr(handler, "stream", None)
+            if handler_stream is not None and getattr(handler_stream, "closed", False):
+                replace = True
+                # Drop this stale handler — do not preserve it.
+                continue
+        survivors.append(handler)
+    root.handlers = survivors
+    if not replace:
+        for handler in root.handlers:
+            if getattr(handler, _HANDLER_MARKER, False):
+                return
 
     if stream is None:
         stream = sys.stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures."""
 
+import logging
 import shutil
 import tempfile
 from collections.abc import AsyncGenerator, Generator
@@ -12,6 +13,7 @@ from lithos.config import LithosConfig, StorageConfig, _reset_config, set_config
 from lithos.coordination import CoordinationService
 from lithos.graph import KnowledgeGraph
 from lithos.knowledge import KnowledgeManager
+from lithos.logging_config import _HANDLER_MARKER
 from lithos.search import SearchEngine
 from lithos.server import LithosServer
 
@@ -23,6 +25,29 @@ _LITHOS_ENV_VARS = (
     "LITHOS_OTEL_ENABLED",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
 )
+
+
+@pytest.fixture(autouse=True)
+def _evict_lithos_log_handlers() -> Generator[None, None, None]:
+    """Drop Lithos-marked root-logger handlers before and after each test.
+
+    Regression guard for #173: when a test invokes the CLI via Click's
+    ``CliRunner``, the CLI calls ``setup_logging()``, which attaches a
+    ``StreamHandler`` pinned to the runner's captured ``sys.stderr``.
+    When the runner finishes, it closes the captured buffer, but the
+    handler remains on the root logger with a closed stream reference.
+    Any later log emit raises ``ValueError: I/O operation on closed
+    file``, surfacing as a flaky test. Evicting our handler between
+    tests isolates that state.
+    """
+    root = logging.getLogger()
+
+    def _evict() -> None:
+        root.handlers = [h for h in root.handlers if not getattr(h, _HANDLER_MARKER, False)]
+
+    _evict()
+    yield
+    _evict()
 
 
 @pytest.fixture

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -77,6 +77,30 @@ class TestSetupLogging:
         marked = [h for h in root.handlers if getattr(h, _HANDLER_MARKER, False)]
         assert len(marked) == 1
 
+    def test_replaces_handler_whose_stream_has_been_closed(self) -> None:
+        """Regression for #173: a marked handler whose stream was closed
+        underneath us (for example by Click's CliRunner after invoke) must
+        be dropped and replaced on the next setup_logging() call, so
+        subsequent log records don't raise ValueError: I/O operation on
+        closed file."""
+        buf_closed = io.StringIO()
+        setup_logging(stream=buf_closed)
+        buf_closed.close()  # simulate CliRunner closing its captured buffer
+
+        buf_new = io.StringIO()
+        setup_logging(stream=buf_new)
+
+        root = logging.getLogger()
+        marked = [h for h in root.handlers if getattr(h, _HANDLER_MARKER, False)]
+        assert len(marked) == 1, (
+            f"Expected exactly one marked handler after closed-stream recovery, got {len(marked)}."
+        )
+        # The surviving handler must be wired to the fresh (open) stream.
+        assert marked[0].stream is buf_new
+        # And a log record must now reach the fresh stream without raising.
+        logging.getLogger("test.closed_stream.recovery").info("still alive")
+        assert buf_new.getvalue(), "Expected log record to land in the new stream."
+
     def test_output_is_valid_json(self) -> None:
         buf = io.StringIO()
         setup_logging(stream=buf)


### PR DESCRIPTION
## Summary
Fixes the intermittent failure of `test_serve_keyboard_interrupt_stops_watcher` (reported as #173).

Root cause: the CLI calls `setup_logging()`, which pins a `StreamHandler` to `sys.stderr` **at call time**. Under Click's `CliRunner` that's the runner's captured `StringIO` buffer — which the runner closes once `invoke()` returns. The handler stays on the root logger with a stale, closed-stream reference. Any later log emit (pytest-asyncio fixture teardown, aiosqlite worker thread, etc.) then writes to the closed buffer and raises `ValueError: I/O operation on closed file` (the same class of lifecycle leak surfaces as `RuntimeError: Event loop is closed` when a background task logs during shutdown).

Repro (before fix): probe test confirmed a marked handler with `stream.closed == True` persisted on the root logger after `CliRunner.invoke` returned.

## Changes
- **`setup_logging()`** now scans existing marked handlers before the idempotency short-circuit and drops any whose stream has been closed. The next call installs a fresh handler instead of silently keeping the broken one. Defensive against any future CliRunner-style stream-closing caller.
- **`tests/conftest.py`** autouse fixture `_evict_lithos_log_handlers` removes marked handlers before and after every test. This closes the cross-test window where a log record could hit the stale handler.

## Test plan
- [x] `make check` green (lint, pyright, 994 unit tests pass — one more than before thanks to the new closed-stream recovery test).
- [x] New regression test `test_replaces_handler_whose_stream_has_been_closed` exercises the recovery path end-to-end.
- [x] Targeted probe run (manual) confirms no marked handler is left on the root logger after the flaky test completes.

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)