### PR TITLE
fix(search): silence sentence_transformers progress bars

### DIFF
--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -639,7 +639,7 @@ collection.count()
 
     def health_check(self) -> None:
         """Probe the embedding model (warm-up / liveness). Raises on failure."""
-        self.model.encode(["health check"])  # result discarded; exercises model load
+        self.model.encode(["health check"], show_progress_bar=False)
 
     @property
     def client(self) -> ClientAPI:
@@ -690,7 +690,7 @@ collection.count()
             return 0
 
         # Generate embeddings
-        embeddings = self.model.encode(chunks).tolist()
+        embeddings = self.model.encode(chunks, show_progress_bar=False).tolist()
 
         # Prepare data for ChromaDB
         ids = [self._chunk_id(doc.id, i) for i in range(len(chunks))]
@@ -759,7 +759,7 @@ collection.count()
             List of semantic results (deduplicated by document)
         """
         # Generate query embedding
-        query_embedding = self.model.encode([query]).tolist()[0]
+        query_embedding = self.model.encode([query], show_progress_bar=False).tolist()[0]
 
         # Build where filter
         # where_filter not used - ChromaDB filtering done post-query


### PR DESCRIPTION
## Summary

- Pass `show_progress_bar=False` to all three `SentenceTransformer.encode()` call sites in `src/lithos/search.py` (`health_check`, `add_document`, `search`).
- Removes the tqdm `Batches: 100%|...|` lines that were being emitted to stderr on every encode call.

## Why

Inspecting the production `lithos` container's docker logs surfaced that 99% of non-`uvicorn.access` log volume was tqdm progress bars from the embedder. They are non-JSON, single-batch (so the bar is meaningless — it just goes 0%→100% on each encode), and mixed in with structured JSON log lines, which breaks log shippers that assume one-line JSON.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [ ] `make test` and `make test-integration`
- [ ] Manual smoke: bring up the container, write a doc and run a semantic search, confirm no `Batches:` lines appear in `docker logs`