### PR TITLE
feat: composite lithos_related tool (#82)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -523,6 +523,48 @@ Traverse provenance lineage (derived-from relationships) for a knowledge item.
 - Returns `{ status: "error", code: "doc_not_found" }` for unknown IDs.
 - Results are sorted by ID for deterministic output.
 
+#### `lithos_related`
+
+Composite "what is this document related to?" view. Merges wiki-link navigation, derived-from provenance, and typed LCMA edges into a single response so agents don't have to fan out across three tools and mentally join the results.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | string | Yes | UUID of knowledge item |
+| `include` | list[string] | No | Subset of `["links", "provenance", "edges"]` to populate (default: all three) |
+| `depth` | int | No | BFS depth 1-3 for `links` and `provenance` (default: 1). Ignored by `edges`. |
+| `namespace` | string | No | Optional namespace filter applied to `edges` only |
+
+**Returns:**
+```json
+{
+  "id": "<queried-uuid>",
+  "included": ["links", "provenance", "edges"],
+  "links": {
+    "outgoing": [{ "id": "<uuid>", "title": "<string>" }],
+    "incoming": [{ "id": "<uuid>", "title": "<string>" }]
+  },
+  "provenance": {
+    "sources": [{ "id": "<uuid>", "title": "<string>" }],
+    "derived": [{ "id": "<uuid>", "title": "<string>" }],
+    "unresolved_sources": ["<uuid>", ...]
+  },
+  "edges": {
+    "outgoing": [<edge-record>, ...],
+    "incoming": [<edge-record>, ...]
+  },
+  "related_ids": ["<uuid>", ...]
+}
+```
+
+**Behavior:**
+- Sections not listed in `include` are omitted entirely (not emitted as empty keys).
+- Unknown `include` values are silently ignored so forward-compatible callers don't break when new backends land.
+- `edges` section is empty when LCMA is disabled in config.
+- `related_ids` is the deduped, sorted union of every id referenced across the included sections. The queried document's own id is excluded so callers can iterate without filtering.
+- `lithos_links`, `lithos_provenance`, and `lithos_edge_list` remain available for scenarios that need finer-grained control (single direction, edge-type filter, etc.). This tool is for the common case.
+- Returns `{ status: "error", code: "doc_not_found" }` for unknown IDs.
+
 ### 5.3 Agent Operations
 
 #### `lithos_agent_register`
@@ -1277,7 +1319,7 @@ These are explicitly not part of the initial implementation but may be considere
 | Category | Tools |
 |----------|-------|
 | Knowledge | `lithos_write`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup` |
-| Graph | `lithos_links`, `lithos_tags`, `lithos_provenance` |
+| Graph | `lithos_links`, `lithos_tags`, `lithos_provenance`, `lithos_related` |
 | Agent | `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list` |
 | Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_list`, `lithos_task_status`, `lithos_finding_post`, `lithos_finding_list` |
 | System | `lithos_stats` |

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2341,6 +2341,146 @@ class LithosServer:
                 span.set_attribute("lithos.derived_count", len(derived))
                 return result
 
+        _RELATED_INCLUDES = ("links", "provenance", "edges")
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_related(
+            id: str,
+            include: list[str] | None = None,
+            depth: int = 1,
+            namespace: str | None = None,
+        ) -> dict[str, Any]:
+            """Composite "what is this document related to?" view.
+
+            Merges three backends into a single response so agents don't have
+            to fan out across ``lithos_links``, ``lithos_provenance``, and
+            ``lithos_edge_list`` and mentally join the results:
+
+            - **links** — structural ``[[wiki-link]]`` navigation (NetworkX).
+            - **provenance** — ``derived_from_ids`` chains (frontmatter index).
+            - **edges** — typed LCMA edges (edges.db), both directions.
+
+            The individual tools remain available for power-user scenarios
+            that need specific traversal control (directional, depth-only,
+            edge-type filtering, etc.). This tool is for the common case.
+
+            Args:
+                id: Document UUID.
+                include: Subset of ``["links", "provenance", "edges"]`` to
+                    populate. Defaults to all three. Unknown values are
+                    silently ignored so forward-compatible callers don't
+                    break when new backends land.
+                depth: BFS depth 1-3 for ``links`` and ``provenance``.
+                    Ignored for ``edges`` (LCMA edges are a flat table).
+                namespace: Optional namespace filter applied to ``edges``.
+                    ``links`` and ``provenance`` don't use namespaces.
+
+            Returns:
+                Dict shaped like::
+
+                    {
+                      "id": "<doc-id>",
+                      "included": ["links", "provenance", "edges"],
+                      "links": {"outgoing": [...], "incoming": [...]},
+                      "provenance": {
+                          "sources": [...], "derived": [...],
+                          "unresolved_sources": [...]
+                      },
+                      "edges": {"outgoing": [...], "incoming": [...]},
+                      "related_ids": ["<id>", ...]   # deduped union
+                    }
+
+                Sections not listed in ``include`` are omitted entirely
+                (not emitted as empty keys). ``related_ids`` holds the
+                deduped union of every id referenced across the included
+                sections — sorted for determinism.
+            """
+            logger.info(
+                "lithos_related: called",
+                extra={"id": id, "include": include, "depth": depth, "namespace": namespace},
+            )
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.related") as span:
+                span.set_attribute("lithos.tool", "lithos_related")
+                span.set_attribute("lithos.id", id)
+
+                if not self.knowledge.has_document(id):
+                    return {
+                        "status": "error",
+                        "code": "doc_not_found",
+                        "message": f"Document not found: {id}",
+                    }
+
+                requested = include if include is not None else list(_RELATED_INCLUDES)
+                selected = [k for k in _RELATED_INCLUDES if k in requested]
+                span.set_attribute("lithos.include", ",".join(selected))
+
+                depth = min(max(depth, 1), 3)
+                span.set_attribute("lithos.depth", depth)
+
+                result: dict[str, Any] = {
+                    "id": id,
+                    "included": selected,
+                }
+                related_ids: set[str] = set()
+
+                # --- links (NetworkX wiki-links) ---------------------------
+                if "links" in selected:
+                    links = self.graph.get_links(doc_id=id, direction="both", depth=depth)
+                    outgoing = [{"id": ln.id, "title": ln.title} for ln in links.outgoing]
+                    incoming = [{"id": ln.id, "title": ln.title} for ln in links.incoming]
+                    result["links"] = {"outgoing": outgoing, "incoming": incoming}
+                    related_ids.update(ln.id for ln in links.outgoing)
+                    related_ids.update(ln.id for ln in links.incoming)
+
+                # --- provenance (frontmatter derived_from_ids) -------------
+                if "provenance" in selected:
+                    sources = self._bfs_provenance(id, "sources", depth)
+                    derived = self._bfs_provenance(id, "derived", depth)
+                    unresolved_sources = sorted(self.knowledge.get_unresolved_sources(id))
+                    result["provenance"] = {
+                        "sources": sources,
+                        "derived": derived,
+                        "unresolved_sources": unresolved_sources,
+                    }
+                    related_ids.update(s["id"] for s in sources)
+                    related_ids.update(d["id"] for d in derived)
+
+                # --- edges (LCMA edges.db) ---------------------------------
+                if "edges" in selected:
+                    if self._config.lcma.enabled:
+                        # Fan out both directions; caller rarely wants just one.
+                        outgoing_edges = await self.edge_store.list_edges(
+                            from_id=id, namespace=namespace
+                        )
+                        incoming_edges = await self.edge_store.list_edges(
+                            to_id=id, namespace=namespace
+                        )
+                    else:
+                        outgoing_edges = []
+                        incoming_edges = []
+                    result["edges"] = {
+                        "outgoing": outgoing_edges,
+                        "incoming": incoming_edges,
+                    }
+                    for edge in outgoing_edges:
+                        tid = edge.get("to_id")
+                        if isinstance(tid, str):
+                            related_ids.add(tid)
+                    for edge in incoming_edges:
+                        fid = edge.get("from_id")
+                        if isinstance(fid, str):
+                            related_ids.add(fid)
+
+                # Exclude the document itself from related_ids so callers
+                # can iterate without filtering.
+                related_ids.discard(id)
+                result["related_ids"] = sorted(related_ids)
+                span.set_attribute("lithos.related_count", len(related_ids))
+
+                return result
+
         @self.mcp.tool()
         @tool_metrics()
         async def lithos_tags(

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -3031,6 +3031,153 @@ class TestDerivedFromIdsInResponses:
         assert items[source_id]["derived_from_ids"] == []
 
 
+class TestLithosRelated:
+    """Tests for #82 lithos_related — composite links + provenance + edges."""
+
+    async def _create_doc(
+        self,
+        server: LithosServer,
+        title: str,
+        *,
+        content: str | None = None,
+        derived_from_ids: list[str] | None = None,
+    ) -> str:
+        args: dict[str, Any] = {
+            "title": title,
+            "content": content if content is not None else f"Content of {title}.",
+            "agent": "related-agent",
+        }
+        if derived_from_ids is not None:
+            args["derived_from_ids"] = derived_from_ids
+        result = await _call_tool(server, "lithos_write", args)
+        assert result["status"] == "created"
+        return result["id"]
+
+    async def test_unknown_id_returns_doc_not_found(self, server: LithosServer):
+        result = await _call_tool(
+            server, "lithos_related", {"id": "00000000-0000-4000-8000-000000000000"}
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "doc_not_found"
+
+    async def test_default_include_covers_all_three_sections(self, server: LithosServer):
+        """Omitting include returns links + provenance + edges (all three)."""
+        doc = await self._create_doc(server, "Related Default")
+        result = await _call_tool(server, "lithos_related", {"id": doc})
+        assert result["id"] == doc
+        assert set(result["included"]) == {"links", "provenance", "edges"}
+        assert "links" in result
+        assert "provenance" in result
+        assert "edges" in result
+        assert result["related_ids"] == []  # isolated doc
+
+    async def test_include_subset_omits_unselected_sections(self, server: LithosServer):
+        doc = await self._create_doc(server, "Related Subset")
+        result = await _call_tool(server, "lithos_related", {"id": doc, "include": ["links"]})
+        assert result["included"] == ["links"]
+        assert "links" in result
+        assert "provenance" not in result
+        assert "edges" not in result
+
+    async def test_unknown_include_values_are_silently_ignored(self, server: LithosServer):
+        doc = await self._create_doc(server, "Related Forward Compat")
+        result = await _call_tool(
+            server, "lithos_related", {"id": doc, "include": ["links", "future_backend"]}
+        )
+        assert result["included"] == ["links"]
+
+    async def test_wiki_links_populate_links_section(self, server: LithosServer):
+        """An outgoing [[wiki-link]] shows up under links.outgoing."""
+        target = await self._create_doc(server, "Related Target Note")
+        linker = await self._create_doc(
+            server,
+            "Related Linker Note",
+            content="See [[related-target-note]] for reference.",
+        )
+        result = await _call_tool(server, "lithos_related", {"id": linker})
+        outgoing_ids = [n["id"] for n in result["links"]["outgoing"]]
+        assert target in outgoing_ids
+        assert target in result["related_ids"]
+
+    async def test_derived_from_populates_provenance_section(self, server: LithosServer):
+        """derived_from_ids shows up under provenance.sources (and reverse)."""
+        source = await self._create_doc(server, "Source Note")
+        derived = await self._create_doc(server, "Derived Note", derived_from_ids=[source])
+
+        result_derived = await _call_tool(server, "lithos_related", {"id": derived})
+        source_ids = [n["id"] for n in result_derived["provenance"]["sources"]]
+        assert source in source_ids
+        assert source in result_derived["related_ids"]
+
+        result_source = await _call_tool(server, "lithos_related", {"id": source})
+        derived_ids = [n["id"] for n in result_source["provenance"]["derived"]]
+        assert derived in derived_ids
+        assert derived in result_source["related_ids"]
+
+    async def test_depth_is_clamped_to_valid_range(self, server: LithosServer):
+        """depth=0 or depth=99 must not blow up — clamped to 1..3."""
+        doc = await self._create_doc(server, "Depth Clamp")
+        zero = await _call_tool(server, "lithos_related", {"id": doc, "depth": 0})
+        huge = await _call_tool(server, "lithos_related", {"id": doc, "depth": 99})
+        assert "links" in zero and "links" in huge
+
+    async def test_related_ids_exclude_self(self, server: LithosServer):
+        """Self-id must never appear in related_ids even if a self-link exists."""
+        doc_id = await self._create_doc(server, "Self Exclude")
+        result = await _call_tool(server, "lithos_related", {"id": doc_id})
+        assert doc_id not in result["related_ids"]
+
+    async def test_edges_populate_both_directions(self, server: LithosServer):
+        """An LCMA edge upserted via lithos_edge_upsert shows up on both endpoints."""
+        a = await self._create_doc(server, "Edge Endpoint A")
+        b = await self._create_doc(server, "Edge Endpoint B")
+
+        up = await _call_tool(
+            server,
+            "lithos_edge_upsert",
+            {
+                "from_id": a,
+                "to_id": b,
+                "type": "related_to",
+                "weight": 0.7,
+                "namespace": "default",
+            },
+        )
+        assert up["status"] == "ok"
+
+        # Outgoing side: A's edges include one where to_id == B.
+        result_a = await _call_tool(server, "lithos_related", {"id": a})
+        outgoing_tos = [e["to_id"] for e in result_a["edges"]["outgoing"]]
+        assert b in outgoing_tos
+        assert b in result_a["related_ids"]
+
+        # Incoming side: B's edges include one where from_id == A.
+        result_b = await _call_tool(server, "lithos_related", {"id": b})
+        incoming_froms = [e["from_id"] for e in result_b["edges"]["incoming"]]
+        assert a in incoming_froms
+        assert a in result_b["related_ids"]
+
+    async def test_namespace_filter_scopes_edges_only(self, server: LithosServer):
+        """namespace='other' filters the edges section; links/provenance untouched."""
+        a = await self._create_doc(server, "NS Scoped A")
+        b = await self._create_doc(server, "NS Scoped B")
+        await _call_tool(
+            server,
+            "lithos_edge_upsert",
+            {
+                "from_id": a,
+                "to_id": b,
+                "type": "related_to",
+                "weight": 0.5,
+                "namespace": "default",
+            },
+        )
+
+        result = await _call_tool(server, "lithos_related", {"id": a, "namespace": "nonexistent"})
+        assert result["edges"]["outgoing"] == []
+        assert result["edges"]["incoming"] == []
+
+
 def test_conformance_module_exists():
     """Sanity check to keep this module discoverable in test listings."""
     assert Path(__file__).name == "test_integration_conformance.py"


### PR DESCRIPTION
## Summary
Adds a composite `lithos_related(id, include, depth, namespace)` MCP tool that merges the three existing graph-query backends into a single response, so agents don't have to fan out across `lithos_links`, `lithos_provenance`, and `lithos_edge_list` and mentally join the results.

The three individual tools remain available — this is for the common "show me everything related to this doc" case, not a replacement.

## What it merges
- **links** — structural `[[wiki-link]]` navigation (NetworkX graph)
- **provenance** — `derived_from_ids` chains (frontmatter BFS)
- **edges** — typed LCMA edges (`edges.db`), both directions

## Response shape
```json
{
  "id": "<doc>",
  "included": ["links", "provenance", "edges"],
  "links":      { "outgoing": [...], "incoming": [...] },
  "provenance": { "sources": [...], "derived": [...],
                  "unresolved_sources": [...] },
  "edges":      { "outgoing": [...], "incoming": [...] },
  "related_ids": ["<uuid>", ...]
}
```

Design notes:
- Sections not in `include` are **omitted** (not emitted as empty keys) — keeps the response tight when a caller only wants one backend.
- Unknown `include` values are silently ignored so forward-compatible callers don't break when new backends land.
- `edges` is empty when LCMA is disabled in config.
- `related_ids` is the deduped, sorted union of every id referenced; the queried doc's own id is filtered out so callers can iterate without guarding.
- `depth` is clamped to 1-3 (matches the behaviour of `lithos_links` / `lithos_provenance`).
- `namespace` filter scopes the `edges` section only (links/provenance don't use namespaces).

## Test plan (10 new integration tests)
- [x] Unknown id → `doc_not_found` envelope
- [x] Default include returns all three sections
- [x] Partial include omits unselected sections (not empty keys)
- [x] Unknown include values silently ignored
- [x] Wiki-link populates `links.outgoing` + `related_ids`
- [x] `derived_from_ids` populates `provenance.sources` and the reverse
- [x] `depth=0` and `depth=99` both clamp safely
- [x] Self-id excluded from `related_ids`
- [x] LCMA edge upserted via `lithos_edge_upsert` visible on both endpoints
- [x] `namespace` filter scopes `edges` only

Also: `make check` green (1000 unit tests pass, +0 regressions) and full CI integration suite green locally (115 passed, ~5:37).

## Docs
SPECIFICATION.md §5.2 gets a new `lithos_related` entry with the full response shape and behaviour notes. Tool matrix at the end of the spec adds `lithos_related` under Graph.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)