### PR TITLE
fix(dx): correct uv commands in README and reindex stats key

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,29 +93,30 @@ claude mcp add --transport sse lithos http://localhost:8765/sse
 ## Development Commands
 
 ```bash
-# Install dependencies (uses uv)
-uv sync --extra dev
+# Install dependencies (uses uv; the ``dev`` dependency group is installed
+# by default via uv, so no extra flag is required).
+uv sync
 
 # Run unit tests
-uv run --extra dev pytest -m "not integration" tests/ -q
+uv run pytest -m "not integration" tests/ -q
 
 # Run integration tests
-uv run --extra dev pytest -m integration tests/ -q
+uv run pytest -m integration tests/ -q
 
 # Run all tests with coverage
-uv run --extra dev pytest tests/ --cov=lithos --cov-report=xml
+uv run pytest tests/ --cov=lithos --cov-report=xml
 
 # Lint
-uv run --extra dev ruff check .
+uv run ruff check .
 
 # Format check
-uv run --extra dev ruff format --check src/ tests/
+uv run ruff format --check src/ tests/
 
 # Type check
-uv run --extra dev pyright src/
+uv run pyright src/
 
 # Auto-fix lint + format
-uv run --extra dev ruff check --fix . && uv run --extra dev ruff format src/ tests/
+uv run ruff check --fix . && uv run ruff format src/ tests/
 
 # Start server (stdio)
 uv run lithos serve

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -233,7 +233,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
 
         # Show stats
         stats = search.get_stats()
-        click.echo(f"Total chunks: {stats.get('chunks', 0)}")
+        click.echo(f"Total chunks: {stats.get('chroma_chunk_count', 0)}")
         click.echo(f"Graph nodes: {graph.node_count()}")
         click.echo(f"Graph edges: {graph.edge_count()}")
 


### PR DESCRIPTION
Closes #204.

## Summary

Two small developer-experience bugs a contributor hits on day one:

### 1. README ``uv`` commands were wrong

README advertised ``uv run --extra dev ...``, but ``pyproject.toml:48`` declares ``dev`` under ``[dependency-groups]``, not ``[project.optional-dependencies]``. ``--extra dev`` fails as written. Fixed by dropping the flag — uv installs groups by default — and updating ``uv sync --extra dev`` to plain ``uv sync``.

### 2. ``lithos reindex`` always printed ``Total chunks: 0``

``src/lithos/cli.py:236`` read ``stats.get('chunks', 0)`` but ``SearchEngine.get_stats()`` (``src/lithos/search.py:1310``) returns ``{"chroma_chunk_count": N}``. Silent key mismatch, always zero. Fixed.

### Note on the third item in #204 (stale ``coverage.xml``)

On investigation, ``coverage.xml`` is already in ``.gitignore`` and was never tracked in git history (``git log --all -- coverage.xml`` returns nothing). The file surfaced in local working copies but is not in the repo. No repo change needed.

## Test plan

- [x] ``uv run ruff check .`` — passes
- [x] ``uv run ruff format --check src/ tests/`` — passes
- [x] ``uv run pytest tests/test_cli.py tests/test_cli_contract.py -q`` — 11 passed
- [x] ``uv sync`` (without ``--extra dev``) installs correctly