### PR TITLE
feat(reconcile): indices reconcile via KnowledgeManager

### DIFF
--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -21,7 +21,12 @@ from lithos.errors import SlugCollisionError
 from lithos.telemetry import lithos_metrics, timed_write, traced
 
 if TYPE_CHECKING:
-    from lithos.search import IndexableDocument
+    from lithos.search import (
+        IndexableDocument,
+        SearchEngine,
+        SearchReconcilePlan,
+        SearchReconcileResult,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -616,6 +621,24 @@ _UNSET = _UnsetType()
 """Sentinel for omit-vs-clear distinction on optional fields."""
 
 
+@dataclass(frozen=True)
+class ReconcilePlan:
+    """Aggregate reconcile plan owned by :class:`KnowledgeManager`.
+
+    Carries one slice per derived view. Today only the search slice exists;
+    ``graph=`` and ``provenance=`` fields land in later ADR-0001 phases.
+    """
+
+    search: "SearchReconcilePlan"
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Outcome of applying a :class:`ReconcilePlan`."""
+
+    search: "SearchReconcileResult"
+
+
 class KnowledgeManager:
     """Manages knowledge documents - CRUD operations."""
 
@@ -641,6 +664,32 @@ class KnowledgeManager:
             updated_at=(doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else ""),
             expires_at=(doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else ""),
         )
+
+    async def _scan_corpus(self) -> list[KnowledgeDocument]:
+        """Return every document in the authoritative markdown corpus.
+
+        Owned by KnowledgeManager because the corpus is its source of truth.
+        Reconciliation reads through here; it never writes.
+        """
+        _, total = await self.list_all(limit=0)
+        if total == 0:
+            return []
+        docs, _ = await self.list_all(limit=total)
+        return docs
+
+    async def plan_reconcile(self, search: "SearchEngine") -> ReconcilePlan:
+        """Plan a reconcile of every derived view against the corpus.
+
+        Today only the search slice is populated. The ``graph`` and
+        ``provenance`` fields land in later ADR-0001 phases.
+        """
+        corpus = await self._scan_corpus()
+        indexables = [self.to_indexable(d) for d in corpus]
+        return ReconcilePlan(search=search.plan_reconcile_to(indexables))
+
+    async def apply_reconcile(self, plan: ReconcilePlan, search: "SearchEngine") -> ReconcileResult:
+        """Apply *plan* — bringing each derived view back into agreement."""
+        return ReconcileResult(search=search.apply_reconcile(plan.search))
 
     def __init__(self, config: LithosConfig):
         """Initialize knowledge manager.

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -65,17 +65,14 @@ def _make_result(
 
 
 async def _scan_corpus(config: LithosConfig) -> list[KnowledgeDocument]:
-    """Return all documents from the authoritative markdown corpus.
+    """Backwards-compatibility shim around :meth:`KnowledgeManager._scan_corpus`.
 
-    Passes ``config`` explicitly into KnowledgeManager so that callers
-    using a non-global config (e.g. tests) get the correct knowledge path.
+    The corpus scan itself moved onto :class:`KnowledgeManager` in #226 because
+    the corpus is its source of truth. This shim still feeds the
+    ``_reconcile_graph`` and ``_reconcile_provenance_projection`` paths; both
+    fold onto KM in later ADR-0001 phases, at which point this shim is deleted.
     """
-    knowledge = KnowledgeManager(config=config)
-    _, total = await knowledge.list_all(limit=0)
-    if total == 0:
-        return []
-    docs, _ = await knowledge.list_all(limit=total)
-    return docs
+    return await KnowledgeManager(config=config)._scan_corpus()
 
 
 def _aggregate_status(statuses: list[ReconcileStatus]) -> ReconcileStatus:
@@ -96,107 +93,69 @@ def _aggregate_status(statuses: list[ReconcileStatus]) -> ReconcileStatus:
 
 
 async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, Any]:
-    """Reconcile Tantivy and ChromaDB indices against the markdown corpus."""
+    """Reconcile the search indices via :class:`KnowledgeManager` (#226).
+
+    KM owns the corpus scan and orchestrates the search slice; this function
+    is a thin adapter that translates the structured
+    :class:`~lithos.knowledge.ReconcilePlan` /
+    :class:`~lithos.knowledge.ReconcileResult` back into the legacy dict shape
+    the public ``reconcile()`` aggregator returns.
+    """
     tracer = get_tracer()
-    actions: list[dict[str, Any]] = []
-    failures: list[dict[str, Any]] = []
 
     logger.info(
         "reconcile indices started: dry_run=%s",
         dry_run,
         extra={"scope": "indices", "dry_run": dry_run},
     )
-    with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
-        scan_span.set_attribute("lithos.reconcile.scope", "indices")
-        try:
-            corpus_docs = await _scan_corpus(config)
-        except Exception as exc:
-            logger.error("Failed to scan corpus for indices reconcile: %s", exc)
-            return _make_result(
-                "indices",
-                dry_run,
-                status="failed",
-                failed=1,
-                failures=[{"code": "internal_error", "detail": str(exc)}],
-            )
-        corpus_ids = {doc.id for doc in corpus_docs}
 
-    search = await SearchEngine.create(config)
-    with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
-        diff_span.set_attribute("lithos.reconcile.scope", "indices")
+    knowledge = KnowledgeManager(config=config)
+    try:
+        with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
+            scan_span.set_attribute("lithos.reconcile.scope", "indices")
+            search = await SearchEngine.create(config)
+            with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
+                diff_span.set_attribute("lithos.reconcile.scope", "indices")
+                plan = await knowledge.plan_reconcile(search)
+    except Exception as exc:
+        logger.error("Failed to plan indices reconcile: %s", exc)
+        return _make_result(
+            "indices",
+            dry_run,
+            status="failed",
+            failed=1,
+            failures=[{"code": "internal_error", "detail": str(exc)}],
+        )
 
-        # --- Tantivy drift detection ---
-        try:
-            if search.tantivy.needs_rebuild:
-                actions.append(
-                    {"backend": "tantivy", "action": "full_rebuild", "reason": "schema_mismatch"}
-                )
-            else:
-                tantivy_ids = search.tantivy.get_indexed_doc_ids()
-                if tantivy_ids != corpus_ids:
-                    actions.append(
-                        {
-                            "backend": "tantivy",
-                            "action": "full_rebuild",
-                            "reason": "doc_set_mismatch",
-                        }
-                    )
-        except Exception as exc:
-            logger.warning("Tantivy drift check failed: %s", exc)
-            actions.append(
-                {"backend": "tantivy", "action": "full_rebuild", "reason": "check_failed"}
-            )
+    actions = [
+        {"backend": a.backend, "action": a.action, "reason": a.reason} for a in plan.search.actions
+    ]
+    scanned = plan.search.scanned
 
-        # --- ChromaDB drift detection ---
-        try:
-            chroma_doc_ids = search.chroma.get_indexed_doc_ids()
-            if chroma_doc_ids != corpus_ids:
-                actions.append(
-                    {"backend": "chroma", "action": "full_rebuild", "reason": "doc_set_mismatch"}
-                )
-        except Exception as exc:
-            logger.warning("ChromaDB drift check failed: %s", exc)
-            actions.append(
-                {"backend": "chroma", "action": "full_rebuild", "reason": "check_failed"}
-            )
-
-    if not actions:
-        return _make_result("indices", dry_run, status="noop", scanned=len(corpus_docs))
+    if plan.search.is_noop:
+        return _make_result("indices", dry_run, status="noop", scanned=scanned)
 
     if dry_run:
         return _make_result(
             "indices",
             dry_run,
             status="ok",
-            scanned=len(corpus_docs),
+            scanned=scanned,
             repaired=len(actions),
             actions=actions,
         )
 
-    # Apply repairs
-    repaired = 0
     with tracer.start_as_current_span("lithos.reconcile.apply") as apply_span:
         apply_span.set_attribute("lithos.reconcile.scope", "indices")
-        for action in actions:
-            backend = action["backend"]
-            apply_span.set_attribute("lithos.reconcile.backend", backend)
-            try:
-                if backend == "tantivy":
-                    indexables = [KnowledgeManager.to_indexable(d) for d in corpus_docs]
-                    search.tantivy.rebuild_from_docs(indexables)
-                    repaired += 1
-                elif backend == "chroma":
-                    search.chroma.clear()
-                    for doc in corpus_docs:
-                        search.chroma.add_document(KnowledgeManager.to_indexable(doc))
-                    repaired += 1
-            except Exception as exc:
-                logger.error("Failed to repair %s backend: %s", backend, exc)
-                failures.append(
-                    {"code": "index_rebuild_failed", "backend": backend, "detail": str(exc)}
-                )
+        result = await knowledge.apply_reconcile(plan, search)
 
+    repaired = result.search.repaired
+    failures = [
+        {"code": "index_rebuild_failed", "backend": f.backend, "detail": f.detail}
+        for f in result.search.failed
+    ]
     n_failed = len(failures)
+
     if n_failed == 0:
         status: ReconcileStatus = "ok"
     elif repaired == 0:
@@ -208,14 +167,14 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
     logger.info(
         "reconcile indices complete: status=%s scanned=%d repaired=%d failed=%d dry_run=%s",
         status,
-        len(corpus_docs),
+        scanned,
         repaired,
         n_failed,
         dry_run,
         extra={
             "scope": "indices",
             "status": status,
-            "scanned": len(corpus_docs),
+            "scanned": scanned,
             "repaired": repaired,
             "failed": n_failed,
             "dry_run": dry_run,
@@ -225,7 +184,7 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
         "indices",
         dry_run,
         status=status,
-        scanned=len(corpus_docs),
+        scanned=scanned,
         repaired=repaired,
         failed=n_failed,
         actions=actions,

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -93,6 +93,56 @@ class IndexableDocument:
 
 
 @dataclass(frozen=True)
+class ReconcileAction:
+    """One action a search-engine reconcile would take.
+
+    ``backend`` names the affected backend (``tantivy`` or ``chroma``);
+    ``action`` is the operation (currently always ``full_rebuild``);
+    ``reason`` is the drift signal that prompted it.
+    """
+
+    backend: str
+    action: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ReconcileFailure:
+    """A backend that errored while applying a reconcile action."""
+
+    backend: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class SearchReconcilePlan:
+    """The dry-run output of :meth:`SearchEngine.plan_reconcile_to`.
+
+    Carries enough context that applying it is mechanical: the list of
+    actions plus the corpus snapshot used to build them.
+    """
+
+    actions: tuple[ReconcileAction, ...]
+    docs: tuple[IndexableDocument, ...]
+    scanned: int
+
+    @property
+    def is_noop(self) -> bool:
+        """True when no drift was detected."""
+        return not self.actions
+
+
+@dataclass(frozen=True)
+class SearchReconcileResult:
+    """The outcome of applying a :class:`SearchReconcilePlan`."""
+
+    actions: tuple[ReconcileAction, ...]
+    repaired: int
+    failed: tuple[ReconcileFailure, ...]
+    scanned: int
+
+
+@dataclass(frozen=True)
 class Healthy:
     """The search engine is operational."""
 
@@ -1650,7 +1700,91 @@ class SearchEngine:
 
         Set during :meth:`create` when the Tantivy schema-version check forces a
         recreate. Read by the server lifespan to decide whether to trigger an
-        initial corpus rebuild. After #226 lands this becomes part of the
-        ``KnowledgeManager.plan_reconcile`` result.
+        initial corpus rebuild. After the graph fold this becomes part of the
+        :meth:`~lithos.knowledge.KnowledgeManager.plan_reconcile` result.
         """
         return self.tantivy.needs_rebuild
+
+    def plan_reconcile_to(self, docs: Iterable[IndexableDocument]) -> SearchReconcilePlan:
+        """Compute a :class:`SearchReconcilePlan` describing drift against *docs*.
+
+        Internal to :class:`~lithos.knowledge.KnowledgeManager` — agents call
+        ``KnowledgeManager.plan_reconcile``, which delegates here. Stores the
+        snapshot of *docs* on the plan so that
+        :meth:`apply_reconcile` is mechanical.
+        """
+        snapshot = tuple(docs)
+        corpus_ids = {d.id for d in snapshot}
+        actions: list[ReconcileAction] = []
+
+        # --- Tantivy drift detection ---
+        try:
+            if self.tantivy.needs_rebuild:
+                actions.append(
+                    ReconcileAction(
+                        backend="tantivy", action="full_rebuild", reason="schema_mismatch"
+                    )
+                )
+            else:
+                tantivy_ids = self.tantivy.get_indexed_doc_ids()
+                if tantivy_ids != corpus_ids:
+                    actions.append(
+                        ReconcileAction(
+                            backend="tantivy",
+                            action="full_rebuild",
+                            reason="doc_set_mismatch",
+                        )
+                    )
+        except Exception as exc:
+            logger.warning("Tantivy drift check failed: %s", exc)
+            actions.append(
+                ReconcileAction(backend="tantivy", action="full_rebuild", reason="check_failed")
+            )
+
+        # --- ChromaDB drift detection ---
+        try:
+            chroma_ids = self.chroma.get_indexed_doc_ids()
+            if chroma_ids != corpus_ids:
+                actions.append(
+                    ReconcileAction(
+                        backend="chroma", action="full_rebuild", reason="doc_set_mismatch"
+                    )
+                )
+        except Exception as exc:
+            logger.warning("ChromaDB drift check failed: %s", exc)
+            actions.append(
+                ReconcileAction(backend="chroma", action="full_rebuild", reason="check_failed")
+            )
+
+        return SearchReconcilePlan(actions=tuple(actions), docs=snapshot, scanned=len(snapshot))
+
+    def apply_reconcile(self, plan: SearchReconcilePlan) -> SearchReconcileResult:
+        """Execute *plan* against both backends; return per-action status.
+
+        Idempotent — applying twice produces the same backend state. Per-backend
+        failures surface via :attr:`SearchReconcileResult.failed`; one
+        backend's failure does not block the other from being repaired.
+        """
+        repaired = 0
+        failures: list[ReconcileFailure] = []
+
+        for action in plan.actions:
+            try:
+                if action.backend == "tantivy":
+                    self.tantivy.rebuild_from_docs(plan.docs)
+                    repaired += 1
+                elif action.backend == "chroma":
+                    self.chroma.clear()
+                    for doc in plan.docs:
+                        self.chroma.add_document(doc)
+                    repaired += 1
+            except Exception as exc:
+                logger.error("Failed to repair %s backend: %s", action.backend, exc)
+                failures.append(ReconcileFailure(backend=action.backend, detail=str(exc)))
+
+        return SearchReconcileResult(
+            actions=plan.actions,
+            repaired=repaired,
+            failed=tuple(failures),
+            scanned=plan.scanned,
+        )

--- a/tests/test_search_reconcile.py
+++ b/tests/test_search_reconcile.py
@@ -1,0 +1,167 @@
+"""Tests for SearchEngine plan_reconcile_to / apply_reconcile (#226)."""
+
+from __future__ import annotations
+
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.knowledge import KnowledgeManager
+from lithos.search import (
+    IndexableDocument,
+    ReconcileFailure,
+    SearchEngine,
+)
+
+
+def _make_indexable(doc_id: str = "11111111-1111-1111-1111-111111111111") -> IndexableDocument:
+    return IndexableDocument(
+        id=doc_id,
+        title="Reconcile Test",
+        content="Body for reconcile test.",
+        path="notes/reconcile-test.md",
+        author="alice",
+        tags=("reconcile",),
+        source_url="",
+        updated_at="",
+        expires_at="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_returns_noop_when_corpus_matches(test_config: LithosConfig) -> None:
+    """No drift → plan is a noop with zero actions."""
+    engine = await SearchEngine.create(test_config)
+    indexable = _make_indexable()
+    engine.index(indexable)
+    # Tantivy may have flipped needs_rebuild during create(); flatten by
+    # rebuilding through the public reconcile flow once first.
+    engine.tantivy.needs_rebuild = False
+
+    plan = engine.plan_reconcile_to([indexable])
+
+    assert plan.is_noop
+    assert plan.actions == ()
+    assert plan.scanned == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_reports_schema_mismatch_when_tantivy_needs_rebuild(
+    test_config: LithosConfig,
+) -> None:
+    """Tantivy.needs_rebuild=True surfaces as full_rebuild / schema_mismatch."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = True
+
+    plan = engine.plan_reconcile_to([_make_indexable()])
+
+    tantivy_actions = [a for a in plan.actions if a.backend == "tantivy"]
+    assert len(tantivy_actions) == 1
+    assert tantivy_actions[0].action == "full_rebuild"
+    assert tantivy_actions[0].reason == "schema_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_plan_reports_doc_set_mismatch(test_config: LithosConfig) -> None:
+    """Corpus and index disagree → full_rebuild / doc_set_mismatch on both backends."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = False
+    # Index nothing; corpus has one doc.
+    plan = engine.plan_reconcile_to([_make_indexable()])
+
+    reasons_by_backend = {a.backend: a.reason for a in plan.actions}
+    assert reasons_by_backend.get("tantivy") == "doc_set_mismatch"
+    assert reasons_by_backend.get("chroma") == "doc_set_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_apply_repairs_drifted_index(test_config: LithosConfig) -> None:
+    """apply_reconcile rebuilds both backends so subsequent search finds the doc."""
+    engine = await SearchEngine.create(test_config)
+    indexable = _make_indexable()
+    engine.tantivy.needs_rebuild = False
+
+    plan = engine.plan_reconcile_to([indexable])
+    result = engine.apply_reconcile(plan)
+
+    assert result.repaired >= 1
+    assert result.failed == ()
+    assert any(r.id == indexable.id for r in engine.full_text_search("reconcile"))
+
+
+@pytest.mark.asyncio
+async def test_apply_is_idempotent(test_config: LithosConfig) -> None:
+    """Applying the same plan twice leaves the index in the same state."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = False
+    indexable = _make_indexable()
+    plan = engine.plan_reconcile_to([indexable])
+
+    engine.apply_reconcile(plan)
+    engine.apply_reconcile(plan)
+
+    # Index has exactly one document for this id.
+    matches = [r for r in engine.full_text_search("reconcile") if r.id == indexable.id]
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_surfaces_per_backend_failures(test_config: LithosConfig) -> None:
+    """A single backend failure lands as a ReconcileFailure; the other still repairs."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = False
+    indexable = _make_indexable()
+    plan = engine.plan_reconcile_to([indexable])
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated tantivy failure")
+
+    engine.tantivy.rebuild_from_docs = _boom  # type: ignore[method-assign]
+
+    result = engine.apply_reconcile(plan)
+
+    assert any(isinstance(f, ReconcileFailure) and f.backend == "tantivy" for f in result.failed)
+    # Chroma still got rebuilt.
+    assert result.repaired >= 1
+
+
+@pytest.mark.asyncio
+async def test_km_plan_matches_search_engine_plan(test_config: LithosConfig) -> None:
+    """KM.plan_reconcile.search slice matches SearchEngine.plan_reconcile_to() for the same corpus."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = False
+    knowledge = KnowledgeManager(test_config)
+
+    km_plan = await knowledge.plan_reconcile(engine)
+
+    # Both plans built from the same (empty) corpus see the same noop state.
+    direct = engine.plan_reconcile_to([])
+    assert km_plan.search.actions == direct.actions
+    assert km_plan.search.scanned == direct.scanned
+
+
+@pytest.mark.asyncio
+async def test_km_apply_repairs_drifted_corpus(
+    test_config: LithosConfig,
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """End-to-end: KM.apply_reconcile rebuilds indices to match the on-disk corpus."""
+    engine = await SearchEngine.create(test_config)
+    engine.tantivy.needs_rebuild = False
+
+    # Seed a real document via the knowledge manager — this writes markdown
+    # but does not index, leaving the indices drifted.
+    write_result = await knowledge_manager.create(
+        title="KM Reconcile Doc",
+        content="Drifted content that the indices have never seen.",
+        agent="agent",
+    )
+    assert write_result.document is not None
+
+    plan = await knowledge_manager.plan_reconcile(engine)
+    assert not plan.search.is_noop
+
+    result = await knowledge_manager.apply_reconcile(plan, engine)
+    assert result.search.failed == ()
+
+    hits = engine.full_text_search("Drifted content")
+    assert any(r.id == write_result.document.id for r in hits)


### PR DESCRIPTION
## Summary

Slice 4 of the seam-tightening work in `docs/plans/seam-tightening-search.md` (Phases 3, 4, 6), `docs/adr/0001-reconciliation-lives-on-knowledge-manager.md`, and `docs/adr/0002-search-engine-hides-its-backends.md`.

Folds the indices scope of reconciliation onto `KnowledgeManager`. The heavy detection and apply logic moves out of `reconcile.py` and onto a private plan/apply pair on `SearchEngine`, consumed only by `KnowledgeManager`.

### `SearchEngine` plan/apply (in `src/lithos/search.py`)

- `ReconcileAction(backend, action, reason)`, `ReconcileFailure(backend, detail)`, `SearchReconcilePlan(actions, docs, scanned)`, and `SearchReconcileResult(actions, repaired, failed, scanned)` added as frozen dataclasses.
- `SearchEngine.plan_reconcile_to(docs)` internalises the drift detection formerly at `reconcile.py:130-161` (`needs_rebuild`, `get_indexed_doc_ids`, doc-set diff). The plan stores the corpus snapshot.
- `SearchEngine.apply_reconcile(plan)` internalises the apply formerly at `reconcile.py:178-196` (`rebuild_from_docs`, `clear` + `add_document` loop) and returns per-action status.

### `KnowledgeManager` composition (indices only)

- `_scan_corpus` moved onto `KnowledgeManager` as an async private method — KM owns the corpus, so the scan lives where the source of truth lives.
- `ReconcilePlan` and `ReconcileResult` wrapper dataclasses added in `src/lithos/knowledge.py` with a single `search=` field today, leaving room for `graph=` and `provenance=` fields in later ADR-0001 phases.
- `KnowledgeManager.plan_reconcile(search)` scans the corpus, calls `search.plan_reconcile_to`, and wraps the result.
- `KnowledgeManager.apply_reconcile(plan, search)` calls `search.apply_reconcile` and wraps.

### CLI and `reconcile.py`

- `_reconcile_indices` in `src/lithos/reconcile.py` is now a thin adapter that translates KM's structured `ReconcilePlan` / `ReconcileResult` into the legacy dict shape the public `reconcile()` aggregator returns. The detection and apply logic it used to carry is gone.
- `_scan_corpus` in `reconcile.py` becomes a backward-compat shim around `KnowledgeManager._scan_corpus`, comment-tagged for ADR-0001 — it disappears with the graph fold.
- `_reconcile_graph` and `_reconcile_provenance_projection` are untouched.

### Tests

- `tests/test_search_reconcile.py` covers the new SearchEngine plan/apply: noop on match, `schema_mismatch` when `needs_rebuild=True`, `doc_set_mismatch` when corpus and index disagree, idempotent apply, per-backend `ReconcileFailure` surfaces correctly. Two tests cover `KM.plan_reconcile` and end-to-end `KM.apply_reconcile` against an artificially-drifted corpus.
- `tests/test_reconcile.py` and `tests/test_provenance_projection.py` pass unchanged through the new dispatch.

Closes #226.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `tests/test_search_reconcile.py` — 8 passed locally
- [x] `tests/test_reconcile.py` + `tests/test_provenance_projection.py` — 27 passed locally
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
