### PR TITLE
docs: clarify OTEL push path; add --telemetry-console flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,67 @@ cd docker
 Each environment gets its own container (`lithos`, `lithos-staging`,
 `lithos-fuzz`), its own host port, and its own data volume, so they can
 all run concurrently. Running `./run.sh` with no arguments prints usage.
+
+## Telemetry & Observability
+
+Lithos emits OpenTelemetry metrics, traces, and logs when telemetry is enabled.
+The **only** supported export path is **OTLP/HTTP push to a collector** — there
+is no `/metrics` scrape endpoint on the Lithos process itself (see closed
+issue [#164](https://github.com/agent-lore/lithos/issues/164) for the
+rationale).
+
+### How metrics reach your dashboards
+
+```
+  Lithos process
+       │  OTLP/HTTP  (push every export_interval_ms, default 30 s)
+       ▼
+  OTEL Collector   ← lithos-observability/otel-collector/config.yml
+       │  Prometheus exporter on :8889
+       ▼
+  Prometheus       ← lithos-observability/prometheus/prometheus.yml
+       │
+       ▼
+  Grafana
+```
+
+Traces fan out to Tempo, logs to Loki, via the same collector.
+
+### Configuration
+
+```yaml
+telemetry:
+  enabled: false               # master switch
+  endpoint: null               # OTLP base URL, e.g. http://otel-collector:4318
+  console_fallback: false      # print spans/metrics to stdout when no endpoint
+  service_name: lithos
+  environment: null            # becomes OTEL deployment.environment
+  export_interval_ms: 30000
+```
+
+Environment variables override `endpoint` per signal when needed:
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`.
+
+### Local debugging without a collector
+
+Pass `--telemetry-console` to `lithos serve` to route metrics and spans to
+stdout via console exporters. This is equivalent to setting
+`telemetry.enabled=true` + `telemetry.console_fallback=true` in config, and is
+the shortest path to "is my instrumentation even firing?" when no collector is
+running.
+
+```bash
+lithos --data-dir ./data serve --telemetry-console
+```
+
+### Running the full observability stack locally
+
+See `lithos-observability/` for a one-command Docker Compose stack (OTEL
+Collector + Prometheus + Grafana + Tempo + Loki). Point Lithos at it with:
+
+```bash
+LITHOS_TELEMETRY__ENABLED=true \
+LITHOS_TELEMETRY__ENDPOINT=http://localhost:4318 \
+lithos serve
+```

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1096,11 +1096,17 @@ index:
   watch_debounce_ms: 500    # Debounce file changes
 
 # Telemetry
+# Metrics, traces, and logs are exported via OpenTelemetry OTLP/HTTP push to a
+# configured collector. There is no /metrics scrape endpoint on the Lithos
+# process itself — the observability stack in `lithos-observability/` runs a
+# collector whose Prometheus exporter (on :8889) is what Prometheus scrapes.
+# See README → "Telemetry & Observability" for the full data-flow diagram.
 telemetry:
   enabled: false
-  endpoint: null
-  console_fallback: false
+  endpoint: null           # OTLP base URL, e.g. http://otel-collector:4318
+  console_fallback: false  # print spans/metrics to stdout when no endpoint
   service_name: lithos
+  environment: null        # OTEL deployment.environment
   export_interval_ms: 30000
 
 # Event Bus
@@ -1123,6 +1129,9 @@ lithos --data-dir ./data serve --transport sse --host 0.0.0.0 --port 8765
 
 # Disable file watcher
 lithos --data-dir ./data serve --no-watch
+
+# Route OTEL metrics + spans to stdout (local debugging without a collector)
+lithos --data-dir ./data serve --telemetry-console
 
 # Rebuild indices (incremental by default)
 lithos --data-dir ./data reindex

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,9 @@ lithos serve --no-watch
 | `--host` | `127.0.0.1` | Host for SSE transport |
 | `-p, --port` | `8765` | Port for SSE transport |
 | `--watch / --no-watch` | watch enabled | Watch for file changes |
+| `--telemetry-console` | off | Route OTEL metrics + spans to stdout (for local debugging without a collector) |
+
+> **Metrics:** Lithos exports metrics via OTLP push to a configured OTEL collector — there is no `/metrics` scrape endpoint on the process itself. See the "Telemetry & Observability" section in the main README for the full push→collector→Prometheus data flow, or use `--telemetry-console` above when no collector is available.
 
 ### `search` — Search the knowledge base
 

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -67,6 +67,16 @@ def cli(ctx: click.Context, config: Path | None, data_dir: Path | None) -> None:
     default=True,
     help="Watch for file changes (default: enabled)",
 )
+@click.option(
+    "--telemetry-console",
+    is_flag=True,
+    default=False,
+    help=(
+        "Route OTEL metrics and spans to stdout via console exporters. "
+        "Useful for local debugging when no OTEL collector is running. "
+        "Equivalent to setting telemetry.enabled=true + telemetry.console_fallback=true."
+    ),
+)
 @click.pass_context
 def serve(
     ctx: click.Context,
@@ -74,12 +84,22 @@ def serve(
     host: str,
     port: int,
     watch: bool,
+    telemetry_console: bool,
 ) -> None:
     """Start the Lithos MCP server."""
     from lithos.server import create_server
     from lithos.telemetry import setup_telemetry, shutdown_telemetry
 
     config: LithosConfig = ctx.obj["config"]
+
+    # --telemetry-console: ensure telemetry runs in console-fallback mode so
+    # metrics/spans land on stdout even when no OTLP collector is configured.
+    # This is a DX shortcut for local debugging — see also #164.
+    if telemetry_console:
+        config.telemetry.enabled = True
+        config.telemetry.console_fallback = True
+        click.echo("Telemetry console-fallback enabled (metrics + spans will print to stdout).")
+
     server = create_server(config)
 
     async def run_server() -> None:

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -301,6 +301,61 @@ class TestCLIContracts:
         assert calls["watch_started"] == 1
         assert calls["watch_stopped"] == 0
 
+    def test_serve_telemetry_console_flag_sets_config_fields(self, temp_dir, monkeypatch):
+        """`--telemetry-console` must flip telemetry.enabled + console_fallback
+        on the live config before ``setup_telemetry`` reads them, so metrics and
+        spans actually land on stdout without requiring an OTLP endpoint."""
+        config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
+        config.ensure_directories()
+        set_config(config)
+
+        captured: dict[str, LithosConfig | None] = {"config": None}
+
+        class _DummyMCP:
+            async def run_stdio_async(self, show_banner=False):
+                return None
+
+        class _DummyServer:
+            def __init__(self):
+                self.mcp = _DummyMCP()
+
+            async def initialize(self):
+                return None
+
+            def start_file_watcher(self):
+                return None
+
+            def stop_file_watcher(self):
+                return None
+
+            async def stop_enrich_worker(self):
+                return None
+
+            async def stop_coordination_stats_refresh(self):
+                return None
+
+        monkeypatch.setattr("lithos.server.create_server", lambda _cfg: _DummyServer())
+
+        def _capture_setup(cfg: LithosConfig) -> None:
+            # Snapshot the config at the moment setup_telemetry() would read it.
+            captured["config"] = cfg
+
+        monkeypatch.setattr("lithos.telemetry.setup_telemetry", _capture_setup)
+        monkeypatch.setattr("lithos.telemetry.shutdown_telemetry", lambda: None)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--data-dir", str(temp_dir), "serve", "--no-watch", "--telemetry-console"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Telemetry console-fallback enabled" in result.output
+
+        snapshot = captured["config"]
+        assert snapshot is not None
+        assert snapshot.telemetry.enabled is True
+        assert snapshot.telemetry.console_fallback is True
+
     def test_serve_keyboard_interrupt_stops_watcher(self, temp_dir, monkeypatch):
         config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
         config.ensure_directories()


### PR DESCRIPTION
## Summary
Follow-up to closed issue #164. Addresses the "why is `http://host:8765/metrics` a 404?" expectation mismatch, without shipping the `/metrics` scrape endpoint itself. See the #164 close comment for why the direct scrape path was declined.

## Changes
- **README** — new "Telemetry & Observability" section with the end-to-end push→collector→Prometheus→Grafana data-flow diagram, the `telemetry:` config block, per-signal `OTEL_EXPORTER_OTLP_*_ENDPOINT` overrides, and a pointer to `lithos-observability/`.
- **docs/SPECIFICATION.md** — annotate the `telemetry:` config with the push-only contract and surface the new CLI flag in the command examples.
- **docs/cli.md** — document `--telemetry-console` on `lithos serve`; add a short "metrics live in OTLP push" explainer.
- **`lithos serve --telemetry-console`** — DX shortcut that flips `telemetry.enabled=True` + `telemetry.console_fallback=True` on the live config *before* `setup_telemetry()` runs, so metrics and spans land on stdout via the console exporters without requiring a collector.

## Test plan
- [x] `make check` — 996 unit tests pass (+1 new).
- [x] New `test_serve_telemetry_console_flag_sets_config_fields` snapshots the config at `setup_telemetry()` time and asserts both fields flipped.
- [x] Existing CLI contract tests untouched.

## Scope notes
- Not tied to #164 — that issue is closed as won't-fix on its own merits. This PR is a narrow doc + DX improvement that happened to surface out of the same conversation.
- No runtime behaviour change for existing users: the flag defaults to off; docs are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)