### PR TITLE
fix(sse): replace soft-race int counter with asyncio.BoundedSemaphore

### DIFF
--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -142,8 +142,14 @@ class LithosServer:
             instructions="Local shared knowledge base for AI agents",
         )
 
-        # SSE delivery: track active client count
-        self._sse_client_count: int = 0
+        # SSE delivery: capacity-gated by an asyncio semaphore (#206).
+        # Replaces a plain int counter whose check-then-increment was a soft
+        # race. Single-threaded asyncio makes ``locked()`` + ``acquire()``
+        # atomic when no ``await`` lies between them — see
+        # :meth:`_try_acquire_sse_slot`.
+        self._sse_semaphore: asyncio.Semaphore = asyncio.BoundedSemaphore(
+            self._config.events.max_sse_clients
+        )
 
         # Register all tools
         self._register_tools()
@@ -450,7 +456,11 @@ class LithosServer:
                     media_type="text/plain",
                 )
 
-        if self._sse_client_count >= sse_config.max_sse_clients:
+        # Atomic capacity gate: locked() + acquire() are not preempted in
+        # single-threaded asyncio because acquire() returns synchronously when
+        # the semaphore is not locked (no ``await`` between observe and
+        # decrement). Replaces a soft-race int-counter check (#206).
+        if not await self._try_acquire_sse_slot():
             return Response(
                 content="Too many SSE clients",
                 status_code=429,
@@ -474,11 +484,6 @@ class LithosServer:
         )
 
         queue = self.event_bus.subscribe(event_types=event_types, tags=tag_filter)
-
-        # Increment before returning the StreamingResponse to avoid a soft race
-        # where concurrent requests all pass the capacity check before any
-        # generator starts and increments the counter.
-        self._sse_client_count += 1
 
         async def _event_stream():
             tracer = get_tracer()
@@ -520,7 +525,7 @@ class LithosServer:
                     conn_span.set_status(StatusCode.ERROR, str(exc))
                     logger.exception("SSE stream error")
                 finally:
-                    self._sse_client_count -= 1
+                    self._sse_semaphore.release()
                     self.event_bus.unsubscribe(queue)
 
         return StreamingResponse(
@@ -531,6 +536,28 @@ class LithosServer:
                 "X-Accel-Buffering": "no",
             },
         )
+
+    async def _try_acquire_sse_slot(self) -> bool:
+        """Non-blocking acquire of an SSE-client slot (#206).
+
+        Single-threaded asyncio guarantees atomicity: ``Semaphore.acquire``
+        returns synchronously when the semaphore is not locked, so the
+        ``locked()`` check and the decrement happen in the same event-loop
+        tick with no opportunity for a concurrent coroutine to race.
+        """
+        if self._sse_semaphore.locked():
+            return False
+        await self._sse_semaphore.acquire()
+        return True
+
+    def _sse_active_count(self) -> int:
+        """Number of currently-acquired SSE slots — backs the OTEL gauge.
+
+        ``asyncio.Semaphore`` does not expose remaining capacity through a
+        public API, so the active count is computed as ``max - available``
+        via the documented internal ``_value`` attribute.
+        """
+        return self._config.events.max_sse_clients - self._sse_semaphore._value  # type: ignore[attr-defined]
 
     async def initialize(self) -> None:
         """Initialize all components."""
@@ -576,7 +603,7 @@ class LithosServer:
                 register_active_claims_observer(lambda: self._cached_active_claims)
 
                 # Register SSE active clients gauge observer
-                register_sse_active_clients_observer(lambda: self._sse_client_count)
+                register_sse_active_clients_observer(self._sse_active_count)
 
                 # Register resource-level OTEL gauges
                 register_resource_gauges(

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -456,8 +456,9 @@ class TestMaxClients:
         server = LithosServer(config)
         await server.initialize()
         try:
-            # Simulate already-at-limit by bumping the counter
-            server._sse_client_count = 2
+            # Saturate the semaphore by acquiring every available slot.
+            for _ in range(2):
+                await server._sse_semaphore.acquire()
 
             request = _make_mock_request(server)
             response = await server._sse_endpoint(request)
@@ -473,7 +474,9 @@ class TestMaxClients:
         server = LithosServer(config)
         await server.initialize()
         try:
-            server._sse_client_count = 4  # one below limit
+            # Acquire 4 slots so only one remains free.
+            for _ in range(4):
+                await server._sse_semaphore.acquire()
 
             request = _make_mock_request(server)
             response = await server._sse_endpoint(request)
@@ -518,19 +521,19 @@ class TestSSEDisabled:
 class TestSSEClientCount:
     @pytest.mark.asyncio
     async def test_client_count_increments_decrements(self, temp_dir: Path) -> None:
-        """_sse_client_count should increment during streaming and decrement when done."""
+        """_sse_active_count() should report 0 before connect and 0 again after stream end."""
         config = _make_config(temp_dir)
         server = LithosServer(config)
         await server.initialize()
         try:
-            assert server._sse_client_count == 0
+            assert server._sse_active_count() == 0
 
             request = _make_mock_request(server)
             evt = LithosEvent(type=NOTE_CREATED)
             await _collect_sse_lines(server, request, emit_events=[evt])
 
-            # After streaming completes the count should return to 0
-            assert server._sse_client_count == 0
+            # After streaming completes the slot must be released.
+            assert server._sse_active_count() == 0
         finally:
             server.stop_file_watcher()
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1228,8 +1228,13 @@ class TestSSEMetrics:
 
         assert mock_counter.add.call_count == 3
 
-    async def test_sse_client_count_decrements_on_disconnect(self):
-        """_sse_client_count must decrement when the SSE async generator is closed early."""
+    async def test_sse_active_count_decrements_on_disconnect(self):
+        """The SSE semaphore slot must be released when the generator closes early.
+
+        Regression for #206: before the semaphore migration, this test asserted
+        on the now-removed ``_sse_client_count`` int.
+        """
+        import asyncio
         from unittest.mock import MagicMock
 
         from starlette.requests import Request
@@ -1241,10 +1246,9 @@ class TestSSEMetrics:
 
         # Build a minimal server skeleton — avoid full initialise()
         server = LithosServer.__new__(LithosServer)
-        server._sse_client_count = 0
-
         cfg = LithosConfig()
         server._config = cfg
+        server._sse_semaphore = asyncio.BoundedSemaphore(cfg.events.max_sse_clients)
 
         # No auth needed
         server.mcp = MagicMock()
@@ -1274,9 +1278,9 @@ class TestSSEMetrics:
         try:
             response = await server._sse_endpoint(request)
 
-            # At this point the count must have been incremented
-            assert server._sse_client_count == 1, (
-                f"Expected _sse_client_count=1 before streaming, got {server._sse_client_count}"
+            # The slot must have been acquired before the streaming response returns.
+            assert server._sse_active_count() == 1, (
+                f"Expected active=1 before streaming, got {server._sse_active_count()}"
             )
 
             body_iter = response.body_iterator
@@ -1293,9 +1297,9 @@ class TestSSEMetrics:
             if hasattr(body_iter, "aclose"):
                 await body_iter.aclose()
 
-            # After closing, the finally block must have run and decremented
-            assert server._sse_client_count == 0, (
-                f"Expected _sse_client_count=0 after disconnect, got {server._sse_client_count}"
+            # After closing, the finally block must have released the slot.
+            assert server._sse_active_count() == 0, (
+                f"Expected active=0 after disconnect, got {server._sse_active_count()}"
             )
         finally:
             tel_module.lithos_metrics._sse_events_delivered = orig


### PR DESCRIPTION
## Summary

The SSE endpoint used a plain `int` counter for connected clients and the comment itself acknowledged the soft race: two concurrent requests could both pass the capacity check before either incremented the counter.

The endpoint now gates capacity through an `asyncio.BoundedSemaphore`. In single-threaded asyncio, `Semaphore.acquire()` returns synchronously when the semaphore is not locked, so the `locked()` check and the slot decrement happen in the same event-loop tick — there is no opportunity for a concurrent coroutine to race.

### Changes

- `self._sse_client_count` int replaced with `self._sse_semaphore`.
- `_try_acquire_sse_slot()` helper does the non-blocking, atomic acquire.
- `_sse_active_count()` backs the OTEL gauge (`asyncio.Semaphore` has no public way to read remaining capacity; the active count is computed as `max - available` via the documented internal `_value`).
- Stream `finally`-block releases the slot.
- Two `TestMaxClients` tests migrated to saturate the semaphore by `acquire()`-ing slots instead of poking the removed counter.
- `TestSSEClientCount` asserts via `_sse_active_count()` instead of the removed counter.

Closes #206.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] All 29 `tests/test_event_delivery.py` tests pass locally
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
