### PR TITLE
fix(lcma): apply tag filter with AND semantics across scouts

### DIFF
--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -102,16 +102,20 @@ def _passes_access_scope(
 
 
 def _passes_tags_filter(meta_tags: list[str] | None, tags: list[str] | None) -> bool:
-    """Return True if the note has at least one of the requested tags.
+    """Return True if the note has *all* requested tags (AND semantics).
 
     ``tags=None`` (the common case) means "no filter" — all notes pass.
     Empty list also means "no filter".
+
+    AND semantics match the ``lithos_retrieve`` docstring and
+    ``KnowledgeManager.list_all``, giving agents a consistent filter
+    contract across the legacy and LCMA tool surfaces.
     """
     if not tags:
         return True
     if not meta_tags:
         return False
-    return any(t in meta_tags for t in tags)
+    return all(t in meta_tags for t in tags)
 
 
 def _passes_path_prefix(meta_path: object | None, path_prefix: str | None) -> bool:

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -1265,6 +1265,47 @@ class TestGlobalTagsAndPathFilters:
         )
         assert hits == []
 
+    @pytest.mark.asyncio
+    async def test_exact_alias_multi_tag_and_semantics(
+        self, seeded_km: KnowledgeManager, seeded_graph: KnowledgeGraph
+    ) -> None:
+        """Multi-tag filters use AND semantics (all tags must match)."""
+        # _ID1 has tags=["testing", "alpha"].
+        # Both tags present → pass.
+        hits = await scout_exact_alias(
+            "note-one",
+            seeded_graph,
+            seeded_km,
+            tags=["testing", "alpha"],
+        )
+        assert _ID1 in {c.node_id for c in hits}
+
+        # One matching, one missing → AND drops the note. Under the old
+        # OR behaviour this would incorrectly surface _ID1.
+        hits = await scout_exact_alias(
+            "note-one",
+            seeded_graph,
+            seeded_km,
+            tags=["testing", "nonexistent"],
+        )
+        assert _ID1 not in {c.node_id for c in hits}
+
+    @pytest.mark.asyncio
+    async def test_provenance_multi_tag_and_semantics(self, seeded_km: KnowledgeManager) -> None:
+        """Provenance scout applies AND across multiple requested tags.
+
+        _ID6 derives from _ID1. Seeding the scout with _ID6 surfaces its
+        source _ID1 (tags=["testing", "alpha"]).
+        """
+        hits = await scout_provenance([_ID6], seeded_km, tags=["testing", "alpha"])
+        assert _ID1 in {c.node_id for c in hits}
+
+        # Under the old OR behaviour the presence of "testing" would let
+        # _ID1 slip through; AND correctly drops it because "nonexistent"
+        # is not on the note.
+        hits = await scout_provenance([_ID6], seeded_km, tags=["testing", "nonexistent"])
+        assert _ID1 not in {c.node_id for c in hits}
+
 
 # ---------------------------------------------------------------------------
 # Explicit namespace override regression test


### PR DESCRIPTION
Closes #195.

## Summary

- `lithos_retrieve` documents `tags` as AND, but `_passes_tags_filter` in `src/lithos/lcma/scouts.py` used `any(...)` (OR).
- Every scout that post-filters was affected: graph, provenance, exact-alias, task-context, coactivation, source-url, freshness.
- `KnowledgeManager.list_all` already uses AND (`knowledge.py:1454`), so this fix also removes a contract drift between the legacy and LCMA tool surfaces.

## Change

One-line behaviour fix: `any(...)` → `all(...)` in `_passes_tags_filter`, with a clarified docstring.

## Tests

Added to `tests/test_scouts.py::TestGlobalTagsAndPathFilters`:
- `test_exact_alias_multi_tag_and_semantics` — a note tagged `["testing", "alpha"]` passes `tags=["testing", "alpha"]` and is dropped by `tags=["testing", "nonexistent"]`. Under the old OR behaviour the second case would have surfaced it.
- `test_provenance_multi_tag_and_semantics` — same shape, exercised through the provenance path.

Full unit suite (1004 tests) passes locally.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run pytest tests/ -m "not integration" -q` (1004 passed)