### PR TITLE
feat(task_list): add with_claims flag to inline active claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **`lithos_task_list` `with_claims` flag.** When set to `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`, so existing payloads are unchanged. Lets list views avoid an N+1 of `lithos_task_status` calls. Implementation issues a single batched `WHERE task_id IN (...)` query rather than one per task.
+
 ### Changed
 
 - **`lithos_write` error envelopes are now canonical top-level statuses.** Each error code surfaces as `status="<code>"` (e.g. `status="slug_collision"`, `status="invalid_input"`) instead of `status="error"` plus a separate `code` field. Affects `slug_collision`, `invalid_input`, `content_too_large`, and `version_conflict`. `status="error"` is retained as a generic fallback. **MCP-boundary breaking change** — clients that dispatched on `(status, code)` need to dispatch on `status` alone. Permitted by the pre-1.0 compatibility policy in `SPECIFICATION.md §1.4`.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -706,8 +706,9 @@ List tasks with optional filters.
 | `status` | string | No | Filter by task status: `open`, `completed`, or `cancelled` |
 | `tags` | string[] | No | Filter to tasks containing all listed tags |
 | `since` | string | No | Filter by `created_at >= since` (ISO datetime) |
+| `with_claims` | boolean | No | When `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`. Use to avoid an N+1 of `lithos_task_status` calls when rendering a list view. |
 
-**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, tags }] }`
+**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, tags, metadata }] }`. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
 
 #### `lithos_task_status`
 Get task status and claims.

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -687,6 +687,7 @@ class CoordinationService:
         status: str | None = None,
         tags: list[str] | None = None,
         since: str | None = None,
+        with_claims: bool = False,
     ) -> list[dict[str, Any]]:
         """List tasks with optional filters.
 
@@ -695,9 +696,14 @@ class CoordinationService:
             status: Filter by status (open/completed/cancelled), or None for all
             tags: Filter by tags (task must have all specified tags)
             since: Filter by created_at >= this ISO datetime string
+            with_claims: When True, include each task's active (non-expired)
+                claims inline as a ``claims`` array. Defaults to False to
+                preserve the lightweight payload for callers that don't need
+                them.
 
         Returns:
-            List of task dicts with id, title, description, status, created_by, created_at, tags
+            List of task dicts with id, title, description, status, created_by,
+            created_at, tags, metadata, and (when with_claims) claims.
         """
         import json
 
@@ -756,7 +762,50 @@ class CoordinationService:
                     }
                 )
 
+            if with_claims and results:
+                claims_by_task = await self._fetch_active_claims_for(db, [r["id"] for r in results])
+                for task in results:
+                    task["claims"] = claims_by_task.get(task["id"], [])
+
             return results
+
+    async def _fetch_active_claims_for(
+        self,
+        db: aiosqlite.Connection,
+        task_ids: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetch active (non-expired) claims for a batch of task IDs.
+
+        Issues a single SQL query rather than one per task. Returns a dict
+        mapping task_id -> list of claim dicts in the same shape the
+        ``lithos_task_status`` MCP tool emits.
+        """
+        if not task_ids:
+            return {}
+
+        now = _format_datetime(datetime.now(timezone.utc))
+        placeholders = ",".join("?" for _ in task_ids)
+        cursor = await db.execute(
+            f"""
+            SELECT task_id, agent, aspect, expires_at
+            FROM claims
+            WHERE task_id IN ({placeholders}) AND expires_at > ?
+            """,
+            (*task_ids, now),
+        )
+        rows = await cursor.fetchall()
+
+        grouped: dict[str, list[dict[str, Any]]] = {tid: [] for tid in task_ids}
+        for row in rows:
+            expires_dt = _parse_datetime(row["expires_at"]) or datetime.now(timezone.utc)
+            grouped[row["task_id"]].append(
+                {
+                    "agent": row["agent"],
+                    "aspect": row["aspect"],
+                    "expires_at": expires_dt.isoformat(),
+                }
+            )
+        return grouped
 
     @traced("lithos.coordination.get_task_status")
     async def get_task_status(

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -3061,6 +3061,7 @@ class LithosServer:
             status: str | None = None,
             tags: list[str] | None = None,
             since: str | None = None,
+            with_claims: bool = False,
         ) -> dict[str, list[dict[str, Any]]]:
             """List tasks with optional filters.
 
@@ -3069,12 +3070,23 @@ class LithosServer:
                 status: Filter by status: "open", "completed", or "cancelled" (None = all)
                 tags: Filter by tags (task must have all specified tags)
                 since: Filter by created_at >= this ISO datetime string (e.g. "2024-01-01T00:00:00Z")
+                with_claims: When True, each task in the response includes its
+                    active (non-expired) claims inline as a ``claims`` array
+                    (same shape as ``lithos_task_status``). Defaults to False.
+                    Use to avoid an N+1 of ``lithos_task_status`` calls when
+                    rendering a list view that needs claim info.
 
             Returns:
-                Dict with tasks list containing id, title, description, status, created_by, created_at, tags
+                Dict with tasks list containing id, title, description, status,
+                created_by, created_at, tags, metadata, and (when with_claims) claims.
             """
             logger.info(
-                "lithos_task_list agent=%s status=%s tags=%s since=%s", agent, status, tags, since
+                "lithos_task_list agent=%s status=%s tags=%s since=%s with_claims=%s",
+                agent,
+                status,
+                tags,
+                since,
+                with_claims,
             )
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.task_list") as span:
@@ -3083,12 +3095,14 @@ class LithosServer:
                     span.set_attribute("lithos.agent", agent)
                 if status:
                     span.set_attribute("lithos.status", status)
+                span.set_attribute("lithos.with_claims", with_claims)
 
                 tasks = await self.coordination.list_tasks(
                     agent=agent,
                     status=status,
                     tags=tags,
                     since=since,
+                    with_claims=with_claims,
                 )
                 return {"tasks": tasks}
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -830,6 +830,61 @@ class TestListTasks:
         assert "tag1" in task["tags"]
         assert task["created_at"] is not None
 
+    @pytest.mark.asyncio
+    async def test_list_tasks_without_with_claims_omits_claims_field(
+        self, coordination_service: CoordinationService
+    ):
+        """By default list_tasks does not attach a claims field."""
+        task_id = await coordination_service.create_task(title="Plain", agent="agent")
+        await coordination_service.claim_task(task_id, "work", "agent")
+
+        tasks = await coordination_service.list_tasks()
+        task = next(t for t in tasks if t["id"] == task_id)
+        assert "claims" not in task
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_with_claims_inlines_active_claims(
+        self, coordination_service: CoordinationService
+    ):
+        """with_claims=True attaches the same claim shape lithos_task_status emits."""
+        claimed_id = await coordination_service.create_task(title="Claimed", agent="agent")
+        await coordination_service.claim_task(
+            claimed_id, "implementation", "worker-a", ttl_minutes=10
+        )
+        unclaimed_id = await coordination_service.create_task(title="Unclaimed", agent="agent")
+
+        tasks = await coordination_service.list_tasks(with_claims=True)
+        by_id = {t["id"]: t for t in tasks}
+
+        assert "claims" in by_id[claimed_id]
+        assert by_id[claimed_id]["claims"] == [
+            {
+                "agent": "worker-a",
+                "aspect": "implementation",
+                "expires_at": by_id[claimed_id]["claims"][0]["expires_at"],
+            }
+        ]
+        # And unclaimed tasks get an empty list, not a missing key.
+        assert by_id[unclaimed_id]["claims"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_with_claims_excludes_expired(
+        self, coordination_service: CoordinationService
+    ):
+        """Expired claims are filtered out, matching lithos_task_status semantics."""
+        task_id = await coordination_service.create_task(title="Expiry", agent="agent")
+        await coordination_service.claim_task(task_id, "work", "agent", ttl_minutes=10)
+
+        # Force-expire the claim by rewriting its expires_at directly.
+        past = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        async with aiosqlite.connect(coordination_service.db_path) as db:
+            await db.execute("UPDATE claims SET expires_at = ? WHERE task_id = ?", (past, task_id))
+            await db.commit()
+
+        tasks = await coordination_service.list_tasks(with_claims=True)
+        task = next(t for t in tasks if t["id"] == task_id)
+        assert task["claims"] == []
+
 
 class TestCoordinationStats:
     """Tests for coordination statistics."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2551,3 +2551,47 @@ class TestTaskMetadataTool:
         )
         assert result["status"] == "error"
         assert result["code"] == "invalid_input"
+
+
+class TestTaskListWithClaims:
+    """lithos_task_list `with_claims` flag at the MCP boundary."""
+
+    async def _call_task_list(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_list")
+        return await tool.fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_default_omits_claims_field(self, server: LithosServer):
+        """Existing callers see no claims key when with_claims is not passed."""
+        task_id = await server.coordination.create_task(title="No Claims Field", agent="test-agent")
+        await server.coordination.claim_task(task_id, "work", "test-agent")
+
+        result = await self._call_task_list(server)
+        task = next(t for t in result["tasks"] if t["id"] == task_id)
+        assert "claims" not in task
+
+    @pytest.mark.asyncio
+    async def test_with_claims_inlines_active_claims(self, server: LithosServer):
+        """with_claims=True returns the same claim shape as lithos_task_status."""
+        task_id = await server.coordination.create_task(
+            title="With Inline Claims", agent="test-agent"
+        )
+        await server.coordination.claim_task(task_id, "implementation", "worker-a", ttl_minutes=10)
+
+        list_result = await self._call_task_list(server, with_claims=True)
+        list_task = next(t for t in list_result["tasks"] if t["id"] == task_id)
+
+        status_tool = await server.mcp.get_tool("lithos_task_status")
+        status_result = await status_tool.fn(task_id=task_id)
+        status_claims = status_result["tasks"][0]["claims"]
+
+        assert list_task["claims"] == status_claims
+
+    @pytest.mark.asyncio
+    async def test_with_claims_unclaimed_returns_empty_list(self, server: LithosServer):
+        """Unclaimed tasks get claims=[], not a missing key."""
+        task_id = await server.coordination.create_task(title="Unclaimed", agent="test-agent")
+
+        result = await self._call_task_list(server, with_claims=True)
+        task = next(t for t in result["tasks"] if t["id"] == task_id)
+        assert task["claims"] == []


### PR DESCRIPTION
## Summary

Add an opt-in ``with_claims: bool = False`` parameter to ``lithos_task_list`` (and the underlying ``coordination.list_tasks``). When ``true``, each task in the response includes its active (non-expired) claims inline as a ``claims`` array — same shape as ``lithos_task_status`` returns. Default is ``false``, so existing payloads are unchanged.

Implementation does a single batched ``WHERE task_id IN (...)`` claims query for the visible result set rather than one per task.

## Why

Audit of the production lithos container's docker logs showed lithos-lens generating ~3,400 distinct MCP sessions/hour against the upstream lithos server. A large multiplier in that number is the dashboard's per-refresh fan-out: for every ``lithos_task_list`` call lens follows up with one ``lithos_task_status`` per visible task (up to ~25) just to attach claim info to the rendered rows. With this flag lens can collapse that to a single tool call per refresh.

A separate lithos-lens PR will pick this up once the flag lands.

## Spec change

``docs/SPECIFICATION.md`` updated to document the new argument and that, when ``with_claims=true``, each task in the response carries ``claims: [{ agent, aspect, expires_at }]``.

## Trade-off worth noting

Folding the claims join into ``lithos_task_list`` means callers can now hit the ``with_claims=true`` path against an unfiltered list of thousands of tasks and get a thousand-row claims read in one shot. The previous per-task ``lithos_task_status`` path made that cost obvious. Default is ``false`` to keep the lighter payload as the safe default.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] `make test` — 1019 passed
- [ ] `make test-integration`
- [ ] Manual: call ``lithos_task_list`` with and without the flag against a populated coordination DB; confirm the ``claims`` field appears only when requested and that the shape matches ``lithos_task_status``.

### New tests

**``tests/test_coordination.py::TestListTasks``**
- ``test_list_tasks_without_with_claims_omits_claims_field`` — default behaviour preserved
- ``test_list_tasks_with_claims_inlines_active_claims`` — claimed and unclaimed tasks both populated correctly
- ``test_list_tasks_with_claims_excludes_expired`` — expired claims filtered out, matching ``lithos_task_status`` semantics

**``tests/test_server.py::TestTaskListWithClaims``**
- ``test_default_omits_claims_field`` — MCP boundary default preserved
- ``test_with_claims_inlines_active_claims`` — parity check against ``lithos_task_status``
- ``test_with_claims_unclaimed_returns_empty_list`` — unclaimed task carries ``claims=[]`` rather than missing key