### PR TITLE
fix(search): /health stops embedding-encoding on every probe

### DIFF
--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -734,8 +734,23 @@ collection.count()
         return backup_path
 
     def health_check(self) -> None:
-        """Probe the embedding model (warm-up / liveness). Raises on failure."""
-        self.model.encode(["health check"], show_progress_bar=False)
+        """Cheap liveness probe of the embedding model.
+
+        Asserts the model is loaded and exposes its expected attributes.
+        Does **not** run a fresh ``encode`` — earlier this method invoked
+        ``self.model.encode(["health check"])`` on every probe, which
+        Docker HEALTHCHECKs and load-balancer liveness checks called every
+        few seconds. Cold starts also paid the full model load. (#198)
+
+        Raises ``RuntimeError`` if the model has not been loaded.
+        """
+        if self._model is None:
+            raise RuntimeError("embedding model not loaded")
+        # ``get_sentence_embedding_dimension`` is an O(1) attribute read on
+        # the loaded model — exercises that the model is structurally
+        # usable without doing any tensor work.
+        if self._model.get_sentence_embedding_dimension() is None:
+            raise RuntimeError("embedding model has no sentence-embedding dimension")
 
     @property
     def client(self) -> ClientAPI:

--- a/tests/test_search_health.py
+++ b/tests/test_search_health.py
@@ -87,3 +87,32 @@ async def test_needs_initial_rebuild_reflects_tantivy_state(
     # A freshly-created index has no schema marker on disk before create runs,
     # so open_or_create writes one and flips the rebuild flag.
     assert engine.needs_initial_rebuild() is True
+
+
+@pytest.mark.asyncio
+async def test_chroma_health_check_does_not_call_encode(
+    search_engine: SearchEngine,
+) -> None:
+    """Regression for #198: liveness probe must not invoke the embedding model.
+
+    The previous implementation called ``self.model.encode(["health check"])`` on
+    every HTTP /health hit, which Docker HEALTHCHECKs and load-balancer liveness
+    probes call every few seconds.
+    """
+    with patch.object(search_engine._chroma._model, "encode") as encode_spy:
+        search_engine._chroma.health_check()
+    encode_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chroma_health_check_raises_when_model_unloaded(
+    search_engine: SearchEngine,
+) -> None:
+    """Liveness probe still fails loudly when the model is genuinely missing."""
+    original = search_engine._chroma._model
+    search_engine._chroma._model = None
+    try:
+        with pytest.raises(RuntimeError, match="not loaded"):
+            search_engine._chroma.health_check()
+    finally:
+        search_engine._chroma._model = original


### PR DESCRIPTION
## Summary

`ChromaIndex.health_check` used to invoke `self.model.encode(["health check"])` on every call. The HTTP `/health` endpoint and `SearchEngine.health()` both route through this method, so Docker HEALTHCHECKs and load-balancer liveness probes paid the full encode cost on every poll, and cold starts triggered model load.

This PR replaces the encode with an O(1) attribute read that asserts the model is loaded and structurally usable:

```python
def health_check(self) -> None:
    if self._model is None:
        raise RuntimeError("embedding model not loaded")
    if self._model.get_sentence_embedding_dimension() is None:
        raise RuntimeError(...)
```

The eager model load in `SearchEngine.create()` (from #223 / #229) makes the model-loaded state guaranteed in production, so this assertion catches real failure modes without doing tensor work.

Closes #198.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] Two new regression tests in `tests/test_search_health.py`:
  - `test_chroma_health_check_does_not_call_encode` — proves the encode no longer fires
  - `test_chroma_health_check_raises_when_model_unloaded` — proves the genuine-failure path still works
- [x] Existing 7 health/count tests still pass
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
