### PR TITLE
feat(search): async SearchEngine.create() factory with eager model load

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -191,10 +192,10 @@ def reindex(ctx: click.Context, clear: bool) -> None:
     config.ensure_directories()
 
     knowledge = KnowledgeManager(config)
-    search = SearchEngine(config)
     graph = KnowledgeGraph(config)
 
     async def do_reindex() -> None:
+        search = await SearchEngine.create(config)
         if clear:
             click.echo("Clearing existing indices...")
             logger.info("reindex: clearing existing indices clear=True")
@@ -369,11 +370,11 @@ def stats(ctx: click.Context) -> None:
     config: LithosConfig = ctx.obj["config"]
 
     knowledge = KnowledgeManager(config)
-    search = SearchEngine(config)
     graph = KnowledgeGraph(config)
     coordination = CoordinationService(config)
 
     async def show_stats() -> None:
+        search = await SearchEngine.create(config)
         # Initialize coordination DB
         await coordination.initialize()
 
@@ -422,22 +423,26 @@ def search(ctx: click.Context, query: str, semantic: bool, limit: int) -> None:
     from lithos.search import SearchEngine
 
     config: LithosConfig = ctx.obj["config"]
-    engine = SearchEngine(config)
 
-    if semantic:
-        click.echo(f"Semantic search: {query}\n")
-        results = engine.semantic_search(query, limit=limit)
-        for i, r in enumerate(results, 1):
-            click.echo(f"{i}. {r.title} (similarity: {r.similarity:.2f})")
-            click.echo(f"   Path: {r.path}")
-            click.echo(f"   {r.snippet[:100]}...\n")
-    else:
+    async def run() -> list[Any]:
+        engine = await SearchEngine.create(config)
+        if semantic:
+            click.echo(f"Semantic search: {query}\n")
+            sem = engine.semantic_search(query, limit=limit)
+            for i, r in enumerate(sem, 1):
+                click.echo(f"{i}. {r.title} (similarity: {r.similarity:.2f})")
+                click.echo(f"   Path: {r.path}")
+                click.echo(f"   {r.snippet[:100]}...\n")
+            return list(sem)
         click.echo(f"Full-text search: {query}\n")
-        results = engine.full_text_search(query, limit=limit)
-        for i, r in enumerate(results, 1):
+        ft = engine.full_text_search(query, limit=limit)
+        for i, r in enumerate(ft, 1):
             click.echo(f"{i}. {r.title} (score: {r.score:.2f})")
             click.echo(f"   Path: {r.path}")
             click.echo(f"   {r.snippet[:100]}...\n")
+        return list(ft)
+
+    results = asyncio.run(run())
 
     if not results:
         click.echo("No results found.")
@@ -524,21 +529,24 @@ def inspect_health(ctx: click.Context) -> None:
     from lithos.search import SearchEngine
 
     config: LithosConfig = ctx.obj["config"]
-    engine = SearchEngine(config)
 
-    status: dict[str, str] = {}
+    async def probe() -> dict[str, str]:
+        engine = await SearchEngine.create(config)
+        result: dict[str, str] = {}
+        try:
+            _ = engine.tantivy.index  # triggers open_or_create if needed
+            result["tantivy"] = "ok"
+        except Exception as exc:
+            result["tantivy"] = f"unavailable: {exc}"
 
-    try:
-        _ = engine.tantivy.index  # triggers open_or_create if needed
-        status["tantivy"] = "ok"
-    except Exception as exc:
-        status["tantivy"] = f"unavailable: {exc}"
+        try:
+            _ = engine.chroma.collection.count()
+            result["chroma"] = "ok"
+        except Exception as exc:
+            result["chroma"] = f"unavailable: {exc}"
+        return result
 
-    try:
-        _ = engine.chroma.collection.count()
-        status["chroma"] = "ok"
-    except Exception as exc:
-        status["chroma"] = f"unavailable: {exc}"
+    status = asyncio.run(probe())
 
     click.echo("Backend health")
     click.echo("=" * 30)

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -121,7 +121,7 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
             )
         corpus_ids = {doc.id for doc in corpus_docs}
 
-    search = SearchEngine(config)
+    search = await SearchEngine.create(config)
     with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
         diff_span.set_attribute("lithos.reconcile.scope", "indices")
 

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -864,6 +864,9 @@ class SearchEngine:
     def __init__(self, config: LithosConfig | None = None):
         """Initialize search engine.
 
+        Internal constructor: prefer :meth:`create` so the embedding model is
+        loaded eagerly and callers never observe a half-initialised engine.
+
         Args:
             config: Configuration. Uses global config if not provided.
         """
@@ -874,6 +877,36 @@ class SearchEngine:
         self._semantic_store_checked = False
         self._semantic_store_healthy = True
         self._semantic_store_error: str | None = None
+
+    @classmethod
+    async def create(cls, config: LithosConfig | None = None) -> SearchEngine:
+        """Construct a fully-initialised :class:`SearchEngine`.
+
+        Opens both backends and awaits the embedding-model load before
+        returning, so no caller ever observes an unloaded engine. A corrupt
+        Chroma store is quarantined and replaced with a fresh one (preserving
+        the behaviour of :meth:`ensure_semantic_backend_healthy`). Failure of
+        the embedding-model load propagates to the caller.
+        """
+        engine = cls(config=config)
+
+        # Open the Tantivy index (triggers schema-version check / rebuild).
+        _ = engine.tantivy
+
+        # Probe the persisted Chroma store; quarantine it if unreadable.
+        engine.ensure_semantic_backend_healthy()
+
+        # Open the Chroma client/collection so the first query does not pay
+        # the open cost. Skip when the store is unhealthy — semantic search
+        # will surface the error through the standard backend path.
+        if engine._semantic_store_healthy:
+            _ = engine.chroma.collection
+
+        # Eagerly load the embedding model. Failure propagates so callers
+        # see a clear error rather than a silently-degraded engine.
+        await engine.chroma.ensure_model_loaded()
+
+        return engine
 
     @property
     def config(self) -> LithosConfig:
@@ -926,10 +959,6 @@ class SearchEngine:
             self._semantic_store_healthy = healthy
             self._semantic_store_error = error
             return healthy, backup_path
-
-    async def ensure_embeddings_loaded(self) -> None:
-        """Pre-warm the embedding model asynchronously."""
-        await self.chroma.ensure_model_loaded()
 
     @traced("lithos.search.index_document")
     def index_document(self, doc: KnowledgeDocument) -> int:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -86,8 +86,11 @@ class LithosServer:
         set_config(self._config)
 
         # Initialize components — all receive self._config explicitly.
+        # ``search`` is created asynchronously in :meth:`initialize` via
+        # ``SearchEngine.create`` so the embedding model is loaded eagerly
+        # before any caller can observe an unloaded engine.
         self.knowledge = KnowledgeManager(self._config)
-        self.search = SearchEngine(self._config)
+        self.search: SearchEngine = None  # type: ignore[assignment]
         self.graph = KnowledgeGraph(self._config)
         self.coordination = CoordinationService(self._config)
         self.event_bus = EventBus(self._config.events)
@@ -538,6 +541,13 @@ class LithosServer:
                 # Ensure directories exist
                 self.config.ensure_directories()
 
+                # Build the search engine eagerly so the embedding model is
+                # loaded before any request arrives. Tests may pre-inject a
+                # ``search`` instance (e.g. a MagicMock) to avoid the real
+                # backend cost.
+                if self.search is None:
+                    self.search = await SearchEngine.create(self._config)
+
                 # Initialize and run schema migrations
                 registry_path = (
                     self.config.storage.lithos_store_path / "migrations" / "registry.json"
@@ -599,14 +609,6 @@ class LithosServer:
                     # Try to load cached graph
                     if not self.graph.load_cache():
                         await self._rebuild_indices()
-
-                # Pre-warm the embedding model in the background so the first real
-                # request does not block the event loop.  Skip if the rebuild path
-                # already loaded it synchronously.
-                if self.search.chroma._model is None:
-                    task = asyncio.create_task(self._prewarm_embeddings())
-                    self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
 
                 # Ensure edge store is open before the enrich worker
                 # starts — projection helpers no-op when edges.db is absent.
@@ -748,17 +750,6 @@ class LithosServer:
             return self.search.chroma.count_chunks()
         except Exception:
             return 0
-
-    async def _prewarm_embeddings(self) -> None:
-        """Pre-warm the embedding model, logging errors instead of crashing."""
-        tracer = get_tracer()
-        with tracer.start_as_current_span("lithos.embeddings.prewarm") as span:
-            try:
-                await self.search.ensure_embeddings_loaded()
-                span.set_attribute("lithos.embeddings.status", "ok")
-            except Exception:
-                span.set_attribute("lithos.embeddings.status", "failed")
-                logger.warning("Background embedding model pre-warm failed", exc_info=True)
 
     async def _rebuild_indices(self) -> None:
         """Rebuild all search indices from files."""
@@ -1556,9 +1547,9 @@ class LithosServer:
                 # hybrid_search) and the mutating methods (index_document, remove_document) are
                 # all wrapped in asyncio.to_thread() so Tantivy commits and ChromaDB embedding
                 # don't block the event loop. Concurrent read+write is not protected by a lock,
-                # but tantivy-py and ChromaDB are thread-safe for these operations. ChromaDB
-                # model init race on ensure_embeddings_loaded() is mitigated by the existing
-                # warmup call at server startup.
+                # but tantivy-py and ChromaDB are thread-safe for these operations. The
+                # embedding model is loaded eagerly in SearchEngine.create() at server
+                # startup, so no model-init race is reachable here.
                 if mode == "fulltext":
                     ft_results = await asyncio.to_thread(
                         self.search.full_text_search,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,10 +84,10 @@ def knowledge_manager(test_config: LithosConfig) -> KnowledgeManager:
     return KnowledgeManager(test_config)
 
 
-@pytest.fixture
-def search_engine(test_config: LithosConfig) -> SearchEngine:
+@pytest_asyncio.fixture
+async def search_engine(test_config: LithosConfig) -> SearchEngine:
     """Create search engine for testing."""
-    return SearchEngine(test_config)
+    return await SearchEngine.create(test_config)
 
 
 @pytest.fixture

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -232,6 +232,10 @@ class TestCLIContracts:
                 self.tantivy = type("T", (), {"index": object()})()
                 self.chroma = type("C", (), {"collection": _BrokenCollection()})()
 
+            @classmethod
+            async def create(cls, config):
+                return cls(config)
+
         monkeypatch.setattr(search_module, "SearchEngine", _BrokenSearchEngine)
         unhealthy = runner.invoke(cli, ["--data-dir", str(temp_dir), "inspect", "health"])
         assert unhealthy.exit_code == 1, unhealthy.output

--- a/tests/test_coactivation.py
+++ b/tests/test_coactivation.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 import aiosqlite
 import frontmatter as fm
 import pytest
+import pytest_asyncio
 
 from lithos.config import LcmaConfig, LithosConfig, StorageConfig
 from lithos.graph import KnowledgeGraph
@@ -122,9 +123,9 @@ def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> Kn
     return graph
 
 
-@pytest.fixture
-def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
-    return SearchEngine(seeded_config)
+@pytest_asyncio.fixture
+async def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
+    return await SearchEngine.create(seeded_config)
 
 
 @pytest.fixture

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -55,7 +55,7 @@ async def test_indices_dry_run_no_mutation(
     assert any(a.get("action") == "full_rebuild" for a in result["actions"])
 
     # Verify the index was NOT populated (no mutation on dry-run)
-    search = SearchEngine(test_config)
+    search = await SearchEngine.create(test_config)
     ft_results = search.full_text_search("alpha document")
     assert len(ft_results) == 0
 
@@ -74,7 +74,7 @@ async def test_indices_real_run_rebuilds_index(
     )
 
     # Index is empty before reconcile
-    search_before = SearchEngine(test_config)
+    search_before = await SearchEngine.create(test_config)
     assert len(search_before.full_text_search("beta integration")) == 0
 
     result = await reconcile(scope="indices", dry_run=False, config=test_config)
@@ -85,7 +85,7 @@ async def test_indices_real_run_rebuilds_index(
     assert result["summary"]["repaired"] > 0
 
     # Search should now find the document
-    search_after = SearchEngine(test_config)
+    search_after = await SearchEngine.create(test_config)
     ft_results = search_after.full_text_search("beta integration")
     assert any(r.id == doc_id for r in ft_results)
 

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import frontmatter as fm
 import pytest
+import pytest_asyncio
 
 from lithos.config import LcmaConfig, LithosConfig, StorageConfig
 from lithos.graph import KnowledgeGraph
@@ -126,9 +127,9 @@ def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> Kn
     return graph
 
 
-@pytest.fixture
-def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
-    return SearchEngine(seeded_config)
+@pytest_asyncio.fixture
+async def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
+    return await SearchEngine.create(seeded_config)
 
 
 @pytest.fixture

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import frontmatter as fm
 import pytest
+import pytest_asyncio
 
 from lithos.config import LithosConfig, StorageConfig
 from lithos.graph import KnowledgeGraph
@@ -190,10 +191,10 @@ def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> Kn
     return graph
 
 
-@pytest.fixture
-def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
+@pytest_asyncio.fixture
+async def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
     """SearchEngine for testing (not indexed, tests mock as needed)."""
-    return SearchEngine(seeded_config)
+    return await SearchEngine.create(seeded_config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -720,6 +720,12 @@ class TestSearchEngineResiliency:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("bad-store")
 
+        # SearchEngine.create() already primed the probe cache; reset so
+        # this test's monkeypatched probe is the one that runs.
+        search_engine._semantic_store_checked = False
+        search_engine._semantic_store_healthy = True
+        search_engine._semantic_store_error = None
+
         calls = {"count": 0}
 
         def _probe(timeout_seconds: float = 10.0):
@@ -744,6 +750,12 @@ class TestSearchEngineResiliency:
         self, search_engine: SearchEngine, monkeypatch: pytest.MonkeyPatch
     ):
         """The Chroma probe only runs once after a successful health check."""
+        # SearchEngine.create() already primed the probe cache; reset so this
+        # test sees the monkeypatched probe.
+        search_engine._semantic_store_checked = False
+        search_engine._semantic_store_healthy = True
+        search_engine._semantic_store_error = None
+
         calls = {"count": 0}
 
         def _probe(timeout_seconds: float = 10.0):

--- a/tests/test_search_create.py
+++ b/tests/test_search_create.py
@@ -1,0 +1,64 @@
+"""Tests for the SearchEngine.create() async factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.search import SearchEngine
+
+
+@pytest.mark.asyncio
+async def test_create_loads_embedding_model_eagerly(test_config: LithosConfig) -> None:
+    """create() returns an engine with the embedding model already loaded."""
+    with patch("lithos.search.SentenceTransformer", return_value=MagicMock()) as ctor:
+        engine = await SearchEngine.create(test_config)
+
+    assert engine.chroma._model is not None, "embedding model should be loaded by create()"
+    ctor.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_propagates_model_load_failure(test_config: LithosConfig) -> None:
+    """create() surfaces an exception raised while loading the embedding model."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("model load failed")
+
+    with (
+        patch("lithos.search.SentenceTransformer", side_effect=_boom),
+        pytest.raises(RuntimeError, match="model load failed"),
+    ):
+        await SearchEngine.create(test_config)
+
+
+@pytest.mark.asyncio
+async def test_create_quarantines_corrupt_chroma_store(test_config: LithosConfig) -> None:
+    """create() quarantines an unreadable Chroma store and proceeds with a clean one."""
+    chroma_path: Path = test_config.storage.chroma_path
+    chroma_path.mkdir(parents=True, exist_ok=True)
+    sentinel_file = chroma_path / "broken.sqlite3"
+    sentinel_file.write_bytes(b"not a real sqlite db")
+
+    # First probe fails (corrupt), second probe (after quarantine) succeeds.
+    probe_responses = iter([(False, "broken store"), (True, None)])
+
+    def _fake_probe(self, timeout_seconds: float = 10.0):
+        return next(probe_responses)
+
+    with (
+        patch("lithos.search.SentenceTransformer", return_value=MagicMock()),
+        patch("lithos.search.ChromaIndex.probe_store", _fake_probe),
+    ):
+        engine = await SearchEngine.create(test_config)
+
+    # The original store directory should be replaced by a fresh one and a
+    # quarantined backup directory should now sit alongside it.
+    siblings = list(chroma_path.parent.iterdir())
+    backup_dirs = [p for p in siblings if p.name.startswith(f"{chroma_path.name}.corrupt-")]
+    assert backup_dirs, "expected a quarantined backup directory after corrupt probe"
+    assert chroma_path.exists(), "fresh chroma path should exist after quarantine"
+    assert engine.chroma._model is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lithos.config import LithosConfig
+from lithos.search import SearchEngine
 from lithos.server import LithosServer, _FileChangeHandler, create_server, get_server
 
 pytestmark = pytest.mark.integration
@@ -125,17 +126,18 @@ class TestServerInitialization:
         rebuild = AsyncMock()
         backup_path = test_config.storage.data_dir / ".chroma.corrupt-test"
 
+        # Pre-inject a mock SearchEngine so initialize() skips the real
+        # async create() and the eager embedding-model load.
+        mock_search = MagicMock(spec=SearchEngine)
+        mock_search.ensure_semantic_backend_healthy.return_value = (True, backup_path)
+        mock_search.tantivy = SimpleNamespace(needs_rebuild=False)
+        server.search = mock_search
         server._rebuild_indices = rebuild  # type: ignore[assignment]
-        server.search.ensure_semantic_backend_healthy = MagicMock(  # type: ignore[method-assign]
-            return_value=(True, backup_path)
-        )
-        server.search._tantivy = SimpleNamespace(needs_rebuild=False)
-        server.search._chroma = SimpleNamespace(_model=object())
 
         await server.initialize()
 
         rebuild.assert_awaited_once()
-        server.search.ensure_semantic_backend_healthy.assert_called_once_with()
+        mock_search.ensure_semantic_backend_healthy.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_initialize_warns_but_stays_up_when_semantic_backend_unavailable(
@@ -145,13 +147,12 @@ class TestServerInitialization:
         server = LithosServer(test_config)
         rebuild = AsyncMock()
 
+        mock_search = MagicMock(spec=SearchEngine)
+        mock_search.ensure_semantic_backend_healthy.return_value = (False, None)
+        mock_search._semantic_store_error = "simulated corruption"
+        mock_search.tantivy = SimpleNamespace(needs_rebuild=False)
+        server.search = mock_search
         server._rebuild_indices = rebuild  # type: ignore[assignment]
-        server.search.ensure_semantic_backend_healthy = MagicMock(  # type: ignore[method-assign]
-            return_value=(False, None)
-        )
-        server.search._semantic_store_error = "simulated corruption"
-        server.search._tantivy = SimpleNamespace(needs_rebuild=False)
-        server.search._chroma = SimpleNamespace(_model=object())
         server.graph.load_cache = MagicMock(return_value=True)  # type: ignore[method-assign]
 
         with caplog.at_level(logging.WARNING, logger="lithos.server"):


### PR DESCRIPTION
## Summary

Slice 1 of the seam-tightening work in `docs/plans/seam-tightening-search.md` (Phase 1) and `docs/adr/0002-search-engine-hides-its-backends.md`.

- Adds `SearchEngine.create(config)` async classmethod that opens both backends and awaits the embedding-model load before returning, so no caller observes an unloaded engine.
- Migrates every `SearchEngine(config)` construction site to `await SearchEngine.create(config)`: FastMCP server lifespan, four CLI commands, `reconcile.py`, and all test fixtures.
- Deletes the unreachable lazy-load null-state observable at `server.py:606` (`if self.search.chroma._model is None`) and the now-dead `_prewarm_embeddings` task and `SearchEngine.ensure_embeddings_loaded` shim.
- Re-quarantines a corrupt Chroma store on startup (preserves existing behaviour).
- Propagates model-load failures cleanly.

Closes #223.

## Test plan

- [x] New `tests/test_search_create.py` covers: model loaded after `create()`; clean failure when model load fails; corrupt-store re-quarantine path
- [x] `make test` — 1022 passed locally; CI green
- [x] `make test-integration` — CI green
- [x] `make lint`
- [x] `make typecheck`
- [x] `make check`

CI on main commit: Lint ✅ · Test ✅ · Integration Test ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
