### PR TITLE
fix: log WARNING on slug_collision so the squatter is visible from logs

### DIFF
--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1262,8 +1262,7 @@ class LithosServer:
                     # response body.  Discovered in the 2026-05-02 staging
                     # incident.
                     logger.warning(
-                        "lithos_write slug_collision: agent=%s "
-                        "title=%.120s slug=%s existing_id=%s",
+                        "lithos_write slug_collision: agent=%s title=%.120s slug=%s existing_id=%s",
                         agent,
                         title,
                         exc.slug,

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1255,6 +1255,20 @@ class LithosServer:
                             summaries=summaries,
                         )
                 except SlugCollisionError as exc:
+                    # Log the collision so the squatting doc is visible from
+                    # ``docker logs lithos-*`` — clients are free to discard
+                    # ``existing_id`` from the response envelope, and without
+                    # this WARNING the only signal of the collision is the
+                    # response body.  Discovered in the 2026-05-02 staging
+                    # incident.
+                    logger.warning(
+                        "lithos_write slug_collision: agent=%s "
+                        "title=%.120s slug=%s existing_id=%s",
+                        agent,
+                        title,
+                        exc.slug,
+                        exc.existing_id,
+                    )
                     span.set_attribute("lithos.write_status", "slug_collision")
                     return {
                         "status": "slug_collision",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2104,6 +2104,39 @@ class TestSlugCollisionServerBoundary:
         assert result["warnings"] == []
 
     @pytest.mark.asyncio
+    async def test_write_slug_collision_emits_warning(
+        self, server: LithosServer, caplog
+    ):
+        """A slug collision must emit a WARNING with the squatting id so
+        operators can find the offending note from ``docker logs`` alone,
+        even when the client throws away ``existing_id`` from the
+        response envelope (2026-05-02 staging incident).
+        """
+        import logging
+
+        first = await self._call_write(
+            server, title="Squatter", content="First.", agent="influx"
+        )
+        assert first["status"] == "created"
+        existing_id = first["id"]
+
+        with caplog.at_level(logging.WARNING, logger="lithos.server"):
+            result = await self._call_write(
+                server, title="Squatter", content="Second.", agent="influx"
+            )
+
+        assert result["status"] == "slug_collision"
+        # The WARNING must carry enough breadcrumbs to find the squatter:
+        # status keyword, agent, slug, and the existing doc id.
+        warnings_text = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        )
+        assert "slug_collision" in warnings_text
+        assert "squatter" in warnings_text  # slug
+        assert existing_id in warnings_text
+        assert "agent=influx" in warnings_text
+
+    @pytest.mark.asyncio
     async def test_write_invalid_input_returns_canonical_envelope(self, server: LithosServer):
         """``invalid_input`` errors surface as ``status="invalid_input"``
         rather than ``status="error"`` plus a discriminator field.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2104,9 +2104,7 @@ class TestSlugCollisionServerBoundary:
         assert result["warnings"] == []
 
     @pytest.mark.asyncio
-    async def test_write_slug_collision_emits_warning(
-        self, server: LithosServer, caplog
-    ):
+    async def test_write_slug_collision_emits_warning(self, server: LithosServer, caplog):
         """A slug collision must emit a WARNING with the squatting id so
         operators can find the offending note from ``docker logs`` alone,
         even when the client throws away ``existing_id`` from the
@@ -2114,9 +2112,7 @@ class TestSlugCollisionServerBoundary:
         """
         import logging
 
-        first = await self._call_write(
-            server, title="Squatter", content="First.", agent="influx"
-        )
+        first = await self._call_write(server, title="Squatter", content="First.", agent="influx")
         assert first["status"] == "created"
         existing_id = first["id"]
 


### PR DESCRIPTION
## Summary

When ``lithos_write`` rejects a write with ``SlugCollisionError`` the server returned a structured response envelope but emitted **no log line**. If the client discards ``existing_id`` from the response (as influx did until its companion fix), the only signal of the collision lives on the client side and operators have no breadcrumb in ``docker logs lithos-*`` to find the squatting note.

This PR adds a single ``logger.warning`` at the catch site that names the agent, title, slug, and existing doc id. **No behaviour change** beyond logging.

## Why

Discovered in the **2026-05-02 staging incident**: arXiv paper ``2604.28197`` (``OmniRobotHome…``) was permanently dropped by influx because two existing notes squatted both the unsuffixed and the ``[arXiv …]`` suffixed slugs — but lithos's own logs showed only INFO-level ``lithos_write`` entries with nothing flagging the collision. Cross-correlating client and server required scraping the influx WARNING and matching it to lithos INFO entries by timestamp.

Companion PR in influx surfaces ``existing_id`` in the client-side WARNING: agent-lore/influx#30.

## Test plan

- [x] ``uv run pytest tests/test_server.py::TestSlugCollisionServerBoundary`` — 5/5 pass (4 existing + 1 new ``test_write_slug_collision_emits_warning``).
- [x] ``uv run ruff check`` clean on modified files.
- [ ] Verify in staging that the next slug collision shows up as a WARNING in ``docker logs lithos-staging`` with ``existing_id=…`` (post-merge).