### PR TITLE
fix(list): push tags/author/path_prefix into FTS for content_query

### DIFF
--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -43,6 +43,7 @@ from lithos.knowledge import (
     VALID_NOTE_TYPES,
     VALID_STATUSES,
     KnowledgeManager,
+    _normalize_datetime,
     _UnsetType,
 )
 from lithos.lcma.migrations import MigrationRegistry, run_migrations
@@ -59,6 +60,13 @@ from lithos.telemetry import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Practical upper bound for ``lithos_list(content_query=...)``. Tantivy
+# returns up to this many hits before Python-side filters run. A million
+# matches from a single FTS query would already be degenerate; at that
+# point the caller should tighten the query, not ask for more results.
+_CONTENT_QUERY_FTS_CAP = 1_000_000
 
 
 class LithosServer:
@@ -2156,12 +2164,13 @@ class LithosServer:
                 limit: Max results (default: 50)
                 offset: Pagination offset
                 title_contains: Filter by case-insensitive substring match on title
-                content_query: Filter by full-text search query (Tantivy). When
-                    provided the entire base-filtered set is searched in-memory,
-                    so results and ``total`` are always correct across pages.
-                    full_text_search is called with a limit equal to the total
-                    number of base-filtered documents so no matches are silently
-                    dropped.
+                content_query: Filter by full-text search query (Tantivy).
+                    Tantivy-native filters (``tags``, ``author``,
+                    ``path_prefix``) are pushed down into the search query so
+                    ranking runs over the already-filtered candidate set,
+                    which is necessary for correctness under ranking pressure
+                    (see #194). ``since`` and ``title_contains`` are applied
+                    against the metadata cache after ranking.
 
             Returns:
                 Dict with items list and total count
@@ -2176,11 +2185,62 @@ class LithosServer:
                 if since:
                     since_dt = datetime.fromisoformat(since)
 
-                if title_contains is not None or content_query is not None:
-                    # When post-fetch filters are active we must fetch the full
-                    # base-filtered set first; filtering after pagination would
-                    # miss docs on earlier pages and produce wrong totals.
-                    # Step 1: get total count with limit=0 (returns count, no docs).
+                if content_query is not None:
+                    # Push the Tantivy-native filters into the search call so
+                    # ranking runs over the filtered candidate set. Using a
+                    # global ranked window and then intersecting (the prior
+                    # approach) silently dropped matches when filtered docs
+                    # ranked deep globally — see #194.
+                    try:
+                        fts_results = await asyncio.to_thread(
+                            self.search.full_text_search,
+                            query=content_query,
+                            limit=_CONTENT_QUERY_FTS_CAP,
+                            tags=tags,
+                            author=author,
+                            path_prefix=path_prefix,
+                        )
+                    except SearchBackendError as exc:
+                        return {
+                            "status": "error",
+                            "code": "search_backend_error",
+                            "message": f"Full-text search failed: {exc}",
+                        }
+
+                    # Apply the filters Tantivy doesn't handle: ``since`` and
+                    # ``title_contains``. Consult the metadata cache so we
+                    # don't incur a disk read per candidate.
+                    matching_ids: list[str] = []
+                    for r in fts_results:
+                        cached = self.knowledge.get_cached_meta(r.id)
+                        if cached is None:
+                            continue
+                        if since_dt is not None:
+                            cached_updated = _normalize_datetime(cached.updated_at)
+                            if cached_updated < since_dt:
+                                continue
+                        if (
+                            title_contains is not None
+                            and title_contains.lower() not in (cached.title or "").lower()
+                        ):
+                            continue
+                        matching_ids.append(r.id)
+
+                    total = len(matching_ids)
+                    page_ids = matching_ids[offset : offset + limit]
+                    docs = []
+                    for doc_id in page_ids:
+                        try:
+                            doc, _ = await self.knowledge.read(id=doc_id)
+                            docs.append(doc)
+                        except Exception:
+                            # Cache can briefly lag the filesystem during
+                            # reconcile; skipping mirrors list_all's behaviour.
+                            continue
+                elif title_contains is not None:
+                    # ``title_contains`` has no Tantivy-backed fast path; fall
+                    # back to list_all and filter in memory. Tracked in #201
+                    # for a metadata-cache-only variant.
                     _, total_base = await self.knowledge.list_all(
                         path_prefix=path_prefix,
                         tags=tags,
@@ -2189,7 +2249,6 @@ class LithosServer:
                         limit=0,
                         offset=0,
                     )
-                    # Step 2: fetch all base-filtered docs for in-memory filtering.
                     if total_base > 0:
                         all_docs, _ = await self.knowledge.list_all(
                             path_prefix=path_prefix,
@@ -2201,30 +2260,7 @@ class LithosServer:
                         )
                     else:
                         all_docs = []
-
-                    if title_contains is not None:
-                        all_docs = [
-                            d for d in all_docs if title_contains.lower() in d.title.lower()
-                        ]
-
-                    if content_query is not None:
-                        try:
-                            fts_results = await asyncio.to_thread(
-                                self.search.full_text_search,
-                                query=content_query,
-                                # Use total_base as the cap so we never silently
-                                # truncate matches from the base-filtered set.
-                                limit=max(total_base, 1),
-                            )
-                            fts_ids = {r.id for r in fts_results}
-                            all_docs = [d for d in all_docs if d.id in fts_ids]
-                        except SearchBackendError as exc:
-                            return {
-                                "status": "error",
-                                "code": "search_backend_error",
-                                "message": f"Full-text search failed: {exc}",
-                            }
-
+                    all_docs = [d for d in all_docs if title_contains.lower() in d.title.lower()]
                     total = len(all_docs)
                     docs = all_docs[offset : offset + limit]
                 else:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -634,6 +635,93 @@ class TestKnowledgeToolWorkflow:
             | {i["id"] for i in page3["items"]}
         )
         assert all_returned_ids == set(widget_ids)
+
+    @pytest.mark.asyncio
+    async def test_lithos_list_content_query_pushes_filters_to_tantivy(self, server: LithosServer):
+        """content_query must push tags/author/path_prefix into full_text_search
+        so ranking runs over the filtered candidate set. Regression guard for
+        #194, where a global-then-intersect strategy silently dropped matches
+        when filtered docs ranked deep globally.
+        """
+        await server.knowledge.create(
+            title="Tagged Doc",
+            content="payload about widgets",
+            tags=["target"],
+            agent="agent",
+        )
+        tool = await server.mcp.get_tool("lithos_list")
+
+        captured: dict[str, object] = {}
+
+        def _capture(**kwargs: object) -> list[object]:
+            captured.update(kwargs)
+            return []
+
+        with patch.object(server.search, "full_text_search", side_effect=_capture):
+            await tool.fn(
+                content_query="widgets",
+                tags=["target"],
+                author="someone",
+                path_prefix="notes/",
+            )
+
+        assert captured.get("tags") == ["target"]
+        assert captured.get("author") == "someone"
+        assert captured.get("path_prefix") == "notes/"
+        # The limit must be a large cap, not the base-filtered count —
+        # pegging the limit to the base set was the root cause of #194.
+        assert isinstance(captured.get("limit"), int)
+        assert captured["limit"] >= 1000
+
+    @pytest.mark.asyncio
+    async def test_lithos_list_content_query_applies_since_and_title_contains(
+        self, server: LithosServer
+    ):
+        """``since`` and ``title_contains`` have no Tantivy-backed filter and
+        are applied post-rank against the metadata cache. Make sure both
+        drop non-matching hits.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        old = (
+            await server.knowledge.create(
+                title="Alpha Widget",
+                content="payload",
+                agent="agent",
+            )
+        ).document
+        new = (
+            await server.knowledge.create(
+                title="Beta Widget",
+                content="payload",
+                agent="agent",
+            )
+        ).document
+
+        # Backdate ``old`` so ``since`` filter excludes it.
+        old_meta = server.knowledge._meta_cache[old.id]
+        server.knowledge._meta_cache[old.id] = replace(
+            old_meta, updated_at=datetime.now(timezone.utc) - timedelta(days=30)
+        )
+
+        hits = [
+            SimpleNamespace(id=old.id),
+            SimpleNamespace(id=new.id),
+        ]
+        tool = await server.mcp.get_tool("lithos_list")
+
+        # ``since`` drops the backdated doc.
+        with patch.object(server.search, "full_text_search", return_value=hits):
+            r = await tool.fn(
+                content_query="payload",
+                since=(datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+            )
+        assert {i["id"] for i in r["items"]} == {new.id}
+
+        # ``title_contains`` drops the non-matching title.
+        with patch.object(server.search, "full_text_search", return_value=hits):
+            r = await tool.fn(content_query="payload", title_contains="alpha")
+        assert {i["id"] for i in r["items"]} == {old.id}
 
     @pytest.mark.asyncio
     async def test_lithos_list_content_query_search_backend_error(self, server: LithosServer):


### PR DESCRIPTION
Closes #194.

## Summary

`lithos_list(content_query=…)` was performing a global Tantivy search with `limit=total_base` (the size of the already-filtered base set) and then intersecting the hits with the filtered set. Because Tantivy ranks globally, filtered docs that ranked deep globally fell outside the limit window and were silently dropped.

## Change

Push the Tantivy-native filters (`tags`, `author`, `path_prefix`) into `full_text_search` so ranking runs over the filtered candidate set:

```python
fts_results = await asyncio.to_thread(
    self.search.full_text_search,
    query=content_query,
    limit=_CONTENT_QUERY_FTS_CAP,   # 1_000_000 — practical upper bound
    tags=tags,
    author=author,
    path_prefix=path_prefix,
)
```

`since` and `title_contains` are applied post-rank against the in-memory metadata cache (no disk reads for non-page items). This also removes the prior O(N) base-set disk read that Review 2 flagged as a memory-spike risk.

`title_contains` without `content_query` still uses the existing `list_all` fetch path (tracked separately in #201 for a metadata-cache-only variant).

## Tests

- `test_lithos_list_content_query_pushes_filters_to_tantivy` — asserts `tags` / `author` / `path_prefix` / `limit` are forwarded to `full_text_search`. Would fail under the old limit=total_base behaviour.
- `test_lithos_list_content_query_applies_since_and_title_contains` — exercises post-rank filtering for both `since` and `title_contains`.

The existing `test_lithos_list_content_query` happy-path test and the pagination tests for `title_contains` still pass.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run pytest tests/ -m "not integration"` (1002 passed)
- [x] `uv run pytest tests/test_server.py` (99 passed)