### PR TITLE
feat(search): IndexableDocument as the cross-seam type

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -216,7 +216,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
                 try:
                     relative_path = file_path.relative_to(knowledge_path)
                     doc, _ = await knowledge.read(path=str(relative_path))
-                    search.index_document(doc)
+                    search.index(KnowledgeManager.to_indexable(doc))
                     graph.add_document(doc)
                     indexed += 1
                 except Exception as e:

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import frontmatter
@@ -19,6 +19,9 @@ import frontmatter
 from lithos.config import LithosConfig
 from lithos.errors import SlugCollisionError
 from lithos.telemetry import lithos_metrics, timed_write, traced
+
+if TYPE_CHECKING:
+    from lithos.search import IndexableDocument
 
 logger = logging.getLogger(__name__)
 
@@ -615,6 +618,29 @@ _UNSET = _UnsetType()
 
 class KnowledgeManager:
     """Manages knowledge documents - CRUD operations."""
+
+    @staticmethod
+    def to_indexable(doc: KnowledgeDocument) -> "IndexableDocument":
+        """Translate a :class:`KnowledgeDocument` into the search seam type.
+
+        The single point where ``None`` values, ``Path`` objects, and
+        list-typed tags are coerced into the seam's all-string form. After
+        this translation, no ``KnowledgeDocument`` shape crosses into
+        :class:`~lithos.search.SearchEngine`.
+        """
+        from lithos.search import IndexableDocument
+
+        return IndexableDocument(
+            id=doc.id,
+            title=doc.title,
+            content=doc.content,
+            path=str(doc.path),
+            author=doc.metadata.author,
+            tags=tuple(doc.metadata.tags),
+            source_url=doc.metadata.source_url or "",
+            updated_at=(doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else ""),
+            expires_at=(doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else ""),
+        )
 
     def __init__(self, config: LithosConfig):
         """Initialize knowledge manager.

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -182,12 +182,13 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
             apply_span.set_attribute("lithos.reconcile.backend", backend)
             try:
                 if backend == "tantivy":
-                    search.tantivy.rebuild_from_docs(corpus_docs)
+                    indexables = [KnowledgeManager.to_indexable(d) for d in corpus_docs]
+                    search.tantivy.rebuild_from_docs(indexables)
                     repaired += 1
                 elif backend == "chroma":
                     search.chroma.clear()
                     for doc in corpus_docs:
-                        search.chroma.add_document(doc)
+                        search.chroma.add_document(KnowledgeManager.to_indexable(doc))
                     repaired += 1
             except Exception as exc:
                 logger.error("Failed to repair %s backend: %s", backend, exc)

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,7 +26,6 @@ from sentence_transformers import SentenceTransformer
 
 from lithos.config import LithosConfig, get_config
 from lithos.errors import IndexingError, SearchBackendError
-from lithos.knowledge import KnowledgeDocument
 from lithos.telemetry import lithos_metrics, traced
 
 if TYPE_CHECKING:
@@ -62,6 +62,34 @@ class SemanticResult:
     source_url: str = ""
     updated_at: str = ""
     is_stale: bool = False
+
+
+@dataclass(frozen=True)
+class IndexableDocument:
+    """The slice of a note the search seam consumes.
+
+    Distinct from :class:`~lithos.knowledge.KnowledgeDocument` (the manager-
+    facing type carrying frontmatter, links, and lifecycle). The fields here
+    are exactly those Tantivy and Chroma write — coercions (None → "",
+    Path → str, list → tuple) live in
+    :meth:`~lithos.knowledge.KnowledgeManager.to_indexable`, the single
+    translation point. See :doc:`CONTEXT.md` and ADR 0002.
+    """
+
+    id: str
+    title: str
+    content: str
+    path: str
+    author: str
+    tags: tuple[str, ...]
+    source_url: str
+    updated_at: str
+    expires_at: str
+
+    @property
+    def full_content(self) -> str:
+        """Title + body, the form Tantivy stores in its ``content`` field."""
+        return f"# {self.title}\n\n{self.content}"
 
 
 @dataclass(frozen=True)
@@ -313,7 +341,7 @@ class TantivyIndex:
             self._schema = self._build_schema()
         return self._schema
 
-    def add_document(self, doc: KnowledgeDocument) -> None:
+    def add_document(self, doc: IndexableDocument) -> None:
         """Add or update a document in the index."""
         writer = self.index.writer(heap_size=15_000_000)
 
@@ -326,12 +354,12 @@ class TantivyIndex:
                 id=doc.id,
                 title=doc.title,
                 content=doc.full_content,
-                path=str(doc.path),
-                author=doc.metadata.author,
-                tags=" ".join(doc.metadata.tags),
-                source_url=doc.metadata.source_url or "",
-                updated_at=doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else "",
-                expires_at=doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else "",
+                path=doc.path,
+                author=doc.author,
+                tags=" ".join(doc.tags),
+                source_url=doc.source_url,
+                updated_at=doc.updated_at,
+                expires_at=doc.expires_at,
             )
         )
 
@@ -340,7 +368,7 @@ class TantivyIndex:
         # Reload to see changes immediately
         self.index.reload()
 
-    def rebuild_from_docs(self, docs: list[KnowledgeDocument]) -> None:
+    def rebuild_from_docs(self, docs: Iterable[IndexableDocument]) -> None:
         """Clear the index and re-index *docs* in a single commit.
 
         Prefer this over calling ``clear()`` + ``add_document()`` in a loop to
@@ -354,16 +382,12 @@ class TantivyIndex:
                     id=doc.id,
                     title=doc.title,
                     content=doc.full_content,
-                    path=str(doc.path),
-                    author=doc.metadata.author,
-                    tags=" ".join(doc.metadata.tags),
-                    source_url=doc.metadata.source_url or "",
-                    updated_at=(
-                        doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else ""
-                    ),
-                    expires_at=(
-                        doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else ""
-                    ),
+                    path=doc.path,
+                    author=doc.author,
+                    tags=" ".join(doc.tags),
+                    source_url=doc.source_url,
+                    updated_at=doc.updated_at,
+                    expires_at=doc.expires_at,
                 )
             )
         writer.commit()
@@ -687,7 +711,7 @@ collection.count()
 
     def add_document(
         self,
-        doc: KnowledgeDocument,
+        doc: IndexableDocument,
         chunk_size: int = 500,
         chunk_max: int = 1000,
     ) -> int:
@@ -704,7 +728,9 @@ collection.count()
         # Remove existing chunks for this document
         self.remove_document(doc.id)
 
-        # Chunk the content
+        # Chunk the content. Chroma uses a plain title prefix (no leading
+        # ``#``) to match the form the embedding model was tuned on; Tantivy
+        # stores ``full_content`` with the ``# `` heading.
         full_text = f"{doc.title}\n\n{doc.content}"
         chunks = chunk_text(full_text, chunk_size, chunk_max)
 
@@ -721,16 +747,12 @@ collection.count()
                 "doc_id": doc.id,
                 "chunk_index": i,
                 "title": doc.title,
-                "path": str(doc.path),
-                "author": doc.metadata.author,
-                "tags": ",".join(doc.metadata.tags),
-                "source_url": doc.metadata.source_url or "",
-                "updated_at": (
-                    doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else ""
-                ),
-                "expires_at": (
-                    doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else ""
-                ),
+                "path": doc.path,
+                "author": doc.author,
+                "tags": ",".join(doc.tags),
+                "source_url": doc.source_url,
+                "updated_at": doc.updated_at,
+                "expires_at": doc.expires_at,
             }
             for i in range(len(chunks))
         ]
@@ -982,9 +1004,9 @@ class SearchEngine:
             self._semantic_store_error = error
             return healthy, backup_path
 
-    @traced("lithos.search.index_document")
-    def index_document(self, doc: KnowledgeDocument) -> int:
-        """Index a document in both search engines.
+    @traced("lithos.search.index")
+    def index(self, doc: IndexableDocument) -> int:
+        """Index an :class:`IndexableDocument` in both backends.
 
         Partial failures (one backend succeeds) are logged as warnings.
         If *both* backends fail the operation is considered a total failure and
@@ -1033,7 +1055,7 @@ class SearchEngine:
             )
 
         logger.debug(
-            "index_document: doc_id=%s chunks=%d backends_failed=%d",
+            "index: doc_id=%s chunks=%d backends_failed=%d",
             doc.id,
             chunks,
             len(errors),
@@ -1041,8 +1063,8 @@ class SearchEngine:
         )
         return chunks
 
-    @traced("lithos.search.remove_document")
-    def remove_document(self, doc_id: str) -> None:
+    @traced("lithos.search.remove")
+    def remove(self, doc_id: str) -> None:
         """Remove a document from both search engines.
 
         Partial failures (one backend succeeds) are logged as warnings.

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -772,7 +772,8 @@ class LithosServer:
                 try:
                     relative_path = file_path.relative_to(knowledge_path)
                     doc, _ = await self.knowledge.read(path=str(relative_path))
-                    await asyncio.to_thread(self.search.index_document, doc)
+                    indexable = KnowledgeManager.to_indexable(doc)
+                    await asyncio.to_thread(self.search.index, indexable)
                     self.graph.add_document(doc)
                     file_count += 1
                 except Exception as e:
@@ -904,13 +905,14 @@ class LithosServer:
                             )
 
                             await self.knowledge.delete(doc_id)
-                            await asyncio.to_thread(self.search.remove_document, doc_id)
+                            await asyncio.to_thread(self.search.remove, doc_id)
                             self.graph.remove_document(doc_id)
                             self.graph.save_cache()
                     else:
                         is_new = not self.knowledge.get_id_by_path(relative_path)
                         doc = await self.knowledge.sync_from_disk(relative_path)
-                        await asyncio.to_thread(self.search.index_document, doc)
+                        indexable = KnowledgeManager.to_indexable(doc)
+                        await asyncio.to_thread(self.search.index, indexable)
                         self.graph.add_document(doc)
                         self.graph.save_cache()
 
@@ -1314,11 +1316,12 @@ class LithosServer:
                 assert doc is not None
                 warnings.extend(result.warnings)
 
-                # Update indices. ``index_document`` is wrapped in
+                # Update indices. ``search.index`` is wrapped in
                 # ``asyncio.to_thread`` so Tantivy commits and ChromaDB
                 # embedding don't block the event loop during concurrent
                 # reads — see #199.
-                await asyncio.to_thread(self.search.index_document, doc)
+                indexable = KnowledgeManager.to_indexable(doc)
+                await asyncio.to_thread(self.search.index, indexable)
                 self.graph.add_document(doc)
                 self.graph.save_cache()
 
@@ -1455,7 +1458,7 @@ class LithosServer:
                         "message": f"Document not found: {id}",
                     }
 
-                await asyncio.to_thread(self.search.remove_document, id)
+                await asyncio.to_thread(self.search.remove, id)
                 self.graph.remove_document(id)
                 self.graph.save_cache()
 
@@ -1550,7 +1553,7 @@ class LithosServer:
                     }
 
                 # Thread safety note: SearchManager read methods (full_text_search, semantic_search,
-                # hybrid_search) and the mutating methods (index_document, remove_document) are
+                # hybrid_search) and the mutating methods (index, remove) are
                 # all wrapped in asyncio.to_thread() so Tantivy commits and ChromaDB embedding
                 # don't block the event loop. Concurrent read+write is not protected by a lock,
                 # but tantivy-py and ChromaDB are thread-safe for these operations. The

--- a/tests/test_async_search.py
+++ b/tests/test_async_search.py
@@ -118,11 +118,11 @@ class TestAsyncSearchNonBlocking:
     @pytest.mark.asyncio
     async def test_server_search_mutation_sites_use_to_thread(self) -> None:
         """Regression guard for #199: ``lithos_write`` and the file-watcher
-        path used to call ``self.search.index_document()`` synchronously,
-        blocking the event loop for Tantivy commits and ChromaDB embeddings.
+        path used to call ``self.search.index()`` synchronously, blocking
+        the event loop for Tantivy commits and ChromaDB embeddings.
 
         Greps the server source to ensure no direct (non-``to_thread``)
-        call to ``index_document`` / ``remove_document`` remains.
+        call to the seam mutation methods remains.
         """
         import inspect
 
@@ -134,7 +134,7 @@ class TestAsyncSearchNonBlocking:
             # Skip comments and inline references; only flag real call sites.
             if stripped.startswith("#"):
                 continue
-            for method in ("index_document", "remove_document"):
+            for method in ("index", "remove"):
                 if f"self.search.{method}(" in stripped:
                     assert "asyncio.to_thread" in stripped, (
                         f"Direct self.search.{method}() call — must be wrapped in "

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from lithos.events import NOTE_DELETED, NOTE_UPDATED
+from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
 
 pytestmark = pytest.mark.integration
@@ -24,7 +25,7 @@ class TestFileWatcherEventEmission:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         queue = server.event_bus.subscribe(event_types=[NOTE_UPDATED])
@@ -46,7 +47,7 @@ class TestFileWatcherEventEmission:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         queue = server.event_bus.subscribe(event_types=[NOTE_DELETED])
@@ -90,7 +91,7 @@ class TestFileWatcherEventEmission:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         # Replace event_bus.emit with a mock that raises
@@ -112,7 +113,7 @@ class TestFileWatcherEventEmission:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path

--- a/tests/test_freshness_conformance.py
+++ b/tests/test_freshness_conformance.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from lithos.knowledge import KnowledgeManager
 from lithos.search import TantivyIndex
 from lithos.server import LithosServer
 
@@ -188,7 +189,7 @@ class TestStalenessInSearchConformance:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         results = server.search.full_text_search("search stale conformance")
         match = [r for r in results if r.id == doc.id]
@@ -206,7 +207,7 @@ class TestStalenessInSearchConformance:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         results = server.search.semantic_search("machine learning algorithms expired")
         match = [r for r in results if r.id == doc.id]
@@ -232,7 +233,7 @@ class TestCacheLookupConformance:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(server, query="distributed systems")
         assert result["hit"] is True
@@ -251,7 +252,7 @@ class TestCacheLookupConformance:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(server, query="graph databases")
         assert result["hit"] is False
@@ -287,7 +288,7 @@ class TestStaleUpdateFlowConformance:
                 expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         # Cache lookup should return stale
         result1 = await self._call_cache_lookup(server, query="serverless computing")
@@ -304,7 +305,7 @@ class TestStaleUpdateFlowConformance:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(updated)
+        server.search.index(KnowledgeManager.to_indexable(updated))
 
         # Cache lookup should now return hit
         result2 = await self._call_cache_lookup(server, query="serverless computing")
@@ -331,7 +332,7 @@ class TestSourceUrlFastPathConformance:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(
             server,
@@ -372,7 +373,7 @@ class TestOnDiskCompatibilityConformance:
                 confidence=0.9,
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         tool = await server.mcp.get_tool("lithos_cache_lookup")
         result = await tool.fn(query="container orchestration")
@@ -401,7 +402,7 @@ class TestSchemaConformance:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         # Corrupt the schema version marker to simulate mismatch
         index_path = test_config.storage.tantivy_path

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -839,7 +839,7 @@ class TestGraphSearch:
             )
         ).document
         knowledge_graph.add_document(doc)
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         hybrid_results = search_engine.hybrid_search("isolation test")
         graph_results = search_engine.graph_search(
@@ -880,7 +880,7 @@ class TestGraphSearch:
 
         for doc in (doc_a, doc_b):
             knowledge_graph.add_document(doc)
-            search_engine.index_document(doc)
+            search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # No seed_ids — should be discovered via hybrid search on query
         results = search_engine.graph_search(

--- a/tests/test_indexable_document.py
+++ b/tests/test_indexable_document.py
@@ -1,0 +1,133 @@
+"""Tests for the IndexableDocument seam type and the KM translation helper (#225)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.knowledge import KnowledgeDocument, KnowledgeManager, KnowledgeMetadata
+from lithos.search import IndexableDocument, SearchEngine
+
+
+def _make_doc(*, source_url=None, updated_at=None, expires_at=None) -> KnowledgeDocument:
+    """Build a KnowledgeDocument with controllable optional fields."""
+    return KnowledgeDocument(
+        id="11111111-1111-1111-1111-111111111111",
+        title="Seam Test Doc",
+        content="Body of the doc.",
+        path=Path("notes/seam-test.md"),
+        metadata=KnowledgeMetadata(
+            id="11111111-1111-1111-1111-111111111111",
+            title="Seam Test Doc",
+            author="alice",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=updated_at,
+            tags=["alpha", "beta"],
+            source_url=source_url,
+            expires_at=expires_at,
+        ),
+    )
+
+
+def test_indexable_document_is_frozen() -> None:
+    """IndexableDocument is immutable — assigning a field raises FrozenInstanceError."""
+    from dataclasses import FrozenInstanceError
+
+    doc = IndexableDocument(
+        id="x",
+        title="t",
+        content="c",
+        path="p",
+        author="a",
+        tags=("one",),
+        source_url="",
+        updated_at="",
+        expires_at="",
+    )
+    with pytest.raises(FrozenInstanceError):
+        doc.title = "mutated"  # type: ignore[misc]
+
+
+def test_indexable_document_full_content_includes_title_heading() -> None:
+    """full_content prepends the title as an H1 — the form Tantivy stores."""
+    doc = IndexableDocument(
+        id="x",
+        title="Hello",
+        content="World",
+        path="p",
+        author="a",
+        tags=(),
+        source_url="",
+        updated_at="",
+        expires_at="",
+    )
+    assert doc.full_content == "# Hello\n\nWorld"
+
+
+def test_to_indexable_preserves_required_fields() -> None:
+    """to_indexable copies id/title/content/author/tags verbatim."""
+    doc = _make_doc()
+    indexable = KnowledgeManager.to_indexable(doc)
+    assert indexable.id == doc.id
+    assert indexable.title == doc.title
+    assert indexable.content == doc.content
+    assert indexable.author == doc.metadata.author
+    assert indexable.tags == ("alpha", "beta")
+
+
+def test_to_indexable_coerces_path_to_string() -> None:
+    """Path objects are stringified at the seam — the backends only see str."""
+    doc = _make_doc()
+    indexable = KnowledgeManager.to_indexable(doc)
+    assert indexable.path == str(doc.path)
+    assert isinstance(indexable.path, str)
+
+
+def test_to_indexable_coerces_none_optionals_to_empty_string() -> None:
+    """source_url, updated_at, expires_at all coerce None -> ''."""
+    doc = _make_doc(source_url=None, updated_at=None, expires_at=None)
+    indexable = KnowledgeManager.to_indexable(doc)
+    assert indexable.source_url == ""
+    assert indexable.updated_at == ""
+    assert indexable.expires_at == ""
+
+
+def test_to_indexable_serialises_datetimes_to_iso() -> None:
+    """updated_at and expires_at are written as ISO strings, not datetimes."""
+    when = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    expires = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    doc = _make_doc(updated_at=when, expires_at=expires)
+    indexable = KnowledgeManager.to_indexable(doc)
+    assert indexable.updated_at == when.isoformat()
+    assert indexable.expires_at == expires.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_search_index_round_trip_through_indexable(
+    test_config: LithosConfig,
+) -> None:
+    """End-to-end: a doc translated through to_indexable is searchable."""
+    engine = await SearchEngine.create(test_config)
+    doc = _make_doc()
+    indexable = KnowledgeManager.to_indexable(doc)
+
+    engine.index(indexable)
+
+    results = engine.full_text_search("Body")
+    assert any(r.id == doc.id for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_remove_by_id(test_config: LithosConfig) -> None:
+    """remove(id) deletes from both backends."""
+    engine = await SearchEngine.create(test_config)
+    indexable = KnowledgeManager.to_indexable(_make_doc())
+    engine.index(indexable)
+
+    engine.remove(indexable.id)
+
+    results = engine.full_text_search("Body")
+    assert not any(r.id == indexable.id for r in results)

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -11,6 +11,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from lithos.config import LithosConfig
+from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer, _FileChangeHandler
 
 pytestmark = pytest.mark.integration
@@ -402,7 +403,7 @@ class TestFileWatcherRace:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1022,8 +1022,7 @@ class TestSchemaVersionDetection:
 
     def test_rebuild_index_still_functional(self, tmp_path):
         """After schema version rebuild, index is still functional."""
-        from lithos.knowledge import KnowledgeDocument, KnowledgeMetadata
-        from lithos.search import TantivyIndex
+        from lithos.search import IndexableDocument, TantivyIndex
 
         index_path = tmp_path / "tantivy"
         idx = TantivyIndex(index_path)
@@ -1036,22 +1035,17 @@ class TestSchemaVersionDetection:
         idx2.open_or_create()
         assert idx2.needs_rebuild is True
 
-        # Index should work after rebuild
-        from datetime import datetime, timezone
-        from pathlib import Path
-
-        doc = KnowledgeDocument(
+        # Index should work after rebuild — the backend now accepts the seam type.
+        doc = IndexableDocument(
             id="test-id",
             title="Test",
             content="Test content.",
-            metadata=KnowledgeMetadata(
-                id="test-id",
-                title="Test",
-                author="agent",
-                created_at=datetime.now(timezone.utc),
-                updated_at=datetime.now(timezone.utc),
-            ),
-            path=Path("test.md"),
+            path="test.md",
+            author="agent",
+            tags=(),
+            source_url="",
+            updated_at="",
+            expires_at="",
         )
         idx2.add_document(doc)
         results = idx2.search("test")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -85,7 +85,7 @@ class TestTantivyIndex:
                 tags=["python", "tutorial"],
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("Python programming")
 
@@ -104,7 +104,7 @@ class TestTantivyIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("Kubernetes")
 
@@ -123,7 +123,7 @@ class TestTantivyIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("microservices architecture")
 
@@ -151,8 +151,8 @@ class TestTantivyIndex:
                 tags=["python", "data"],
             )
         ).document
-        search_engine.index_document(doc1)
-        search_engine.index_document(doc2)
+        search_engine.index(KnowledgeManager.to_indexable(doc1))
+        search_engine.index(KnowledgeManager.to_indexable(doc2))
 
         # Search with tag filter
         results = search_engine.full_text_search("Python", tags=["web"])
@@ -182,8 +182,8 @@ class TestTantivyIndex:
                 tags=["project:other-project"],
             )
         ).document
-        search_engine.index_document(target)
-        search_engine.index_document(other)
+        search_engine.index(KnowledgeManager.to_indexable(target))
+        search_engine.index(KnowledgeManager.to_indexable(other))
 
         results = search_engine.full_text_search("knowledge graph", tags=["project:lithos-core"])
         result_ids = {r.id for r in results}
@@ -212,8 +212,8 @@ class TestTantivyIndex:
                 tags=["project:lithos-core"],
             )
         ).document
-        search_engine.index_document(match)
-        search_engine.index_document(missing_priority)
+        search_engine.index(KnowledgeManager.to_indexable(match))
+        search_engine.index(KnowledgeManager.to_indexable(missing_priority))
 
         results = search_engine.full_text_search(
             "topic of interest",
@@ -242,7 +242,7 @@ class TestTantivyIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("REST API")
 
@@ -261,7 +261,7 @@ class TestTantivyIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # Update document
         updated = (
@@ -271,7 +271,7 @@ class TestTantivyIndex:
                 content="Updated content about caching strategies.",
             )
         ).document
-        search_engine.index_document(updated)
+        search_engine.index(KnowledgeManager.to_indexable(updated))
 
         # Old content should not match
         old_results = search_engine.full_text_search("databases")
@@ -293,14 +293,14 @@ class TestTantivyIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # Verify it's searchable
         results = search_engine.full_text_search("Temporary")
         assert any(r.id == doc.id for r in results)
 
         # Remove from index
-        search_engine.remove_document(doc.id)
+        search_engine.remove(doc.id)
 
         # Should no longer appear
         results = search_engine.full_text_search("Temporary")
@@ -322,7 +322,7 @@ class TestChromaIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # Search with semantically similar but different words
         results = search_engine.semantic_search("how to handle failures gracefully")
@@ -342,7 +342,7 @@ class TestChromaIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # High threshold should filter out weak matches
         results = search_engine.semantic_search(
@@ -375,7 +375,7 @@ class TestChromaIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.semantic_search("Python programming", limit=10)
 
@@ -395,7 +395,7 @@ class TestChromaIndex:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.semantic_search("database performance tuning")
 
@@ -424,7 +424,7 @@ class TestSearchEngineIntegration:
                     tags=doc_data["tags"],
                 )
             ).document
-            search_engine.index_document(doc)
+            search_engine.index(KnowledgeManager.to_indexable(doc))
             created_docs.append(doc)
 
         # Full-text search
@@ -463,9 +463,9 @@ class TestSearchEngineIntegration:
             )
         ).document
 
-        search_engine.index_document(highly_relevant)
-        search_engine.index_document(somewhat_relevant)
-        search_engine.index_document(not_relevant)
+        search_engine.index(KnowledgeManager.to_indexable(highly_relevant))
+        search_engine.index(KnowledgeManager.to_indexable(somewhat_relevant))
+        search_engine.index(KnowledgeManager.to_indexable(not_relevant))
 
         results = search_engine.full_text_search("Python testing pytest")
 
@@ -485,7 +485,7 @@ class TestSearchEngineIntegration:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # Verify indexed
         assert len(search_engine.full_text_search("cleared")) >= 1
@@ -508,7 +508,7 @@ class TestSearchEngineIntegration:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         stats = search_engine.get_stats()
 
@@ -538,8 +538,8 @@ class TestChromaIndexFilters:
                 agent="bob",
             )
         ).document
-        search_engine.index_document(alice_doc)
-        search_engine.index_document(bob_doc)
+        search_engine.index(KnowledgeManager.to_indexable(alice_doc))
+        search_engine.index(KnowledgeManager.to_indexable(bob_doc))
 
         results = search_engine.chroma.search(
             "deep learning transformers", limit=10, threshold=0.0, author="alice"
@@ -561,7 +561,7 @@ class TestChromaIndexFilters:
                 agent="charlie",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.chroma.search(
             "machine learning", limit=10, threshold=0.0, author="nobody"
@@ -589,8 +589,8 @@ class TestChromaIndexFilters:
                 path="notes",
             )
         ).document
-        search_engine.index_document(procedures_doc)
-        search_engine.index_document(notes_doc)
+        search_engine.index(KnowledgeManager.to_indexable(procedures_doc))
+        search_engine.index(KnowledgeManager.to_indexable(notes_doc))
 
         results = search_engine.chroma.search(
             "deploying microservices", limit=10, threshold=0.0, path_prefix="procedures"
@@ -629,9 +629,9 @@ class TestChromaIndexFilters:
                 path="notes",
             )
         ).document
-        search_engine.index_document(match_doc)
-        search_engine.index_document(wrong_author_doc)
-        search_engine.index_document(wrong_path_doc)
+        search_engine.index(KnowledgeManager.to_indexable(match_doc))
+        search_engine.index(KnowledgeManager.to_indexable(wrong_author_doc))
+        search_engine.index(KnowledgeManager.to_indexable(wrong_path_doc))
 
         results = search_engine.chroma.search(
             "database indexing",
@@ -665,8 +665,8 @@ class TestChromaIndexFilters:
                 agent="bob",
             )
         ).document
-        search_engine.index_document(alice_doc)
-        search_engine.index_document(bob_doc)
+        search_engine.index(KnowledgeManager.to_indexable(alice_doc))
+        search_engine.index(KnowledgeManager.to_indexable(bob_doc))
 
         results = search_engine.semantic_search(
             "reinforcement learning", limit=10, threshold=0.0, author="alice"
@@ -697,8 +697,8 @@ class TestChromaIndexFilters:
                 path="scratch",
             )
         ).document
-        search_engine.index_document(arch_doc)
-        search_engine.index_document(other_doc)
+        search_engine.index(KnowledgeManager.to_indexable(arch_doc))
+        search_engine.index(KnowledgeManager.to_indexable(other_doc))
 
         results = search_engine.semantic_search(
             "event-driven message queues", limit=10, threshold=0.0, path_prefix="architecture"
@@ -863,7 +863,7 @@ class TestSearchEngineResiliency:
             )
         ).document
         # Should not raise even though Tantivy is broken
-        chunks = search_engine.index_document(doc)
+        chunks = search_engine.index(KnowledgeManager.to_indexable(doc))
         # Chroma still works, so chunks > 0
         assert chunks >= 1
 
@@ -888,7 +888,7 @@ class TestSearchEngineResiliency:
         ).document
 
         with pytest.raises(IndexingError) as exc_info:
-            search_engine.index_document(doc)
+            search_engine.index(KnowledgeManager.to_indexable(doc))
 
         assert "tantivy" in exc_info.value.backend_errors
         assert "chroma" in exc_info.value.backend_errors
@@ -911,10 +911,10 @@ class TestSearchEngineResiliency:
                 agent="test-agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         # Should not raise even though Tantivy remove is broken
-        search_engine.remove_document(doc.id)  # no exception
+        search_engine.remove(doc.id)  # no exception
 
     @pytest.mark.asyncio
     async def test_remove_document_total_failure_raises(
@@ -929,7 +929,7 @@ class TestSearchEngineResiliency:
         search_engine.chroma.remove_document = _boom  # type: ignore[method-assign]
 
         with pytest.raises(IndexingError) as exc_info:
-            search_engine.remove_document("fake-doc-id")
+            search_engine.remove("fake-doc-id")
 
         assert "tantivy" in exc_info.value.backend_errors
         assert "chroma" in exc_info.value.backend_errors
@@ -1076,7 +1076,7 @@ class TestExpiresAtInSearch:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("expired research")
         assert len(results) >= 1
@@ -1099,7 +1099,7 @@ class TestExpiresAtInSearch:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("fresh research")
         assert len(results) >= 1
@@ -1119,7 +1119,7 @@ class TestExpiresAtInSearch:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("no expiry research")
         assert len(results) >= 1
@@ -1142,7 +1142,7 @@ class TestExpiresAtInSearch:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.semantic_search("machine learning expired")
         match = [r for r in results if r.id == doc.id]
@@ -1164,7 +1164,7 @@ class TestExpiresAtInSearch:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.semantic_search("deep learning fresh")
         match = [r for r in results if r.id == doc.id]
@@ -1183,7 +1183,7 @@ class TestExpiresAtInSearch:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.semantic_search("neural networks no expiry")
         match = [r for r in results if r.id == doc.id]
@@ -1228,7 +1228,7 @@ class TestHybridSearch:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.hybrid_search("distributed systems consensus")
 
@@ -1250,7 +1250,7 @@ class TestHybridSearch:
                 agent="agent",
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.full_text_search("BM25 full text")
 
@@ -1270,7 +1270,7 @@ class TestHybridSearch:
                 tags=["python"],
             )
         ).document
-        search_engine.index_document(doc)
+        search_engine.index(KnowledgeManager.to_indexable(doc))
 
         results = search_engine.hybrid_search("Python programming")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lithos.config import LithosConfig
+from lithos.knowledge import KnowledgeManager
 from lithos.search import SearchEngine
 from lithos.server import LithosServer, _FileChangeHandler, create_server, get_server
 
@@ -210,7 +211,7 @@ class TestServerInitialization:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path
@@ -408,7 +409,7 @@ class TestKnowledgeToolWorkflow:
                 agent="agent",
             )
         ).document
-        server.search.index_document(target)
+        server.search.index(KnowledgeManager.to_indexable(target))
         server.graph.add_document(target)
 
         # Create source with link
@@ -419,7 +420,7 @@ class TestKnowledgeToolWorkflow:
                 agent="agent",
             )
         ).document
-        server.search.index_document(source)
+        server.search.index(KnowledgeManager.to_indexable(source))
         server.graph.add_document(source)
 
         # Verify graph has edge
@@ -782,7 +783,7 @@ class TestKnowledgeToolWorkflow:
                 path="watched",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path
@@ -811,7 +812,7 @@ class TestSearchToolWorkflow:
                 tags=["kubernetes", "deployment"],
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         # Search should find it
         results = server.search.full_text_search("Kubernetes kubectl")
@@ -830,7 +831,7 @@ class TestSearchToolWorkflow:
                 agent="agent",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         # Search with related but different terms
         results = server.search.semantic_search("dealing with failures in software")
@@ -858,8 +859,8 @@ class TestSearchToolWorkflow:
                 tags=["java"],
             )
         ).document
-        server.search.index_document(python_doc)
-        server.search.index_document(java_doc)
+        server.search.index(KnowledgeManager.to_indexable(python_doc))
+        server.search.index(KnowledgeManager.to_indexable(java_doc))
 
         # Search with tag filter
         results = server.search.full_text_search("Programming", tags=["python"])
@@ -1106,7 +1107,7 @@ class TestEndToEndScenarios:
                 tags=["research", "api"],
             )
         ).document
-        server.search.index_document(research_doc)
+        server.search.index(KnowledgeManager.to_indexable(research_doc))
         server.graph.add_document(research_doc)
 
         # Step 4: Researcher posts finding
@@ -1152,7 +1153,7 @@ Based on [[api-research-notes]].
                 tags=["documentation", "api"],
             )
         ).document
-        server.search.index_document(docs)
+        server.search.index(KnowledgeManager.to_indexable(docs))
         server.graph.add_document(docs)
 
         # Step 9: Verify graph connection
@@ -1202,7 +1203,7 @@ Based on [[api-research-notes]].
                     tags=tags,
                 )
             ).document
-            server.search.index_document(doc)
+            server.search.index(KnowledgeManager.to_indexable(doc))
             server.graph.add_document(doc)
             created_docs[title] = doc
 
@@ -1235,7 +1236,7 @@ Based on [[api-research-notes]].
                     tags=["stats"],
                 )
             ).document
-            server.search.index_document(doc)
+            server.search.index(KnowledgeManager.to_indexable(doc))
             server.graph.add_document(doc)
 
         await server.coordination.register_agent("stats-agent")
@@ -1469,7 +1470,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(server, query="quantum computing", tags=["research"])
         assert result["hit"] is True
@@ -1493,7 +1494,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(server, query="AI trends", tags=["research"])
         assert result["hit"] is False
@@ -1524,7 +1525,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(
             server,
@@ -1548,7 +1549,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(
             server,
@@ -1572,7 +1573,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(
             server, query="dark matter theories", min_confidence=0.5
@@ -1595,7 +1596,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(low_doc)
+        server.search.index(KnowledgeManager.to_indexable(low_doc))
 
         high_doc = (
             await server.knowledge.create(
@@ -1606,7 +1607,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(high_doc)
+        server.search.index(KnowledgeManager.to_indexable(high_doc))
 
         # Force both docs into candidates list to test sorting
         with patch.object(
@@ -1648,7 +1649,7 @@ class TestCacheLookup:
         path.write_text(doc.to_markdown())
         # Re-read to reload from disk
         server.knowledge._id_to_path[doc.id] = doc.path
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(
             server, query="blockchain consensus", max_age_hours=24
@@ -1671,7 +1672,7 @@ class TestCacheLookup:
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
 
         # Should fail tag filter (doc has "python" but we ask for "rust")
         result = await self._call_cache_lookup(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,6 +5,7 @@ Run with:  uv run pytest tests/test_smoke.py -v
 
 import pytest
 
+from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
 
 pytestmark = pytest.mark.integration
@@ -22,7 +23,7 @@ async def test_smoke_write_index_search(server: LithosServer):
             tags=["smoke", "test"],
         )
     ).document
-    server.search.index_document(doc)
+    server.search.index(KnowledgeManager.to_indexable(doc))
     server.graph.add_document(doc)
 
     # Full-text search

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
 
 
@@ -1097,7 +1098,7 @@ class TestFileWatcherEventsCounter:
                 agent="test-agent",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path
@@ -1125,7 +1126,7 @@ class TestFileWatcherEventsCounter:
                 agent="test-agent",
             )
         ).document
-        server.search.index_document(doc)
+        server.search.index(KnowledgeManager.to_indexable(doc))
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path


### PR DESCRIPTION
## Summary

Slice 3 of the seam-tightening work in `docs/plans/seam-tightening-search.md` (Phase 1 type definition + downstream migration) and `docs/adr/0002-search-engine-hides-its-backends.md`.

Introduces `IndexableDocument` as the **only** document shape that crosses into `SearchEngine`. `KnowledgeDocument` no longer reaches the backends.

### New seam type

- `IndexableDocument` (frozen dataclass) added in `src/lithos/search.py` with the exact fields Tantivy and Chroma write — verified by reading `TantivyIndex.add_document` and `ChromaIndex.add_document`:
  - `id, title, content, path, author, tags (tuple[str, ...]), source_url, updated_at, expires_at` — all required, all strings.
  - `full_content` property gives the title-prefixed form Tantivy stores.
- `KnowledgeManager.to_indexable(doc)` staticmethod is the single translation point. Coerces `None → ""`, `Path → str`, `list → tuple`, `datetime → ISO`.

### Method rename

`SearchEngine.index_document` → `SearchEngine.index`, `SearchEngine.remove_document` → `SearchEngine.remove`. Names match the agent-facing contract; no deprecation aliases.

### Migrations

- `TantivyIndex.add_document`, `TantivyIndex.rebuild_from_docs`, `ChromaIndex.add_document` accept `IndexableDocument`. Backends become dumb writers — no more inline None-coercion.
- `cli.py reindex`, `server.py` (lifespan + file watcher + `lithos_write` + `lithos_delete`), `reconcile.py` route every index/remove call through `KnowledgeManager.to_indexable`.
- 9 test files updated. Regression guard in `test_async_search.py` rewritten for the `index`/`remove` names.

### New tests

`tests/test_indexable_document.py` covers:
- Immutability (`FrozenInstanceError` on assignment)
- `full_content` composition
- Each `to_indexable` coercion: required fields, `Path → str`, `None → ""`, `list → tuple`, `datetime → ISO`
- End-to-end index/remove round trip through the seam type

Closes #225.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `tests/test_indexable_document.py` — 8 passed locally
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
