### PR TITLE
fix: lithos_search tags filter silently drops tags with colons (#191)

### DIFF
--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -380,20 +380,29 @@ class TantivyIndex:
         self.index.reload()
         searcher = self.index.searcher()
 
-        # Build query with filters
+        # Build query with filters. Tags and path_prefix are applied as
+        # post-filters below; including them in the Tantivy query string is
+        # unsafe because values may contain reserved characters (e.g. a colon
+        # in ``project:lithos-core`` is parsed as a field separator, which
+        # then raises a parse error and silently returns no results — see
+        # GitHub #191).
         query_parts = [query]
-        if tags:
-            for tag in tags:
-                query_parts.append(f"tags:{tag}")
         if author:
             query_parts.append(f"author:{author}")
 
         full_query = " AND ".join(f"({p})" for p in query_parts)
 
+        # When filtering by tags or path_prefix we may discard hits after
+        # the fact, so request extra results to reduce the chance of returning
+        # fewer than ``limit`` when matches do exist. Tantivy still caps this
+        # at the number of documents in the index.
+        effective_limit = limit * 5 if (tags or path_prefix) else limit
+
         try:
             parsed_query = self.index.parse_query(full_query, ["title", "content"])
-            results = searcher.search(parsed_query, limit).hits
-        except Exception:
+            results = searcher.search(parsed_query, effective_limit).hits
+        except Exception as exc:
+            logger.warning("Tantivy query parse/search failed: %s | query=%r", exc, full_query)
             return []
 
         search_results: list[SearchResult] = []
@@ -404,6 +413,16 @@ class TantivyIndex:
             # Apply path prefix filter
             if path_prefix and not str(doc_path).startswith(path_prefix):
                 continue
+
+            # Apply tags filter (AND across requested tags).
+            # Tags are stored as a single space-separated string via the
+            # ``en_stem`` tokenizer; the stored field preserves the original
+            # input, so we can compare tag values verbatim.
+            if tags:
+                doc_tags_raw = doc.get_first("tags") or ""
+                doc_tag_set = set(str(doc_tags_raw).split())
+                if not all(t in doc_tag_set for t in tags):
+                    continue
 
             # Generate snippet from content
             content = doc.get_first("content") or ""
@@ -422,6 +441,9 @@ class TantivyIndex:
                     is_stale=_compute_is_stale(expires_at_str),
                 )
             )
+
+            if len(search_results) >= limit:
+                break
 
         return search_results
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -161,6 +161,70 @@ class TestTantivyIndex:
         assert results[0].id == doc1.id
 
     @pytest.mark.asyncio
+    async def test_search_with_tag_containing_colon(
+        self, knowledge_manager: KnowledgeManager, search_engine: SearchEngine
+    ):
+        """Regression for #191: tags with colons (e.g. ``project:foo``) must
+        filter correctly instead of silently returning no results."""
+        target = (
+            await knowledge_manager.create(
+                title="Knowledge graph construction",
+                content="Notes on building a knowledge graph from wiki-links.",
+                agent="agent",
+                tags=["project:lithos-core", "priority:high"],
+            )
+        ).document
+        other = (
+            await knowledge_manager.create(
+                title="Unrelated document",
+                content="Notes on building a knowledge graph from wiki-links.",
+                agent="agent",
+                tags=["project:other-project"],
+            )
+        ).document
+        search_engine.index_document(target)
+        search_engine.index_document(other)
+
+        results = search_engine.full_text_search("knowledge graph", tags=["project:lithos-core"])
+        result_ids = {r.id for r in results}
+
+        assert target.id in result_ids
+        assert other.id not in result_ids
+
+    @pytest.mark.asyncio
+    async def test_search_tag_filter_requires_all_tags(
+        self, knowledge_manager: KnowledgeManager, search_engine: SearchEngine
+    ):
+        """Multiple tag filters behave as AND, including tags with colons."""
+        match = (
+            await knowledge_manager.create(
+                title="Both tags match",
+                content="Content describing a topic of interest.",
+                agent="agent",
+                tags=["project:lithos-core", "priority:high"],
+            )
+        ).document
+        missing_priority = (
+            await knowledge_manager.create(
+                title="Only project tag",
+                content="Content describing a topic of interest.",
+                agent="agent",
+                tags=["project:lithos-core"],
+            )
+        ).document
+        search_engine.index_document(match)
+        search_engine.index_document(missing_priority)
+
+        results = search_engine.full_text_search(
+            "topic of interest",
+            tags=["project:lithos-core", "priority:high"],
+        )
+        result_ids = {r.id for r in results}
+
+        assert match.id in result_ids
+        assert missing_priority.id not in result_ids
+
+    @pytest.mark.asyncio
     async def test_search_no_results(self, search_engine: SearchEngine):
         """Search with no matches returns empty list."""
         results = search_engine.full_text_search("xyznonexistentterm123")


### PR DESCRIPTION
## Summary

Fixes #191. `lithos_search(tags=[\"project:lithos-core\"])` silently returned `[]` because tags were appended to the Tantivy query string as `tags:<value>`, and any colon inside `<value>` was parsed as a second field separator. That raised a `parse_query` error, which was swallowed by a bare `except Exception: return []`.

This affected *any* tag containing a colon, including the common conventions `project:*`, `priority:*`, etc. `lithos_list` and `lithos_retrieve` were unaffected (they use a different code path).

## Approach

Option A from the issue — apply tag filtering as a post-filter in `TantivyIndex.search()`, mirroring how `path_prefix` already works. This avoids every tokenizer/parser pitfall and is consistent with the existing filter pipeline.

- `tags` and `path_prefix` are now applied against the stored `tags` / `path` fields after Tantivy returns hits.
- Because post-filtering can discard hits, the Tantivy fetch is widened by 5× when either filter is in play; the result list is still capped at the caller's `limit`.
- The previously silent `except Exception` now logs a warning with the offending query so future query-parse regressions are visible.

## Test plan

- [x] `uv run pytest tests/test_search.py -q` — 57 passed
- [x] `uv run pytest -m "not integration" tests/ -q` — 1002 passed, 322 deselected
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pyright src/` — 0 errors
- [x] New regression test: `test_search_with_tag_containing_colon` — verifies `tags=[\"project:lithos-core\"]` returns the tagged doc and excludes the non-tagged doc
- [x] New regression test: `test_search_tag_filter_requires_all_tags` — verifies AND semantics across multiple colon-bearing tags

Closes #191.