### PR TITLE
refactor: remove lithos_links and lithos_provenance (#82)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -140,7 +140,7 @@ data/
 **LCMA SQLite stores under `.lithos/`:**
 
 - **`coordination.db`** — agents, tasks, claims, findings (pre-LCMA, unchanged).
-- **`edges.db`** — LCMA typed/weighted edges. Tables: `edges` (`edge_id`, `from_id`, `to_id`, `type`, `weight`, `namespace`, `created_at`, `updated_at`, `provenance_actor`, `provenance_type`, `evidence`, `conflict_state`). Created lazily on the first `lithos_edge_upsert` call. Separate from the `.graph/` NetworkX wiki-link cache — `edges.db` carries semantic/learned relationships, NetworkX continues to power `lithos_links`.
+- **`edges.db`** — LCMA typed/weighted edges. Tables: `edges` (`edge_id`, `from_id`, `to_id`, `type`, `weight`, `namespace`, `created_at`, `updated_at`, `provenance_actor`, `provenance_type`, `evidence`, `conflict_state`). Created lazily on the first `lithos_edge_upsert` call. Separate from the `.graph/` NetworkX wiki-link cache — `edges.db` carries semantic/learned relationships, NetworkX continues to power the `links` section of `lithos_related`.
 - **`stats.db`** — LCMA retrieval state. Tables: `node_stats`, `coactivation`, `enrich_queue`, `working_memory`, `receipts`. Created lazily on the first `lithos_retrieve` call (when the first receipt is written). The `enrich_queue` and reinforcement columns in `node_stats` are placeholders for the MVP 2 `lithos-enrich` worker.
 
 ### 3.2 Knowledge File Format
@@ -466,20 +466,6 @@ List knowledge items with filters.
 
 ### 5.2 Graph Operations
 
-#### `lithos_links`
-Get links for a knowledge item.
-
-**Arguments:**
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `id` | string | Yes | UUID of knowledge item |
-| `direction` | string | No | "outgoing", "incoming", or "both" (default: "both") |
-| `depth` | int | No | Traversal depth (default: 1, max: 3) |
-
-**Returns:** `{ outgoing: [{ id, title }], incoming: [{ id, title }] }`
-
-**Multi-hop behavior:** Returns flat lists regardless of depth. For `depth > 1`, results include all reachable nodes within N hops, deduplicated. Path information is not preserved.
-
 #### `lithos_tags`
 List all tags with document counts.
 
@@ -492,40 +478,11 @@ List all tags with document counts.
 
 **Note:** To find documents with a specific tag, use `lithos_list(tags=["tag-name"])`.
 
-#### `lithos_provenance`
-Traverse provenance lineage (derived-from relationships) for a knowledge item.
-
-**Arguments:**
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `id` | string | Yes | UUID of knowledge item |
-| `direction` | string | No | "sources", "derived", or "both" (default: "both") |
-| `depth` | int | No | Traversal depth 1-3 (default: 1) |
-| `include_unresolved` | bool | No | Include unresolved source IDs (default: true) |
-
-**Returns:**
-```json
-{
-  "id": "<queried-uuid>",
-  "sources": [{ "id": "<uuid>", "title": "<string>" }],
-  "derived": [{ "id": "<uuid>", "title": "<string>" }],
-  "unresolved_sources": ["<uuid>", ...]
-}
-```
-
-**Behavior:**
-- Uses BFS traversal over in-memory provenance indexes.
-- `sources` walks the `derived_from_ids` chain (what was this derived from?).
-- `derived` walks the reverse index (what was derived from this?).
-- `depth` is clamped to 1-3. Depth > 1 follows multi-hop chains (e.g., A→B→C at depth 2).
-- Cycles are handled via a visited set — BFS terminates without infinite loops.
-- `unresolved_sources` is only populated when `include_unresolved=true` (the default). Contains source UUIDs that reference documents not currently in the knowledge base.
-- Returns `{ status: "error", code: "doc_not_found" }` for unknown IDs.
-- Results are sorted by ID for deterministic output.
-
 #### `lithos_related`
 
-Composite "what is this document related to?" view. Merges wiki-link navigation, derived-from provenance, and typed LCMA edges into a single response so agents don't have to fan out across three tools and mentally join the results.
+Composite "what is this document related to?" view. Merges wiki-link navigation, derived-from provenance, and typed LCMA edges into a single response.
+
+This tool replaces the previously separate `lithos_links` and `lithos_provenance` tools. Both were pure subsets of `lithos_related` and were removed pre-1.0 to keep the MCP tool count tight. For edge-table queries that are not centred on a single document (e.g. "list all `contradicts` edges"), use `lithos_edge_list` — that tool is the only way to express filters like `type` alone or `to_id` alone.
 
 **Arguments:**
 | Name | Type | Required | Description |
@@ -562,7 +519,7 @@ Composite "what is this document related to?" view. Merges wiki-link navigation,
 - Unknown `include` values are silently ignored so forward-compatible callers don't break when new backends land.
 - `edges` section is empty when LCMA is disabled in config.
 - `related_ids` is the deduped, sorted union of every id referenced across the included sections. The queried document's own id is excluded so callers can iterate without filtering.
-- `lithos_links`, `lithos_provenance`, and `lithos_edge_list` remain available for scenarios that need finer-grained control (single direction, edge-type filter, etc.). This tool is for the common case.
+- `lithos_edge_list` remains available for edge-table queries not centred on a single document (global filter by type, namespace, etc.).
 - Returns `{ status: "error", code: "doc_not_found" }` for unknown IDs.
 
 ### 5.3 Agent Operations
@@ -778,7 +735,7 @@ Get knowledge base statistics.
 
 ### 5.6 LCMA Operations (Phase 7 MVP 1)
 
-These tools are additive to the pre-LCMA surface — they do not replace `lithos_search`, `lithos_read`, or `lithos_links`. See `docs/plans/lcma-design.md` for the design rationale.
+These tools are additive to the pre-LCMA surface — they do not replace `lithos_search`, `lithos_read`, or `lithos_related`. See `docs/plans/lcma-design.md` for the design rationale.
 
 #### `lithos_retrieve`
 
@@ -1254,7 +1211,7 @@ These are explicitly not part of the initial implementation but may be considere
 - Full edit history / provenance log
 - Hierarchical multi-hop link results
 - ~~Structured MCP error codes (`NOT_FOUND`, `CLAIM_CONFLICT`, `AMBIGUOUS_LINK`, etc.)~~ (Implemented via `{ status: "error", code, message }` envelopes; see §10.2 for the full list of error codes)
-- ~~Structured `source` provenance with `derived_from` links to source knowledge items~~ (Implemented in Phase 3 via `derived_from_ids` and `lithos_provenance`)
+- ~~Structured `source` provenance with `derived_from` links to source knowledge items~~ (Implemented in Phase 3 via `derived_from_ids`, exposed through `lithos_related`)
 - ~~`lithos_tags` prefix filtering~~ (Implemented via `prefix`)
 - `lithos_delete` audit trail logging (record which agent deleted what)
 
@@ -1319,14 +1276,14 @@ These are explicitly not part of the initial implementation but may be considere
 | Category | Tools |
 |----------|-------|
 | Knowledge | `lithos_write`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup` |
-| Graph | `lithos_links`, `lithos_tags`, `lithos_provenance`, `lithos_related` |
+| Graph | `lithos_tags`, `lithos_related` |
 | Agent | `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list` |
 | Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_list`, `lithos_task_status`, `lithos_finding_post`, `lithos_finding_list` |
 | System | `lithos_stats` |
 | LCMA (Phase 7 MVP 1) | `lithos_retrieve`, `lithos_edge_upsert`, `lithos_edge_list` |
 | HTTP | `GET /health` (not an MCP tool; see §5.7) |
 
-**Total: 27 MCP tools + 1 HTTP endpoint** (24 pre-LCMA + 3 LCMA MVP 1 additive)
+**Total: 28 MCP tools + 1 HTTP endpoint** (the Graph surface was tightened pre-1.0 by removing `lithos_links` and `lithos_provenance` in favour of the composite `lithos_related`; `lithos_edge_list` is retained for non-doc-centric edge-table queries)
 
 ---
 

--- a/docs/mcp-roadmap-alignment.md
+++ b/docs/mcp-roadmap-alignment.md
@@ -12,7 +12,7 @@ MCP roadmap source: https://modelcontextprotocol.io/development/roadmap
 | MCP Roadmap Item | Lithos Status | Notes |
 |-----------------|---------------|-------|
 | Agent discovery / Server Cards | ✅ Implemented | `lithos_agent_register`, `lithos_agent_list`, `lithos_agent_info` provide a shared agent directory with type metadata |
-| Provenance metadata / Audit trails | ✅ Implemented | `derived_from_ids`, `source_url`, `lithos_provenance` — BFS traversal of provenance graph |
+| Provenance metadata / Audit trails | ✅ Implemented | `derived_from_ids`, `source_url`, exposed via the `provenance` section of `lithos_related` — BFS traversal of provenance graph |
 | Agent task lifecycle (retry, expiry) | ✅ Implemented | `lithos_task_claim` with TTL, `lithos_task_complete`, `lithos_task_status`; expiry via `expires_at` |
 | Triggers and event-driven updates | ✅ Implemented (ahead) | SSE event delivery (Phase 6.5) — real-time knowledge change stream |
 | Scalable session handling | 🟡 Partial | Stateless MCP tool surface; no session resumption semantics defined |

--- a/docs/plans/final-architecture-guardrails.md
+++ b/docs/plans/final-architecture-guardrails.md
@@ -106,9 +106,9 @@ Sensitive-data policy:
 
 ## 6.1 Provenance API Authority
 
-- Canonical lineage queries use `lithos_provenance` (frontmatter/index authority).
+- Canonical lineage queries use the `provenance` section of `lithos_related` (frontmatter/index authority).
 - Edge queries (`lithos_edge_list`) are graph/learning oriented and may include projected lineage edges.
-- If results diverge, lineage answers follow `lithos_provenance`.
+- If results diverge, lineage answers follow `lithos_related` / `provenance`.
 
 ## 7) Conformance Test Matrix
 

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -100,7 +100,7 @@ Rules: (1) strip `knowledge/` prefix, (2) take the directory path (everything be
 
 ### Edge
 
-LCMA introduces typed, weighted edges stored in `edges.db`. These are **separate from** the existing wiki-link graph (NetworkX DiGraph), which continues to handle `[[wiki-link]]` relationships, link resolution, and the `lithos_links` tool.
+LCMA introduces typed, weighted edges stored in `edges.db`. These are **separate from** the existing wiki-link graph (NetworkX DiGraph), which continues to handle `[[wiki-link]]` relationships, link resolution, and the `links` section of `lithos_related`.
 
 LCMA edge fields:
 
@@ -425,7 +425,7 @@ Note: `salience`, `usage_stats`, and `embedding_spaces` are stored in `stats.db`
 
 ## 4.3 Edges Store Schema (sqlite)
 
-Stored in `data/.lithos/edges.db`. This is **separate from** the existing NetworkX wiki-link graph (`data/.graph/graph.json`), which continues to power `lithos_links` and wiki-link resolution.
+Stored in `data/.lithos/edges.db`. This is **separate from** the existing NetworkX wiki-link graph (`data/.graph/graph.json`), which continues to power the `links` section of `lithos_related` and wiki-link resolution.
 
 The two systems complement each other:
 
@@ -452,7 +452,7 @@ Indexes:
 - `(from_id)`, `(to_id)`, `(type)`, `(namespace)`
 - optionally `(from_id, type)` for speed
 
-New MCP tools for LCMA edges (do not modify existing `lithos_links`):
+New MCP tools for LCMA edges (do not modify the `links` section of `lithos_related`):
 
 - `lithos_edge_upsert` — create or update a typed edge (combines former `lithos_edge_create` + `lithos_edge_update`)
 - `lithos_edge_list` — query edges by node, type, or namespace
@@ -663,7 +663,8 @@ def scout_provenance(q: QueryContext, seed_nodes: list[str], k: int) -> list[Can
     # Walk derived_from_ids forward (what was derived from these seeds?)
     # and reverse (what did these seeds derive from?).
     # Uses existing KnowledgeMetadata.derived_from_ids and provenance index
-    # (KnowledgeManager._build_provenance_index, lithos_provenance tool).
+    # (KnowledgeManager._build_provenance_index; same traversal exposed via
+    # the provenance section of lithos_related).
     # Cheap and high-signal: declared lineage is the strongest relationship signal
     # in the knowledge base.
     ...
@@ -1524,10 +1525,10 @@ Write-contract note for LCMA params:
 
 ## Alignment with Existing Lithos (preserving backward compatibility)
 
-### Existing tools preserved (24 tools, no renames or removals)
+### Existing tools preserved (post-consolidation)
 
 - Knowledge: `lithos_write`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup`
-- Graph: `lithos_links`, `lithos_tags`, `lithos_provenance`
+- Graph: `lithos_tags`, `lithos_related` (the composite tool that superseded the pre-1.0 `lithos_links` and `lithos_provenance`)
 - Agents: `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list`
 - Coordination: `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_list`, `lithos_task_status`
 - Findings: `lithos_finding_post`, `lithos_finding_list`
@@ -1566,7 +1567,7 @@ Write-contract note for LCMA params:
 
 Provenance query policy:
 
-- Canonical lineage queries use `lithos_provenance` (frontmatter/index based).
+- Canonical lineage queries use the `provenance` section of `lithos_related` (frontmatter/index based).
 - `lithos_edge_list` is for typed LCMA edges and projected relationships; it is not the canonical lineage API.
 
 ### Existing frontmatter fields preserved
@@ -1587,7 +1588,7 @@ LCMA is also compatible with cross-plan metadata additions: `source_url`, `deriv
 ### Key design decisions
 
 - **`confidence` vs `salience`**: `confidence` (frontmatter) = author's belief about accuracy. `salience` (stats.db) = retrieval utility learned from usage. Both are 0–1 floats but serve different purposes.
-- **NetworkX vs edges.db**: NetworkX handles structural `[[wiki-link]]` navigation and powers `lithos_links`. edges.db handles semantic/learned relationships with weights and types. Both are queried by the graph scout.
+- **NetworkX vs edges.db**: NetworkX handles structural `[[wiki-link]]` navigation and powers the `links` section of `lithos_related`. edges.db handles semantic/learned relationships with weights and types. Both are queried by the graph scout.
 - **Declared provenance vs learned edges**: `derived_from_ids` is the source of truth for declared lineage. `edges.db` can carry mirrored `derived_from` edges as an accelerator only.
 - **Frontmatter vs stats.db**: Static metadata in frontmatter (author, tags, note_type). Dynamic signals in stats.db (salience, retrieval_count, decay). This avoids constant file rewrites from learning updates.
 - **Concept nodes**: Emerge as derived clusters in `stats.db` first, then promoted to regular `KnowledgeDocument` notes with `note_type: “concept”` via `lithos_write` once stable. Not auto-materialized — promotion requires exceeding a stability threshold to avoid noisy git churn.

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2242,105 +2242,6 @@ class LithosServer:
 
         # ==================== Graph Tools ====================
 
-        @self.mcp.tool()
-        @tool_metrics()
-        async def lithos_links(
-            id: str,
-            direction: str = "both",
-            depth: int = 1,
-        ) -> dict[str, list[dict[str, str]]]:
-            """Get links for a document.
-
-            Args:
-                id: Document UUID
-                direction: "outgoing", "incoming", or "both"
-                depth: Traversal depth 1-3 (default: 1)
-
-            Returns:
-                Dict with outgoing and incoming lists of {id, title}
-            """
-            logger.info("lithos_links id=%s direction=%s depth=%d", id, direction, depth)
-            tracer = get_tracer()
-            with tracer.start_as_current_span("lithos.tool.links") as span:
-                span.set_attribute("lithos.tool", "lithos_links")
-                span.set_attribute("lithos.id", id)
-                span.set_attribute("lithos.direction", direction)
-                span.set_attribute("lithos.depth", depth)
-
-                if direction not in ("outgoing", "incoming", "both"):
-                    direction = "both"
-
-                links = self.graph.get_links(
-                    doc_id=id,
-                    direction=direction,  # type: ignore
-                    depth=depth,
-                )
-
-                return {
-                    "outgoing": [{"id": link.id, "title": link.title} for link in links.outgoing],
-                    "incoming": [{"id": link.id, "title": link.title} for link in links.incoming],
-                }
-
-        @self.mcp.tool()
-        @tool_metrics()
-        async def lithos_provenance(
-            id: str,
-            direction: str = "both",
-            depth: int = 1,
-            include_unresolved: bool = True,
-        ) -> dict[str, Any]:
-            """Query document lineage via provenance indexes.
-
-            Args:
-                id: Document UUID
-                direction: "sources", "derived", or "both"
-                depth: BFS traversal depth 1-3 (default: 1)
-                include_unresolved: Include unresolved source UUIDs (default: True)
-
-            Returns:
-                Dict with id, sources, derived, and optionally unresolved_sources
-            """
-            logger.info("lithos_provenance id=%s direction=%s depth=%d", id, direction, depth)
-            tracer = get_tracer()
-            with tracer.start_as_current_span("lithos.tool.provenance") as span:
-                span.set_attribute("lithos.tool", "lithos_provenance")
-                span.set_attribute("lithos.id", id)
-                span.set_attribute("lithos.direction", direction)
-                span.set_attribute("lithos.depth", depth)
-
-                if not self.knowledge.has_document(id):
-                    return {
-                        "status": "error",
-                        "code": "doc_not_found",
-                        "message": f"Document not found: {id}",
-                    }
-
-                if direction not in ("sources", "derived", "both"):
-                    direction = "both"
-
-                depth = min(max(depth, 1), 3)
-
-                sources: list[dict[str, str]] = []
-                derived: list[dict[str, str]] = []
-
-                if direction in ("sources", "both"):
-                    sources = self._bfs_provenance(id, "sources", depth)
-                if direction in ("derived", "both"):
-                    derived = self._bfs_provenance(id, "derived", depth)
-
-                result: dict[str, Any] = {
-                    "id": id,
-                    "sources": sources,
-                    "derived": derived,
-                }
-
-                if include_unresolved:
-                    result["unresolved_sources"] = sorted(self.knowledge.get_unresolved_sources(id))
-
-                span.set_attribute("lithos.sources_count", len(sources))
-                span.set_attribute("lithos.derived_count", len(derived))
-                return result
-
         _RELATED_INCLUDES = ("links", "provenance", "edges")
 
         @self.mcp.tool()
@@ -2353,17 +2254,18 @@ class LithosServer:
         ) -> dict[str, Any]:
             """Composite "what is this document related to?" view.
 
-            Merges three backends into a single response so agents don't have
-            to fan out across ``lithos_links``, ``lithos_provenance``, and
-            ``lithos_edge_list`` and mentally join the results:
+            Merges three graph-query backends into a single response so agents
+            don't have to fan out across multiple tools and mentally join the
+            results:
 
             - **links** — structural ``[[wiki-link]]`` navigation (NetworkX).
             - **provenance** — ``derived_from_ids`` chains (frontmatter index).
             - **edges** — typed LCMA edges (edges.db), both directions.
 
-            The individual tools remain available for power-user scenarios
-            that need specific traversal control (directional, depth-only,
-            edge-type filtering, etc.). This tool is for the common case.
+            For edge-table queries that are not centred on a single document
+            (e.g. "list all ``contradicts`` edges", "audit a namespace"), use
+            :func:`lithos_edge_list` instead — that tool is the only way to
+            express filters like ``type`` alone or ``to_id`` alone.
 
             Args:
                 id: Document UUID.

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -702,9 +702,9 @@ class TestGraphEdgeConsistency:
         assert not server.graph.has_edge(linker_id, beta_id)
 
         links_before = await _call_tool(
-            server, "lithos_links", {"id": linker_id, "direction": "outgoing"}
+            server, "lithos_related", {"id": linker_id, "include": ["links"]}
         )
-        before_ids = [link["id"] for link in links_before["outgoing"]]
+        before_ids = [link["id"] for link in links_before["links"]["outgoing"]]
         assert alpha_id in before_ids
         assert beta_id not in before_ids
 
@@ -725,22 +725,22 @@ class TestGraphEdgeConsistency:
         assert server.graph.has_edge(linker_id, beta_id)
 
         links_after = await _call_tool(
-            server, "lithos_links", {"id": linker_id, "direction": "outgoing"}
+            server, "lithos_related", {"id": linker_id, "include": ["links"]}
         )
-        after_ids = [link["id"] for link in links_after["outgoing"]]
+        after_ids = [link["id"] for link in links_after["links"]["outgoing"]]
         assert beta_id in after_ids
         assert alpha_id not in after_ids
 
         # Verify incoming links on targets are consistent.
         alpha_incoming = await _call_tool(
-            server, "lithos_links", {"id": alpha_id, "direction": "incoming"}
+            server, "lithos_related", {"id": alpha_id, "include": ["links"]}
         )
-        assert not any(link["id"] == linker_id for link in alpha_incoming["incoming"])
+        assert not any(link["id"] == linker_id for link in alpha_incoming["links"]["incoming"])
 
         beta_incoming = await _call_tool(
-            server, "lithos_links", {"id": beta_id, "direction": "incoming"}
+            server, "lithos_related", {"id": beta_id, "include": ["links"]}
         )
-        assert any(link["id"] == linker_id for link in beta_incoming["incoming"])
+        assert any(link["id"] == linker_id for link in beta_incoming["links"]["incoming"])
 
 
 class TestAgentAndCoordinationMCPTools:
@@ -1427,12 +1427,12 @@ class TestSearchAndListFilters:
         assert "old-agent" not in agent_ids
 
 
-class TestLinksDepthAndDirection:
-    """Tests for lithos_links with depth > 1 and direction=both."""
+class TestRelatedLinksDepth:
+    """Tests for lithos_related (links section) with depth > 1 and both directions."""
 
     @pytest.mark.asyncio
-    async def test_links_direction_both(self, server: LithosServer):
-        """lithos_links direction=both returns outgoing and incoming."""
+    async def test_links_both_directions(self, server: LithosServer):
+        """lithos_related returns wiki-link neighbours in both directions at depth=1."""
         a = await _call_tool(
             server,
             "lithos_write",
@@ -1461,18 +1461,18 @@ class TestLinksDepthAndDirection:
             },
         )
 
-        links = await _call_tool(
-            server, "lithos_links", {"id": b["id"], "direction": "both", "depth": 1}
+        result = await _call_tool(
+            server, "lithos_related", {"id": b["id"], "include": ["links"], "depth": 1}
         )
-        outgoing_ids = [link["id"] for link in links["outgoing"]]
-        incoming_ids = [link["id"] for link in links["incoming"]]
+        outgoing_ids = [link["id"] for link in result["links"]["outgoing"]]
+        incoming_ids = [link["id"] for link in result["links"]["incoming"]]
 
         assert c["id"] in outgoing_ids
         assert a["id"] in incoming_ids
 
     @pytest.mark.asyncio
     async def test_links_depth_2_traversal(self, server: LithosServer):
-        """lithos_links depth=2 returns transitive neighbors."""
+        """depth=2 returns transitive neighbours; depth=1 does not."""
         a = await _call_tool(
             server,
             "lithos_write",
@@ -1501,25 +1501,25 @@ class TestLinksDepthAndDirection:
             },
         )
 
-        # Depth 1 from root should find middle but not leaf
-        links_d1 = await _call_tool(
-            server, "lithos_links", {"id": a["id"], "direction": "outgoing", "depth": 1}
+        # Depth 1 from root should find middle but not leaf.
+        d1 = await _call_tool(
+            server, "lithos_related", {"id": a["id"], "include": ["links"], "depth": 1}
         )
-        d1_ids = [link["id"] for link in links_d1["outgoing"]]
+        d1_ids = [link["id"] for link in d1["links"]["outgoing"]]
         assert b["id"] in d1_ids
         assert c["id"] not in d1_ids
 
-        # Depth 2 from root should find both middle and leaf
-        links_d2 = await _call_tool(
-            server, "lithos_links", {"id": a["id"], "direction": "outgoing", "depth": 2}
+        # Depth 2 from root should find both middle and leaf.
+        d2 = await _call_tool(
+            server, "lithos_related", {"id": a["id"], "include": ["links"], "depth": 2}
         )
-        d2_ids = [link["id"] for link in links_d2["outgoing"]]
+        d2_ids = [link["id"] for link in d2["links"]["outgoing"]]
         assert b["id"] in d2_ids
         assert c["id"] in d2_ids
 
     @pytest.mark.asyncio
     async def test_links_depth_2_both_directions(self, server: LithosServer):
-        """lithos_links depth=2 direction=both returns transitive links in both directions."""
+        """depth=2 covers transitive links in both directions from a mid-chain node."""
         a = await _call_tool(
             server,
             "lithos_write",
@@ -1548,12 +1548,12 @@ class TestLinksDepthAndDirection:
             },
         )
 
-        # From mid at depth=2: outgoing should reach end, incoming should reach start
-        links = await _call_tool(
-            server, "lithos_links", {"id": b["id"], "direction": "both", "depth": 2}
+        # From mid at depth=2: outgoing should reach end, incoming should reach start.
+        result = await _call_tool(
+            server, "lithos_related", {"id": b["id"], "include": ["links"], "depth": 2}
         )
-        outgoing_ids = [link["id"] for link in links["outgoing"]]
-        incoming_ids = [link["id"] for link in links["incoming"]]
+        outgoing_ids = [link["id"] for link in result["links"]["outgoing"]]
+        incoming_ids = [link["id"] for link in result["links"]["incoming"]]
 
         assert c["id"] in outgoing_ids
         assert a["id"] in incoming_ids
@@ -2731,8 +2731,8 @@ class TestRebuildIndicesProvenance:
         assert derived_id not in mgr._id_to_title
 
 
-class TestLithosProvenance:
-    """Tests for US-011: lithos_provenance MCP tool."""
+class TestRelatedProvenance:
+    """Tests for the provenance section of lithos_related (US-011 coverage)."""
 
     async def _create_doc(
         self,
@@ -2752,56 +2752,52 @@ class TestLithosProvenance:
         assert result["status"] == "created"
         return result["id"]
 
+    async def _prov(self, server: LithosServer, doc_id: str, *, depth: int = 1) -> dict[str, Any]:
+        result = await _call_tool(
+            server,
+            "lithos_related",
+            {"id": doc_id, "include": ["provenance"], "depth": depth},
+        )
+        assert "provenance" in result, result
+        return result["provenance"]
+
     async def test_single_depth_sources(self, server: LithosServer):
-        """direction='sources' returns immediate source documents."""
+        """Immediate source document shows up under provenance.sources."""
         source_id = await self._create_doc(server, "Prov Source A")
         derived_id = await self._create_doc(server, "Prov Derived A", derived_from_ids=[source_id])
 
-        result = await _call_tool(
-            server, "lithos_provenance", {"id": derived_id, "direction": "sources"}
-        )
-        assert result["id"] == derived_id
-        assert len(result["sources"]) == 1
-        assert result["sources"][0]["id"] == source_id
-        assert result["sources"][0]["title"] == "Prov Source A"
-        assert result["derived"] == []
+        prov = await self._prov(server, derived_id)
+        assert len(prov["sources"]) == 1
+        assert prov["sources"][0]["id"] == source_id
+        assert prov["sources"][0]["title"] == "Prov Source A"
+        # No incoming derives from this leaf doc.
+        assert prov["derived"] == []
 
     async def test_single_depth_derived(self, server: LithosServer):
-        """direction='derived' returns immediate derived documents."""
+        """Immediate derived document shows up under provenance.derived."""
         source_id = await self._create_doc(server, "Prov Source B")
         derived_id = await self._create_doc(server, "Prov Derived B", derived_from_ids=[source_id])
 
-        result = await _call_tool(
-            server, "lithos_provenance", {"id": source_id, "direction": "derived"}
-        )
-        assert result["id"] == source_id
-        assert result["sources"] == []
-        assert len(result["derived"]) == 1
-        assert result["derived"][0]["id"] == derived_id
+        prov = await self._prov(server, source_id)
+        assert prov["sources"] == []
+        assert len(prov["derived"]) == 1
+        assert prov["derived"][0]["id"] == derived_id
 
     async def test_multi_depth_bfs_chain(self, server: LithosServer):
-        """depth=2 BFS traverses A->B->C chain."""
+        """depth=2 BFS traverses A->B->C chain in both directions."""
         a_id = await self._create_doc(server, "Chain A")
         b_id = await self._create_doc(server, "Chain B", derived_from_ids=[a_id])
         c_id = await self._create_doc(server, "Chain C", derived_from_ids=[b_id])
 
-        # From A, derived depth=2 should find B and C
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": a_id, "direction": "derived", "depth": 2},
-        )
-        derived_ids = [n["id"] for n in result["derived"]]
+        # From A at depth=2 the derived list should reach B and C.
+        prov_a = await self._prov(server, a_id, depth=2)
+        derived_ids = [n["id"] for n in prov_a["derived"]]
         assert b_id in derived_ids
         assert c_id in derived_ids
 
-        # From C, sources depth=2 should find B and A
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": c_id, "direction": "sources", "depth": 2},
-        )
-        source_ids = [n["id"] for n in result["sources"]]
+        # From C at depth=2 the sources list should reach B and A.
+        prov_c = await self._prov(server, c_id, depth=2)
+        source_ids = [n["id"] for n in prov_c["sources"]]
         assert b_id in source_ids
         assert a_id in source_ids
 
@@ -2810,7 +2806,7 @@ class TestLithosProvenance:
         a_id = await self._create_doc(server, "Cycle A")
         b_id = await self._create_doc(server, "Cycle B", derived_from_ids=[a_id])
 
-        # Now update A to also derive from B (creates a cycle)
+        # Update A to also derive from B (creates a cycle).
         await _call_tool(
             server,
             "lithos_write",
@@ -2823,110 +2819,42 @@ class TestLithosProvenance:
             },
         )
 
-        # Should return without hanging, depth=3 to maximize traversal
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": a_id, "direction": "both", "depth": 3},
-        )
-        # Both A's sources and derived should include B
-        source_ids = [n["id"] for n in result["sources"]]
-        derived_ids = [n["id"] for n in result["derived"]]
+        # Should return without hanging at depth=3.
+        prov = await self._prov(server, a_id, depth=3)
+        source_ids = [n["id"] for n in prov["sources"]]
+        derived_ids = [n["id"] for n in prov["derived"]]
         assert b_id in source_ids
         assert b_id in derived_ids
 
     async def test_unresolved_sources_included(self, server: LithosServer):
-        """include_unresolved=True shows unresolved source UUIDs."""
+        """Unresolved source UUIDs surface under provenance.unresolved_sources."""
         missing_id = "00000000-0000-0000-0000-000000aaaaaa"
         doc_id = await self._create_doc(server, "Unresolved Prov", derived_from_ids=[missing_id])
 
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": doc_id, "include_unresolved": True},
-        )
-        assert missing_id in result["unresolved_sources"]
-
-    async def test_unresolved_sources_excluded(self, server: LithosServer):
-        """include_unresolved=False omits unresolved_sources key."""
-        missing_id = "00000000-0000-0000-0000-000000bbbbbb"
-        doc_id = await self._create_doc(server, "No Unresolved Prov", derived_from_ids=[missing_id])
-
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": doc_id, "include_unresolved": False},
-        )
-        assert "unresolved_sources" not in result
-
-    async def test_unknown_id_returns_error(self, server: LithosServer):
-        """Unknown ID returns doc_not_found error."""
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": "00000000-0000-0000-0000-ffffffffffff"},
-        )
-        assert result["status"] == "error"
-        assert result["code"] == "doc_not_found"
+        prov = await self._prov(server, doc_id)
+        assert missing_id in prov["unresolved_sources"]
 
     async def test_both_direction(self, server: LithosServer):
-        """direction='both' returns sources and derived."""
+        """provenance includes sources and derived without an explicit flag."""
         a_id = await self._create_doc(server, "Both Source")
         b_id = await self._create_doc(server, "Both Middle", derived_from_ids=[a_id])
         c_id = await self._create_doc(server, "Both Derived", derived_from_ids=[b_id])
 
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": b_id, "direction": "both"},
-        )
-        source_ids = [n["id"] for n in result["sources"]]
-        derived_ids = [n["id"] for n in result["derived"]]
+        prov = await self._prov(server, b_id)
+        source_ids = [n["id"] for n in prov["sources"]]
+        derived_ids = [n["id"] for n in prov["derived"]]
         assert a_id in source_ids
         assert c_id in derived_ids
 
-    async def test_results_sorted_by_id(self, server: LithosServer):
-        """Sources and derived lists are sorted by ID."""
+    async def test_sources_sorted_by_id(self, server: LithosServer):
+        """Sources list is sorted by ID for deterministic output."""
         s1 = await self._create_doc(server, "Sort Source 1")
         s2 = await self._create_doc(server, "Sort Source 2")
         doc_id = await self._create_doc(server, "Sort Derived", derived_from_ids=[s1, s2])
 
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": doc_id, "direction": "sources"},
-        )
-        ids = [n["id"] for n in result["sources"]]
+        prov = await self._prov(server, doc_id)
+        ids = [n["id"] for n in prov["sources"]]
         assert ids == sorted(ids)
-
-    async def test_depth_clamped(self, server: LithosServer):
-        """Depth values are clamped to 1-3."""
-        a_id = await self._create_doc(server, "Clamp A")
-        b_id = await self._create_doc(server, "Clamp B", derived_from_ids=[a_id])
-        c_id = await self._create_doc(server, "Clamp C", derived_from_ids=[b_id])
-        _d_id = await self._create_doc(server, "Clamp D", derived_from_ids=[c_id])
-
-        # depth=0 should be clamped to 1
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": a_id, "direction": "derived", "depth": 0},
-        )
-        derived_ids = [n["id"] for n in result["derived"]]
-        assert b_id in derived_ids
-        # depth=1 should not reach C
-        assert c_id not in derived_ids
-
-        # depth=100 should be clamped to 3
-        result = await _call_tool(
-            server,
-            "lithos_provenance",
-            {"id": a_id, "direction": "derived", "depth": 100},
-        )
-        derived_ids = [n["id"] for n in result["derived"]]
-        # Should reach up to 3 levels deep
-        assert b_id in derived_ids
-        assert c_id in derived_ids
 
 
 class TestDerivedFromIdsInResponses:

--- a/tests/test_provenance_conformance.py
+++ b/tests/test_provenance_conformance.py
@@ -351,11 +351,12 @@ class TestIndexLifecycleConformance:
         # This must terminate
         result = await _call_tool(
             server,
-            "lithos_provenance",
-            {"id": a["id"], "direction": "both", "depth": 3},
+            "lithos_related",
+            {"id": a["id"], "include": ["provenance"], "depth": 3},
         )
-        assert "sources" in result
-        assert "derived" in result
+        assert "provenance" in result
+        assert "sources" in result["provenance"]
+        assert "derived" in result["provenance"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -277,15 +277,15 @@ class TestTelemetryIntegration:
         tool_attrs = dict(tool_span.attributes)
         assert tool_attrs.get("lithos.provenance.source_count") == 1
 
-    async def test_provenance_tool_emits_span(self, otel_server):
-        """lithos_provenance emits a span with direction and depth."""
+    async def test_related_tool_emits_span(self, otel_server):
+        """lithos_related emits a span with include subset and depth."""
         server, exporter = otel_server
 
         # Create a doc
         result = await server.mcp._call_tool_mcp(
             "lithos_write",
             {
-                "title": "OTEL Prov Query",
+                "title": "OTEL Related Query",
                 "content": "Test.",
                 "agent": "test-agent",
             },
@@ -294,23 +294,22 @@ class TestTelemetryIntegration:
 
         exporter.clear()
 
-        # Call lithos_provenance
+        # Call lithos_related with provenance-only include
         await server.mcp._call_tool_mcp(
-            "lithos_provenance",
-            {"id": doc_id, "direction": "both", "depth": 1},
+            "lithos_related",
+            {"id": doc_id, "include": ["provenance"], "depth": 1},
         )
 
         spans = exporter.get_finished_spans()
         span_names = [s.name for s in spans]
-        assert "lithos.tool.provenance" in span_names
+        assert "lithos.tool.related" in span_names
 
-        prov_span = next(s for s in spans if s.name == "lithos.tool.provenance")
-        prov_attrs = dict(prov_span.attributes)
-        assert prov_attrs.get("lithos.tool") == "lithos_provenance"
-        assert prov_attrs.get("lithos.direction") == "both"
-        assert prov_attrs.get("lithos.depth") == 1
-        assert "lithos.sources_count" in prov_attrs
-        assert "lithos.derived_count" in prov_attrs
+        related_span = next(s for s in spans if s.name == "lithos.tool.related")
+        related_attrs = dict(related_span.attributes)
+        assert related_attrs.get("lithos.tool") == "lithos_related"
+        assert related_attrs.get("lithos.include") == "provenance"
+        assert related_attrs.get("lithos.depth") == 1
+        assert "lithos.related_count" in related_attrs
 
 
 class TestWriteDurationHistogram:


### PR DESCRIPTION
## Summary
Follow-up to #188 (composite `lithos_related`). Removes the two redundant graph-query tools whose full behaviour is now covered by `lithos_related`:

- `lithos_links` ≡ `lithos_related(include=["links"])` plus a client-side pick of outgoing/incoming.
- `lithos_provenance` ≡ `lithos_related(include=["provenance"])` plus a client-side pick of sources/derived. The `include_unresolved=False` knob is dropped — unresolved sources always surface on the composite path.

`lithos_edge_list` is **kept** — it expresses queries the composite can't (e.g. "list all `contradicts` edges globally", "audit every edge in a namespace"). No single-doc center required there.

## Rationale
Every MCP tool costs LLM context and decision burden at request time. Pre-1.0 is the right window to trim, and the replacement is already proven by #188 and its tests.

## What's retained
- Internal helpers `graph.get_links(...)` and `self._bfs_provenance(...)` stay — `lithos_related` uses them.
- All behaviour (depth clamping, cycle-safe BFS, unresolved-source surfacing) continues to hold; the tests that covered those invariants were migrated, not deleted.

## Scope
- **server.py**: two `@mcp.tool()` registrations removed. Tool count drops 30 → 28.
- **Tests** (migrated, not duplicated):
  - `TestLinksDepthAndDirection` → `TestRelatedLinksDepth`
  - `TestLithosProvenance` → `TestRelatedProvenance` (dropped two near-duplicates of existing `TestLithosRelated` coverage, plus the `include_unresolved=False` test whose feature is gone)
  - `test_provenance_conformance.py` cycle test migrated
  - `test_telemetry.py`: `test_provenance_tool_emits_span` → `test_related_tool_emits_span`
- **Docs**: `SPECIFICATION.md` §5.2 entries removed, `lithos_related` entry updated with the migration note, tool matrix + total count updated; cross-references in `mcp-roadmap-alignment.md`, `plans/final-architecture-guardrails.md`, and `plans/lcma-design.md` rewired. Archived plan docs (`plans/archive/*`) left alone.

## Test plan
- [x] `make check` — 1000 unit tests pass, no regressions.
- [x] `make test-integration` — 112 tests pass across the MCP SSE, CI conformance, and CLI contract suites.

## Dependencies
Based on `feat/82-composite-lithos-related` (PR #188). Rebase onto `main` after #188 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)