### PR TITLE
fix(coordination): WARN log when _parse_datetime cannot parse a value

### DIFF
--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -163,7 +163,15 @@ class AccessLogEntry:
 
 
 def _parse_datetime(value: str | datetime | None) -> datetime | None:
-    """Parse datetime from SQLite."""
+    """Parse a datetime from SQLite.
+
+    Returns ``None`` for legitimately-missing values (the field is NULL or
+    already ``None``) and *also* for values the parser could not interpret.
+    Unparseable values are logged at WARNING with the offending raw input so
+    that silent data corruption (a partial write, a manual edit, a schema
+    mismatch) shows up in operator logs rather than degrading silently to
+    ``None`` and then to ``datetime.now()`` at the call site (#205).
+    """
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -172,6 +180,10 @@ def _parse_datetime(value: str | datetime | None) -> datetime | None:
         # SQLite stores as ISO format string
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
+        logger.warning(
+            "Failed to parse datetime from SQLite value %r; treating as missing",
+            value,
+        )
         return None
 
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1214,3 +1214,35 @@ class TestTaskMetadata:
         task = await service.get_task("legacy-task-215")
         assert task is not None
         assert task.metadata == {}
+
+
+class TestParseDatetimeWarnsOnFailure:
+    """Regression for #205: silent None on parse failure hid data corruption."""
+
+    def test_returns_none_and_warns_on_unparseable_value(self, caplog):
+        """An unparseable string still returns None but emits a WARNING."""
+        import logging
+
+        from lithos.coordination import _parse_datetime
+
+        with caplog.at_level(logging.WARNING, logger="lithos.coordination"):
+            result = _parse_datetime("not-a-real-timestamp")
+
+        assert result is None
+        assert any(
+            "Failed to parse datetime" in r.getMessage()
+            and "not-a-real-timestamp" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_none_input_does_not_warn(self, caplog):
+        """Legitimately-missing values stay silent — only corruption is logged."""
+        import logging
+
+        from lithos.coordination import _parse_datetime
+
+        with caplog.at_level(logging.WARNING, logger="lithos.coordination"):
+            result = _parse_datetime(None)
+
+        assert result is None
+        assert not any("Failed to parse datetime" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

`_parse_datetime` previously returned `None` silently for both legitimately-missing values (NULL / `None` input) and unparseable strings. Call sites then fall back to `datetime.now(timezone.utc)`, so a corrupt timestamp in the SQLite tasks DB became "now" and was never flagged.

This PR keeps the silent path for legitimately-missing inputs and emits a WARNING with the offending raw value when parsing actually fails.

Closes #205.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] New regression tests in `tests/test_coordination.py::TestParseDatetimeWarnsOnFailure` cover both paths
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
