### PR TITLE
docs: group lithos_write parameters by role (closes #135)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -288,21 +288,51 @@ Normative contract references for the write path:
 Create or update a knowledge file.
 
 **Arguments:**
+
+Parameters are flat at the MCP boundary but grouped below by role to aid discoverability. The grouping is documentation only and mirrors the canonical field taxonomy in `unified-write-contract.md`.
+
+*Core (required):*
+
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `title` | string | Yes | Title of the knowledge item |
 | `content` | string | Yes | Markdown content (without frontmatter) |
 | `agent` | string | Yes | Your agent identifier |
+
+*Identity & metadata:*
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | string | No | UUID to update existing; omit to create new |
 | `tags` | string[] | No | List of tags |
 | `confidence` | float | No | Confidence score 0-1 (default: 1.0) |
 | `path` | string | No | Subdirectory path (e.g., "procedures") |
-| `id` | string | No | UUID to update existing; omit to create new |
-| `source_task` | string | No | Task ID or provenance note (stored as `source` in frontmatter) |
+
+*Provenance:*
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
 | `source_url` | string | No | Canonical URL provenance (http/https), dedup key after normalization. Pass `""` to clear on update. |
 | `derived_from_ids` | string[] | No | Canonical declared lineage (UUIDs). On create: `null`/omit stores `[]`. On update: `null`/omit preserves existing, `[]` clears, non-empty replaces. Self-references rejected. |
+| `source_task` | string | No | Task ID or provenance note (stored as `source` in frontmatter) |
+
+*Freshness:*
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
 | `ttl_hours` | float | No | Relative freshness window; converted to `expires_at` |
 | `expires_at` | string | No | Absolute ISO datetime freshness deadline |
+
+*Concurrency:*
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
 | `expected_version` | int | No | Optimistic-locking guard for updates; ignored on create |
+
+*LCMA:*
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
 | `schema_version` | int | No | LCMA schema version (default: 1 on create). Preserved on update if omitted. |
 | `namespace` | string | No | LCMA namespace. Persisted only when explicitly passed; derived from path at read time otherwise. |
 | `access_scope` | enum | No | `shared` \| `task` \| `agent_private` (default: `shared` on create). `task` requires `source_task`. |

--- a/docs/plans/unified-write-contract.md
+++ b/docs/plans/unified-write-contract.md
@@ -207,4 +207,24 @@ Write and batch paths are instrumented through OTEL foundation (`telemetry.py`, 
 
 ## API Ergonomics Follow-up
 
-The pre-1.0 interface may expose many optional write parameters. A follow-up API cleanup can introduce grouped objects (for example `provenance`, `freshness`, `lcma`) without changing on-disk semantics defined here.
+The pre-1.0 interface exposes many optional write parameters. Two options were considered:
+
+1. **Grouped request objects** at the MCP boundary (`provenance`, `freshness`, `lcma`).
+2. **Grouped documentation only** — keep the flat parameter surface, but introduce section headers in the tool docstring and spec tables mirroring the same taxonomy.
+
+Phase 8 is scoped to **option 2**. Rationale:
+
+- The primary caller is an MCP agent reading a flat tool schema. Nested object params tend to raise argument-construction errors in tool-use rather than reduce them.
+- The flat shape does not prevent any invariant that the canonical field contract (this document) already enforces in the manager layer — grouping would be purely cosmetic.
+- A breaking change to every caller and every conformance test is disproportionate to the ergonomic delta.
+
+The canonical taxonomy used in docs and the `lithos_write` docstring is:
+
+- **Core (required):** `title`, `content`, `agent`
+- **Identity & metadata:** `id`, `tags`, `confidence`, `path`
+- **Provenance:** `source_url`, `derived_from_ids`, `source_task`
+- **Freshness:** `ttl_hours`, `expires_at`
+- **Concurrency:** `expected_version`, and the batch-only `if_match_updated_at` / `if_match_hash`
+- **LCMA:** `schema_version`, `namespace`, `access_scope`, `note_type`, `status`, `summaries`, `entities`
+
+Grouped request objects remain a possible post-1.0 addition, introduced **additively** (accepted alongside the flat params) rather than as a replacement, and only if pressure from human-facing MCP client authors materialises.

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -950,30 +950,45 @@ class LithosServer:
         ) -> dict[str, Any]:
             """Create or update a knowledge file.
 
+            Args are grouped below by role. The grouping is documentation only —
+            all parameters remain flat at the MCP boundary. See
+            `docs/plans/unified-write-contract.md` for the normative field
+            contract.
+
             Args:
-                title: Title of the knowledge item
-                content: Markdown content (without frontmatter)
-                agent: Your agent identifier
+                title: Title of the knowledge item.
+                content: Markdown content (without frontmatter).
+                agent: Your agent identifier.
+
+                --- Identity & metadata ---
+                id: UUID to update existing; omit to create new.
                 tags: List of tags. On update: null/omit preserves existing; [] clears
                     all tags; non-empty list replaces.
                 confidence: Confidence score 0-1 (default: 1.0 on create). On update:
                     null/omit preserves existing; float sets new value.
-                path: Subdirectory path (e.g., "procedures")
-                id: UUID to update existing; omit to create new
-                source_task: Task ID this knowledge came from
+                path: Subdirectory path (e.g., "procedures").
+
+                --- Provenance ---
                 source_url: URL provenance for this knowledge. On update: null/omit
                     preserves existing; "" clears; string sets new value.
                 derived_from_ids: List of source document UUIDs this note was derived
                     from. On update: null/omit preserves existing; [] clears;
                     non-empty list replaces.
+                source_task: Task ID this knowledge came from.
+
+                --- Freshness ---
                 ttl_hours: Time-to-live in hours from now. Computes expires_at.
                     Mutually exclusive with expires_at.
                 expires_at: Absolute ISO 8601 expiry datetime. On update: null/omit
                     preserves existing; "" clears; ISO string sets new value.
                     Mutually exclusive with ttl_hours.
+
+                --- Concurrency ---
                 expected_version: If provided on update, reject with version_conflict if the
                     document's current version differs. Omit to skip version checking.
                     On create, this parameter is silently ignored.
+
+                --- LCMA ---
                 schema_version: LCMA schema version (default 1 on create).
                 namespace: LCMA namespace. Persisted only if explicitly passed;
                     derived at read time otherwise.


### PR DESCRIPTION
## Summary

Scopes Phase 8 API ergonomics cleanup (#135) down to documentation grouping only. No code behaviour changes, no signature changes, no breaking change for existing callers.

After reconsidering the original proposal, grouped request objects at the MCP boundary (`provenance`, `freshness`, `lcma`) would mostly hurt the primary caller — MCP agents handle flat scalar tool schemas more reliably than nested objects — while costing a migration across every caller and every conformance test. The grouping also does not enforce any invariant the manager layer doesn't already enforce via the canonical write contract.

This PR keeps the flat parameter surface but mirrors the same canonical taxonomy in three surfaces so it stays consistent:

- **`src/lithos/server.py`** — `lithos_write` docstring now carries `--- Identity & metadata ---`, `--- Provenance ---`, `--- Freshness ---`, `--- Concurrency ---`, `--- LCMA ---` section dividers. Signature is unchanged.
- **`docs/SPECIFICATION.md`** — the single arguments table is split into sub-tables under the same section headings (Core required, then the five groups).
- **`docs/plans/unified-write-contract.md`** — the \"API Ergonomics Follow-up\" section now records the decision, the rationale, the canonical taxonomy, and leaves grouped objects on the backlog as an *additive* post-1.0 option contingent on human-facing MCP-client pain materialising (rather than a breaking replacement).

## Taxonomy (applied identically across all three surfaces)

- **Core (required):** `title`, `content`, `agent`
- **Identity & metadata:** `id`, `tags`, `confidence`, `path`
- **Provenance:** `source_url`, `derived_from_ids`, `source_task`
- **Freshness:** `ttl_hours`, `expires_at`
- **Concurrency:** `expected_version` (+ batch-only `if_match_updated_at` / `if_match_hash` per the write contract)
- **LCMA:** `schema_version`, `namespace`, `access_scope`, `note_type`, `status`, `summaries`, `entities`

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run pytest tests/test_server.py tests/test_cli_contract.py -q` — 107 passed (MCP tool surface unchanged)
- [x] No parameter signatures, default values, or response envelopes changed

Closes #135.