### PR TITLE
fix(lcma): snippet against full_content so title matches surface

### DIFF
--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -606,7 +606,10 @@ async def run_retrieve(
             try:
                 doc, _ = await knowledge.read(id=c.node_id)
                 meta = doc.metadata
-                snippet = generate_snippet(doc.content, query)
+                # Tantivy indexes ``doc.full_content`` (title prepended as
+                # H1), so snippet against the same string to match the
+                # ``lithos_search`` behaviour for title-only query matches.
+                snippet = generate_snippet(doc.full_content, query)
                 results.append(
                     {
                         "id": doc.id,

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -347,6 +347,73 @@ class TestStoredSalienceAffectsRetrieval:
         assert result_ids.index(_ID2) < result_ids.index(_ID1)
 
 
+class TestRetrieveSnippetParity:
+    """lithos_retrieve must produce snippets from the same string Tantivy
+    indexes so title-only matches surface the matching term.
+
+    Regression guard for #196.
+    """
+
+    @pytest.mark.asyncio
+    async def test_snippet_includes_title_only_matches(
+        self,
+        seeded_config: LithosConfig,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        stats_store: StatsStore,
+    ) -> None:
+        kp = seeded_config.storage.knowledge_path
+        nid = "11111111-2222-4333-4444-555555555555"
+        note = fm.Post(
+            "# Quantum Title Match\n\nBody talks only about pottery and lemons.",
+            id=nid,
+            title="Quantum Title Match",
+            author="agent-alpha",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            tags=["testing"],
+            access_scope="shared",
+            note_type="observation",
+        )
+        (kp / "quantum-title.md").write_text(fm.dumps(note))
+        km = KnowledgeManager(seeded_config)  # fresh scan picks the note up
+
+        from lithos.search import SearchResult
+
+        hit = [
+            SearchResult(
+                id=nid,
+                score=0.9,
+                title="Quantum Title Match",
+                snippet="tantivy-indexed-snippet-ignored",
+                path="quantum-title.md",
+            ),
+        ]
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=hit),
+            patch.object(seeded_search, "full_text_search", return_value=hit),
+        ):
+            result = await run_retrieve(
+                query="Quantum",
+                search=seeded_search,
+                knowledge=km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        row = next(r for r in result["results"] if r["id"] == nid)
+        # Under the old behaviour (snippet against doc.content only) the
+        # query term never appears and the snippet falls back to the
+        # opening of the body. With full_content the title is included.
+        assert "Quantum" in row["snippet"]
+
+
 # ---------------------------------------------------------------------------
 # compute_temperature
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #196.

## Summary

`lithos_retrieve` generated snippets from `doc.content` (body only), but Tantivy indexes `doc.full_content` (title prepended as an H1, see `KnowledgeDocument.full_content` in `src/lithos/knowledge.py:408-410`). A query that only matched in the title produced a useful snippet via `lithos_search` but an unrelated one via `lithos_retrieve`, even though the two tools are documented with a compatible result schema.

## Change

`src/lithos/lcma/retrieve.py:609` now snippets against `doc.full_content` instead of `doc.content`, with a comment explaining the coupling.

## Tests

New regression class `TestRetrieveSnippetParity` in `tests/test_retrieve.py`:
- Seeds a note titled "Quantum Title Match" whose body does *not* contain "Quantum".
- Patches both search backends to surface that note.
- Asserts the emitted snippet contains "Quantum". Under the old behaviour the snippet would fall back to the opening of the body.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run pytest tests/test_retrieve.py tests/test_lcma_retrieve_integration.py -q` (56 passed)