### PR TITLE
fix(server): wrap search mutations in asyncio.to_thread

### DIFF
--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -775,7 +775,7 @@ class LithosServer:
                 try:
                     relative_path = file_path.relative_to(knowledge_path)
                     doc, _ = await self.knowledge.read(path=str(relative_path))
-                    self.search.index_document(doc)
+                    await asyncio.to_thread(self.search.index_document, doc)
                     self.graph.add_document(doc)
                     file_count += 1
                 except Exception as e:
@@ -907,13 +907,13 @@ class LithosServer:
                             )
 
                             await self.knowledge.delete(doc_id)
-                            self.search.remove_document(doc_id)
+                            await asyncio.to_thread(self.search.remove_document, doc_id)
                             self.graph.remove_document(doc_id)
                             self.graph.save_cache()
                     else:
                         is_new = not self.knowledge.get_id_by_path(relative_path)
                         doc = await self.knowledge.sync_from_disk(relative_path)
-                        self.search.index_document(doc)
+                        await asyncio.to_thread(self.search.index_document, doc)
                         self.graph.add_document(doc)
                         self.graph.save_cache()
 
@@ -1308,8 +1308,11 @@ class LithosServer:
                 assert doc is not None
                 warnings.extend(result.warnings)
 
-                # Update indices
-                self.search.index_document(doc)
+                # Update indices. ``index_document`` is wrapped in
+                # ``asyncio.to_thread`` so Tantivy commits and ChromaDB
+                # embedding don't block the event loop during concurrent
+                # reads — see #199.
+                await asyncio.to_thread(self.search.index_document, doc)
                 self.graph.add_document(doc)
                 self.graph.save_cache()
 
@@ -1446,7 +1449,7 @@ class LithosServer:
                         "message": f"Document not found: {id}",
                     }
 
-                self.search.remove_document(id)
+                await asyncio.to_thread(self.search.remove_document, id)
                 self.graph.remove_document(id)
                 self.graph.save_cache()
 
@@ -1541,12 +1544,12 @@ class LithosServer:
                     }
 
                 # Thread safety note: SearchManager read methods (full_text_search, semantic_search,
-                # hybrid_search) are wrapped in asyncio.to_thread() to avoid blocking the event loop.
-                # Concurrent reads via tantivy-py and ChromaDB are safe. Known risk: lithos_write
-                # calls index_document() synchronously without to_thread() — concurrent read+write
-                # is not protected by a lock. This is an existing limitation pre-LCMA; tracked for
-                # future hardening. ChromaDB model init race on ensure_embeddings_loaded() is
-                # mitigated by the existing warmup call at server startup.
+                # hybrid_search) and the mutating methods (index_document, remove_document) are
+                # all wrapped in asyncio.to_thread() so Tantivy commits and ChromaDB embedding
+                # don't block the event loop. Concurrent read+write is not protected by a lock,
+                # but tantivy-py and ChromaDB are thread-safe for these operations. ChromaDB
+                # model init race on ensure_embeddings_loaded() is mitigated by the existing
+                # warmup call at server startup.
                 if mode == "fulltext":
                     ft_results = await asyncio.to_thread(
                         self.search.full_text_search,

--- a/tests/test_async_search.py
+++ b/tests/test_async_search.py
@@ -114,3 +114,29 @@ class TestAsyncSearchNonBlocking:
         assert "self.search.full_text_search" in source
         assert "self.search.semantic_search" in source
         assert "self.search.hybrid_search" in source
+
+    @pytest.mark.asyncio
+    async def test_server_search_mutation_sites_use_to_thread(self) -> None:
+        """Regression guard for #199: ``lithos_write`` and the file-watcher
+        path used to call ``self.search.index_document()`` synchronously,
+        blocking the event loop for Tantivy commits and ChromaDB embeddings.
+
+        Greps the server source to ensure no direct (non-``to_thread``)
+        call to ``index_document`` / ``remove_document`` remains.
+        """
+        import inspect
+
+        from lithos import server
+
+        source = inspect.getsource(server)
+        for line in source.splitlines():
+            stripped = line.strip()
+            # Skip comments and inline references; only flag real call sites.
+            if stripped.startswith("#"):
+                continue
+            for method in ("index_document", "remove_document"):
+                if f"self.search.{method}(" in stripped:
+                    assert "asyncio.to_thread" in stripped, (
+                        f"Direct self.search.{method}() call — must be wrapped in "
+                        f"asyncio.to_thread (#199). Offending line: {stripped!r}"
+                    )


### PR DESCRIPTION
Closes #199.

## Summary

Reads in the search path were wrapped in ``asyncio.to_thread``, but ``lithos_write``, ``lithos_delete``, the file-watcher path, and the ``reindex`` helper all called ``self.search.index_document()`` / ``remove_document()`` synchronously. Tantivy commit + ChromaDB embedding ran on the event loop, blocking concurrent reads (and any other async task) for the duration of each write. The server comment itself acknowledged the risk:

> Known risk: ``lithos_write`` calls ``index_document()`` synchronously without ``to_thread()`` — concurrent read+write is not protected by a lock. This is an existing limitation pre-LCMA; tracked for future hardening.

With LCMA's MVP2 paths (enrich worker, edge upsert, coactivation bumps) driving more writes than the pre-LCMA workload, this is worth closing before the release.

## Change

Wrap every search mutation call site in ``asyncio.to_thread`` to match the read-path treatment. Five call sites covered:

| Site | File:line |
|---|---|
| Reindex loop | `server.py:770` |
| File-watcher delete | `server.py:902` |
| File-watcher create/update | `server.py:908` |
| ``lithos_write`` | `server.py:1304` |
| ``lithos_delete`` | `server.py:1441` |

Updated the thread-safety note in ``lithos_search`` so it reflects the new behaviour.

## Tests

- New ``test_server_search_mutation_sites_use_to_thread`` in ``tests/test_async_search.py`` — greps the server source and asserts any ``self.search.index_document`` / ``remove_document`` call on a non-comment line is inside an ``asyncio.to_thread`` wrap. Mirrors the existing ``test_server_search_call_sites_use_to_thread`` regression guard for reads.
- Full unit suite (1003 tests) passes.
- Full ``tests/test_server.py`` (97 tests) passes.

## Test plan

- [x] ``make lint``
- [x] ``make typecheck``
- [x] ``uv run pytest tests/ -m "not integration"`` — 1003 passed
- [x] ``uv run pytest tests/test_server.py`` — 97 passed
- [x] ``uv run pytest tests/test_async_search.py`` — 4 passed