### PR TITLE
feat: add metadata JSON field to tasks

### DIFF
--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     tags JSON,
     outcome TEXT,
-    completed_at TIMESTAMP
+    completed_at TIMESTAMP,
+    metadata JSON
 );
 
 -- Claims (with automatic expiry)
@@ -108,6 +109,7 @@ class Task:
     tags: list[str] = field(default_factory=list)
     outcome: str | None = None
     completed_at: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -146,6 +148,7 @@ class TaskStatus:
     title: str
     status: str
     claims: list[Claim]
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -220,6 +223,7 @@ class CoordinationService:
             await db.executescript(SCHEMA)
             await self._migrate_tasks_add_outcome(db)
             await self._migrate_tasks_add_completed_at(db)
+            await self._migrate_tasks_add_metadata(db)
             await db.commit()
         logger.info("coordination service initialized: db_path=%s", self.db_path)
 
@@ -240,6 +244,15 @@ class CoordinationService:
         if "completed_at" not in columns:
             await db.execute("ALTER TABLE tasks ADD COLUMN completed_at TIMESTAMP")
             logger.info("coordination.db migration applied: added tasks.completed_at")
+
+    @staticmethod
+    async def _migrate_tasks_add_metadata(db: aiosqlite.Connection) -> None:
+        """Add metadata column to existing tasks tables."""
+        cursor = await db.execute("PRAGMA table_info(tasks)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "metadata" not in columns:
+            await db.execute("ALTER TABLE tasks ADD COLUMN metadata JSON")
+            logger.info("coordination.db migration applied: added tasks.metadata")
 
     async def _get_db(self) -> aiosqlite.Connection:
         """Get database connection."""
@@ -423,8 +436,16 @@ class CoordinationService:
         agent: str,
         description: str | None = None,
         tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> str:
         """Create a new task.
+
+        Args:
+            title: Task title
+            agent: Creating agent identifier
+            description: Task description
+            tags: Task tags
+            metadata: Arbitrary JSON metadata dict (optional)
 
         Returns:
             Task ID
@@ -436,15 +457,16 @@ class CoordinationService:
 
         task_id = str(uuid.uuid4())
         tags_json = json.dumps(tags) if tags else None
+        metadata_json = json.dumps(metadata) if metadata is not None else None
         now = _format_datetime(datetime.now(timezone.utc))
 
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 """
-                INSERT INTO tasks (id, title, description, created_by, tags, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO tasks (id, title, description, created_by, tags, created_at, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (task_id, title, description, agent, tags_json, now),
+                (task_id, title, description, agent, tags_json, now, metadata_json),
             )
             await db.commit()
 
@@ -472,11 +494,16 @@ class CoordinationService:
                 with contextlib.suppress(json.JSONDecodeError):
                     tags = json.loads(row["tags"])
 
-            # outcome/completed_at may be absent on legacy rows (pre-migration
+            # outcome/completed_at/metadata may be absent on legacy rows (pre-migration
             # reads should not be possible, but defend against it defensively).
             row_keys = row.keys()
             outcome = row["outcome"] if "outcome" in row_keys else None
             completed_at_raw = row["completed_at"] if "completed_at" in row_keys else None
+
+            task_metadata: dict[str, Any] = {}
+            if "metadata" in row_keys and row["metadata"]:
+                with contextlib.suppress(json.JSONDecodeError):
+                    task_metadata = json.loads(row["metadata"])
 
             return Task(
                 id=row["id"],
@@ -488,6 +515,7 @@ class CoordinationService:
                 tags=tags,
                 outcome=outcome,
                 completed_at=_parse_datetime(completed_at_raw),
+                metadata=task_metadata,
             )
 
     @traced("lithos.coordination.update_task")
@@ -498,12 +526,15 @@ class CoordinationService:
         title: str | None = None,
         description: str | None = None,
         tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> bool:
         """Update mutable task metadata.
 
         Only updates fields that are not None (partial update pattern).
         Only open tasks can be updated; completed or cancelled tasks are
         treated as not found (consistent with complete_task behaviour).
+
+        To clear metadata entirely, pass an empty dict ``{}``.
 
         Returns:
             True if task was found, is open, and was updated; False otherwise
@@ -525,6 +556,9 @@ class CoordinationService:
         if tags is not None:
             sets.append("tags = ?")
             params.append(json.dumps(tags))
+        if metadata is not None:
+            sets.append("metadata = ?")
+            params.append(json.dumps(metadata))
 
         if not sets:
             # Nothing to update; check task exists and is open
@@ -690,7 +724,11 @@ class CoordinationService:
             rows = await cursor.fetchall()
 
             results: list[dict[str, Any]] = []
+            row_keys: list[str] | None = None
             for row in rows:
+                if row_keys is None:
+                    row_keys = list(row.keys())
+
                 task_tags: list[str] = []
                 if row["tags"]:
                     with contextlib.suppress(json.JSONDecodeError):
@@ -699,6 +737,11 @@ class CoordinationService:
                 # Filter by tags: task must contain all requested tags
                 if tags and not all(t in task_tags for t in tags):
                     continue
+
+                task_metadata: dict[str, Any] = {}
+                if "metadata" in row_keys and row["metadata"]:
+                    with contextlib.suppress(json.JSONDecodeError):
+                        task_metadata = json.loads(row["metadata"])
 
                 results.append(
                     {
@@ -709,6 +752,7 @@ class CoordinationService:
                         "created_by": row["created_by"],
                         "created_at": row["created_at"],
                         "tags": task_tags,
+                        "metadata": task_metadata,
                     }
                 )
 
@@ -726,6 +770,8 @@ class CoordinationService:
             task_id: Specific task ID, or None for all active tasks
             include_all: When True and task_id is None, include non-open tasks
         """
+        import json
+
         now = _format_datetime(datetime.now(timezone.utc))
 
         async with aiosqlite.connect(self.db_path) as db:
@@ -744,8 +790,12 @@ class CoordinationService:
 
             tasks = await cursor.fetchall()
             result: list[TaskStatus] = []
+            task_row_keys: list[str] | None = None
 
             for task in tasks:
+                if task_row_keys is None:
+                    task_row_keys = list(task.keys())
+
                 # Get active (non-expired) claims
                 claims_cursor = await db.execute(
                     """
@@ -767,12 +817,18 @@ class CoordinationService:
                     for row in claim_rows
                 ]
 
+                task_metadata: dict[str, Any] = {}
+                if "metadata" in task_row_keys and task["metadata"]:
+                    with contextlib.suppress(json.JSONDecodeError):
+                        task_metadata = json.loads(task["metadata"])
+
                 result.append(
                     TaskStatus(
                         id=task["id"],
                         title=task["title"],
                         status=task["status"],
                         claims=claims,
+                        metadata=task_metadata,
                     )
                 )
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2593,6 +2593,7 @@ class LithosServer:
             agent: str,
             description: str | None = None,
             tags: list[str] | None = None,
+            metadata: dict[str, Any] | None = None,
         ) -> dict[str, str]:
             """Create a new coordination task.
 
@@ -2601,6 +2602,7 @@ class LithosServer:
                 agent: Creating agent identifier
                 description: Task description
                 tags: Task tags
+                metadata: Arbitrary JSON metadata dict (optional)
 
             Returns:
                 Dict with task_id
@@ -2615,6 +2617,7 @@ class LithosServer:
                     agent=agent,
                     description=description,
                     tags=tags,
+                    metadata=metadata,
                 )
                 span.set_attribute("lithos.task_id", task_id)
 
@@ -2636,10 +2639,12 @@ class LithosServer:
             title: str | None = None,
             description: str | None = None,
             tags: list[str] | None = None,
+            metadata: dict[str, Any] | None = None,
         ) -> dict[str, Any]:
-            """Update mutable task metadata (title, description, tags).
+            """Update mutable task metadata (title, description, tags, metadata).
 
-            At least one of title, description, or tags must be provided.
+            At least one of title, description, tags, or metadata must be provided.
+            Pass an empty dict ``{}`` for metadata to clear it.
 
             Args:
                 task_id: Task ID to update
@@ -2647,15 +2652,16 @@ class LithosServer:
                 title: New task title (optional)
                 description: New task description (optional)
                 tags: New task tags (optional)
+                metadata: Arbitrary JSON metadata dict; pass {} to clear (optional)
 
             Returns:
                 Dict with success and message
             """
-            if title is None and description is None and tags is None:
+            if title is None and description is None and tags is None and metadata is None:
                 return {
                     "status": "error",
                     "code": "invalid_input",
-                    "message": "At least one of title, description, or tags must be provided",
+                    "message": "At least one of title, description, tags, or metadata must be provided",
                 }
 
             logger.info("lithos_task_update task=%s agent=%s", task_id, agent)
@@ -2670,6 +2676,7 @@ class LithosServer:
                     title=title,
                     description=description,
                     tags=tags,
+                    metadata=metadata,
                 )
                 span.set_attribute("lithos.success", updated)
 
@@ -3116,6 +3123,7 @@ class LithosServer:
                             "id": s.id,
                             "title": s.title,
                             "status": s.status,
+                            "metadata": s.metadata,
                             "claims": [
                                 {
                                     "agent": c.agent,

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -996,3 +996,166 @@ class TestTaskOutcomeMigration:
         assert task is not None
         assert task.outcome == "done"
         assert task.completed_at is not None
+
+
+class TestTaskMetadata:
+    """Tests for metadata JSON field on tasks (#215)."""
+
+    @pytest.mark.asyncio
+    async def test_create_task_with_metadata(self, coordination_service: CoordinationService):
+        """create_task(metadata=...) persists the metadata dict."""
+        meta = {"priority": "high", "source": "forge", "count": 42}
+        task_id = await coordination_service.create_task(
+            title="Task With Metadata",
+            agent="agent",
+            metadata=meta,
+        )
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == meta
+
+    @pytest.mark.asyncio
+    async def test_create_task_without_metadata_defaults_empty(
+        self, coordination_service: CoordinationService
+    ):
+        """Omitting metadata is backward-compatible — task.metadata is {}."""
+        task_id = await coordination_service.create_task(
+            title="Task Without Metadata",
+            agent="agent",
+        )
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_update_task_metadata(self, coordination_service: CoordinationService):
+        """update_task(metadata=...) replaces the stored metadata."""
+        task_id = await coordination_service.create_task(
+            title="Updatable Task",
+            agent="agent",
+            metadata={"initial": True},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id,
+            agent="agent",
+            metadata={"priority": "low", "revised": True},
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"priority": "low", "revised": True}
+
+    @pytest.mark.asyncio
+    async def test_update_task_metadata_clear(self, coordination_service: CoordinationService):
+        """Passing metadata={} clears the stored metadata."""
+        task_id = await coordination_service.create_task(
+            title="Task To Clear",
+            agent="agent",
+            metadata={"to_be": "cleared"},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id,
+            agent="agent",
+            metadata={},
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_includes_metadata(self, coordination_service: CoordinationService):
+        """list_tasks response dicts include the metadata field."""
+        meta = {"env": "test"}
+        task_id = await coordination_service.create_task(
+            title="Listed Task",
+            agent="agent",
+            metadata=meta,
+        )
+
+        tasks = await coordination_service.list_tasks()
+        task_dict = next((t for t in tasks if t["id"] == task_id), None)
+        assert task_dict is not None
+        assert "metadata" in task_dict
+        assert task_dict["metadata"] == meta
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_no_metadata_returns_empty_dict(
+        self, coordination_service: CoordinationService
+    ):
+        """Tasks created without metadata return {} in list_tasks, not null."""
+        task_id = await coordination_service.create_task(
+            title="No Meta Task",
+            agent="agent",
+        )
+
+        tasks = await coordination_service.list_tasks()
+        task_dict = next((t for t in tasks if t["id"] == task_id), None)
+        assert task_dict is not None
+        assert task_dict["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_includes_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        """get_task_status response includes metadata from the task."""
+        meta = {"sprint": 7, "team": "alpha"}
+        task_id = await coordination_service.create_task(
+            title="Status Task",
+            agent="agent",
+            metadata=meta,
+        )
+
+        statuses = await coordination_service.get_task_status(task_id)
+        assert len(statuses) == 1
+        assert statuses[0].metadata == meta
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_metadata_column(self, tmp_path):
+        """Simulate a pre-#215 coordination.db and confirm initialize() migrates it."""
+        db_path = tmp_path / "coordination.db"
+
+        # Build a legacy tasks table without metadata column.
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT DEFAULT 'open',
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON,
+                    outcome TEXT,
+                    completed_at TIMESTAMP
+                )
+                """
+            )
+            await db.execute(
+                "INSERT INTO tasks (id, title, created_by) VALUES (?, ?, ?)",
+                ("legacy-task-215", "Legacy", "legacy-agent"),
+            )
+            await db.commit()
+
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+        await service.initialize()
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("PRAGMA table_info(tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+
+        assert "metadata" in columns
+
+        # Legacy row returns {} for metadata (not null).
+        task = await service.get_task("legacy-task-215")
+        assert task is not None
+        assert task.metadata == {}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2327,3 +2327,170 @@ class TestHealthEndpoint:
             response = await server._health_endpoint(request)
 
         assert response.status_code == 503
+
+
+class TestTaskMetadataTool:
+    """Tests for metadata field in lithos_task_create, lithos_task_update, lithos_task_list, lithos_task_status (#215)."""
+
+    async def _call_task_create(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_create")
+        return await tool.fn(**kwargs)
+
+    async def _call_task_update(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_update")
+        return await tool.fn(**kwargs)
+
+    async def _call_task_list(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_list")
+        return await tool.fn(**kwargs)
+
+    async def _call_task_status(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_status")
+        return await tool.fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_task_create_with_metadata(self, server: LithosServer):
+        """lithos_task_create: metadata is stored and readable back via get_task."""
+        meta = {"priority": "high", "source": "mcp-tool-test"}
+        result = await self._call_task_create(
+            server,
+            title="Task With Metadata",
+            agent="test-agent",
+            metadata=meta,
+        )
+        assert "task_id" in result
+
+        task = await server.coordination.get_task(result["task_id"])
+        assert task is not None
+        assert task.metadata == meta
+
+    @pytest.mark.asyncio
+    async def test_task_create_no_metadata_returns_empty_dict(self, server: LithosServer):
+        """lithos_task_create: omitting metadata results in task.metadata == {}."""
+        result = await self._call_task_create(
+            server,
+            title="Task No Metadata",
+            agent="test-agent",
+        )
+        assert "task_id" in result
+
+        task = await server.coordination.get_task(result["task_id"])
+        assert task is not None
+        assert task.metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_task_update_metadata(self, server: LithosServer):
+        """lithos_task_update: metadata field is updated correctly."""
+        task_id = await server.coordination.create_task(
+            title="Update Meta Task",
+            agent="test-agent",
+            metadata={"old_key": "old_val"},
+        )
+
+        result = await self._call_task_update(
+            server,
+            task_id=task_id,
+            agent="test-agent",
+            metadata={"new_key": "new_val", "count": 99},
+        )
+        assert result["success"] is True
+
+        task = await server.coordination.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"new_key": "new_val", "count": 99}
+
+    @pytest.mark.asyncio
+    async def test_task_update_clear_metadata(self, server: LithosServer):
+        """lithos_task_update: passing {} clears metadata."""
+        task_id = await server.coordination.create_task(
+            title="Clear Meta Task",
+            agent="test-agent",
+            metadata={"to_be": "cleared"},
+        )
+
+        result = await self._call_task_update(
+            server,
+            task_id=task_id,
+            agent="test-agent",
+            metadata={},
+        )
+        assert result["success"] is True
+
+        task = await server.coordination.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_task_list_includes_metadata(self, server: LithosServer):
+        """lithos_task_list: response dicts include metadata field."""
+        meta = {"sprint": 3}
+        task_id = await server.coordination.create_task(
+            title="Listed Meta Task",
+            agent="test-agent",
+            metadata=meta,
+        )
+
+        result = await self._call_task_list(server)
+        task_dict = next((t for t in result["tasks"] if t["id"] == task_id), None)
+        assert task_dict is not None
+        assert "metadata" in task_dict
+        assert task_dict["metadata"] == meta
+
+    @pytest.mark.asyncio
+    async def test_task_list_no_metadata_returns_empty_dict(self, server: LithosServer):
+        """lithos_task_list: tasks without metadata return {} not null."""
+        task_id = await server.coordination.create_task(
+            title="No Meta Listed Task",
+            agent="test-agent",
+        )
+
+        result = await self._call_task_list(server)
+        task_dict = next((t for t in result["tasks"] if t["id"] == task_id), None)
+        assert task_dict is not None
+        assert task_dict["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_task_status_includes_metadata(self, server: LithosServer):
+        """lithos_task_status: response includes metadata field."""
+        meta = {"team": "forge", "issue": 215}
+        task_id = await server.coordination.create_task(
+            title="Status Meta Task",
+            agent="test-agent",
+            metadata=meta,
+        )
+
+        result = await self._call_task_status(server, task_id=task_id)
+        assert len(result["tasks"]) == 1
+        assert "metadata" in result["tasks"][0]
+        assert result["tasks"][0]["metadata"] == meta
+
+    @pytest.mark.asyncio
+    async def test_task_status_no_metadata_returns_empty_dict(self, server: LithosServer):
+        """lithos_task_status: tasks without metadata return {} not null."""
+        task_id = await server.coordination.create_task(
+            title="Status No Meta Task",
+            agent="test-agent",
+        )
+
+        result = await self._call_task_status(server, task_id=task_id)
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_task_update_metadata_only_no_other_fields_returns_error(
+        self, server: LithosServer
+    ):
+        """lithos_task_update: metadata=None with no other fields returns invalid_input."""
+        task_id = await server.coordination.create_task(
+            title="Guard Test Task",
+            agent="test-agent",
+        )
+
+        result = await self._call_task_update(
+            server,
+            task_id=task_id,
+            agent="test-agent",
+            # no fields at all
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"


### PR DESCRIPTION
## Summary

Adds a `metadata JSON` column to the `tasks` table, following the same pattern used for `metadata` on the `agents` table and the existing `outcome`/`completed_at` migration guards.

## Changes

### coordination.py
- Added `metadata JSON` column to the `tasks` table schema
- Added `_migrate_tasks_add_metadata()` migration guard (same pattern as `_migrate_tasks_add_outcome`)
- Updated `Task` dataclass: `metadata: dict[str, Any] = field(default_factory=dict)`
- Updated `TaskStatus` dataclass: `metadata: dict[str, Any] = field(default_factory=dict)`
- Updated `create_task()` to accept optional `metadata: dict[str, Any] | None`, serialised to JSON on write
- Updated `update_task()` to accept optional `metadata: dict[str, Any] | None`; pass `{}` to clear
- Updated `get_task()` to deserialise metadata on read (returns `{}` for legacy/null rows)
- Updated `list_tasks()` to include `metadata` in returned task dicts
- Updated `get_task_status()` to deserialise metadata and include in `TaskStatus`

### server.py
- Updated `lithos_task_create` tool to accept optional `metadata` dict parameter
- Updated `lithos_task_update` tool to accept optional `metadata` dict parameter (pass `{}` to clear); updated guard to include `metadata` in the required-field check
- Updated `lithos_task_status` response to include `metadata` field

### Tests
- `tests/test_coordination.py`: 9 new tests in `TestTaskMetadata` covering create-with-metadata, default-empty, update-metadata, clear-metadata (`{}`), list_tasks includes metadata, get_task_status includes metadata, and migration guard
- `tests/test_server.py`: 9 new tests in `TestTaskMetadataTool` covering all four MCP tools (create, update, list, status)

## Backward Compatibility

Existing tasks without a `metadata` column or with `NULL` metadata return `{}` (not null), both in the `Task` dataclass and in all MCP tool responses.

Closes #215