### PR TITLE
fix(sync): handle FileMovedEvent so external renames preserve doc id

### DIFF
--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 NOTE_CREATED = "note.created"
 NOTE_UPDATED = "note.updated"
 NOTE_DELETED = "note.deleted"
+NOTE_RENAMED = "note.renamed"
 
 TASK_CREATED = "task.created"
 TASK_CLAIMED = "task.claimed"

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -27,6 +27,7 @@ from lithos.events import (
     FINDING_POSTED,
     NOTE_CREATED,
     NOTE_DELETED,
+    NOTE_RENAMED,
     NOTE_UPDATED,
     TASK_CANCELLED,
     TASK_CLAIMED,
@@ -879,6 +880,80 @@ class LithosServer:
         """Stop the enrichment background worker."""
         if self._enrich_worker is not None:
             await self._enrich_worker.stop()
+
+    async def handle_file_rename(self, src_path: Path, dest_path: Path) -> None:
+        """Handle a file-rename watchdog event (#202).
+
+        External renames (Obsidian rename, ``mv``, ``git checkout``) used to
+        be processed as a delete+create pair: the doc id was lost, wiki-links
+        pointing at the old path went stale, and the indices drifted until
+        the next reconcile. Now we update the path mapping under the same
+        doc id and re-index in place.
+
+        Behaviour by source/destination location:
+        - both inside knowledge_path → rename in place, emit ``note.renamed``.
+        - source inside, destination outside → treat as deletion.
+        - source outside, destination inside → treat as creation.
+        - both outside → no-op.
+        """
+        knowledge_path = self.config.storage.knowledge_path
+
+        def _relative_or_none(path: Path) -> Path | None:
+            try:
+                return path.relative_to(knowledge_path)
+            except ValueError:
+                return None
+
+        src_rel = _relative_or_none(src_path) if src_path.suffix == ".md" else None
+        dest_rel = _relative_or_none(dest_path) if dest_path.suffix == ".md" else None
+
+        if src_rel is None and dest_rel is None:
+            return
+        if src_rel is None and dest_rel is not None:
+            await self.handle_file_change(dest_path)
+            return
+        if src_rel is not None and dest_rel is None:
+            await self.handle_file_change(src_path, deleted=True)
+            return
+
+        # Genuine in-corpus rename.
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.file_rename") as span:
+            assert src_rel is not None
+            assert dest_rel is not None
+            span.set_attribute("lithos.src_path", str(src_rel))
+            span.set_attribute("lithos.dest_path", str(dest_rel))
+            async with self._update_lock:
+                try:
+                    doc_id = self.knowledge.get_id_by_path(src_rel)
+                    # ``sync_from_disk`` re-reads frontmatter and rebinds the
+                    # path mapping under the existing doc id. The graph and
+                    # search backends overwrite by id, so re-indexing closes
+                    # the loop without losing wiki-link targets.
+                    doc = await self.knowledge.sync_from_disk(dest_rel)
+                    indexable = KnowledgeManager.to_indexable(doc)
+                    await asyncio.to_thread(self.search.index, indexable)
+                    self.graph.add_document(doc)
+
+                    lithos_metrics.file_watcher_events.add(1, {"event_type": "renamed"})
+                    await self._emit(
+                        LithosEvent(
+                            type=NOTE_RENAMED,
+                            payload={
+                                "id": doc_id or doc.id,
+                                "src_path": str(src_rel),
+                                "dest_path": str(dest_rel),
+                            },
+                        )
+                    )
+                except FileNotFoundError:
+                    # Destination disappeared between the watchdog event and
+                    # our processing — treat as a deletion of the source.
+                    await self.handle_file_change(src_path, deleted=True)
+                except Exception as exc:
+                    logger.error(
+                        "Error handling file rename %s -> %s: %s", src_path, dest_path, exc
+                    )
 
     async def handle_file_change(self, path: Path, deleted: bool = False) -> None:
         """Handle a file change event."""
@@ -3405,10 +3480,35 @@ class _FileChangeHandler(FileSystemEventHandler):
         if not event.is_directory:
             self._schedule_update(Path(str(event.src_path)), deleted=True)
 
+    def on_moved(self, event: FileSystemEvent) -> None:
+        """Handle external file renames (#202).
+
+        Watchdog emits this on most platforms (POSIX inotify, macOS FSEvents,
+        Windows ReadDirectoryChangesW). Some network filesystems do not — in
+        that case watchdog falls back to a delete+create pair which still
+        works through the existing handlers, just less precisely.
+        """
+        if event.is_directory:
+            return
+        dest_path = getattr(event, "dest_path", None)
+        if dest_path is None:
+            return
+        self._schedule_rename(Path(str(event.src_path)), Path(str(dest_path)))
+
     def _schedule_update(self, path: Path, deleted: bool = False) -> None:
         try:
             future = asyncio.run_coroutine_threadsafe(
                 self.server.handle_file_change(path, deleted),
+                self._loop,
+            )
+            future.add_done_callback(self._log_future_exception)
+        except Exception:
+            pass
+
+    def _schedule_rename(self, src_path: Path, dest_path: Path) -> None:
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self.server.handle_file_rename(src_path, dest_path),
                 self._loop,
             )
             future.add_done_callback(self._log_future_exception)

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lithos.events import NOTE_DELETED, NOTE_UPDATED
+from lithos.events import NOTE_DELETED, NOTE_RENAMED, NOTE_UPDATED
 from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
 
@@ -123,6 +123,67 @@ class TestFileWatcherEventEmission:
 
         # Should not raise even though emit fails
         await server.handle_file_change(file_path, deleted=True)
+
+    async def test_file_rename_preserves_doc_id_and_emits_renamed(
+        self, server: LithosServer
+    ) -> None:
+        """An external rename keeps the doc id and emits ``note.renamed`` (#202)."""
+        doc = (
+            await server.knowledge.create(
+                title="Renamable Doc",
+                content="Body that survives a rename.",
+                agent="test-agent",
+                path="watched",
+            )
+        ).document
+        server.search.index(KnowledgeManager.to_indexable(doc))
+        server.graph.add_document(doc)
+
+        original_id = doc.id
+        knowledge_path = server.config.storage.knowledge_path
+        src_path = knowledge_path / doc.path
+        dest_rel = doc.path.with_name("renamed-doc.md")
+        dest_path = knowledge_path / dest_rel
+        src_path.rename(dest_path)
+
+        queue = server.event_bus.subscribe(event_types=[NOTE_RENAMED])
+        await server.handle_file_rename(src_path, dest_path)
+
+        # Path mapping is now under the destination, doc id unchanged.
+        assert server.knowledge.get_id_by_path(dest_rel) == original_id
+        # The old path is no longer in the path → id mapping.
+        assert server.knowledge.get_id_by_path(doc.path) is None
+        # The renamed event fired with both paths.
+        event = queue.get_nowait()
+        assert event.type == NOTE_RENAMED
+        assert event.payload["id"] == original_id
+        assert event.payload["src_path"] == str(doc.path)
+        assert event.payload["dest_path"] == str(dest_rel)
+
+    async def test_file_rename_updates_graph_path(self, server: LithosServer) -> None:
+        """Renamed files end up in the graph under the new path lookup (#202)."""
+        doc = (
+            await server.knowledge.create(
+                title="Graph Rename Doc",
+                content="Linked from elsewhere via [[graph-rename-doc]] won't matter for path lookup.",
+                agent="test-agent",
+                path="watched",
+            )
+        ).document
+        server.search.index(KnowledgeManager.to_indexable(doc))
+        server.graph.add_document(doc)
+
+        knowledge_path = server.config.storage.knowledge_path
+        src_path = knowledge_path / doc.path
+        dest_rel = doc.path.with_name("graph-renamed.md")
+        dest_path = knowledge_path / dest_rel
+        src_path.rename(dest_path)
+
+        await server.handle_file_rename(src_path, dest_path)
+
+        # Old path lookup gone, new path lookup wired to the same node.
+        assert server.graph._path_to_node.get(str(doc.path)) is None
+        assert server.graph._path_to_node.get(str(dest_rel)) == doc.id
 
     async def test_file_change_update_rebuilds_graph_edges(self, server: LithosServer) -> None:
         """handle_file_change rebuilds graph edges when a file is modified."""


### PR DESCRIPTION
## Summary

Watchdog has emitted `FileMovedEvent` for external renames all along, but `_FileChangeHandler` had no `on_moved` handler. Renames (Obsidian, `mv`, `git checkout`) degenerated into a delete+create pair processed in platform-dependent order — the doc id changed (or was lost), wiki-links pointing at the old path went stale, and the indices drifted until the next reconcile.

This PR adds a proper rename path:

- **`_FileChangeHandler.on_moved`** schedules `handle_file_rename` via the event loop using a new `_schedule_rename` helper.
- **`LithosServer.handle_file_rename(src, dest)`** covers four cases:
  - both inside `knowledge_path`: rename in place — `sync_from_disk` rebinds the path mapping under the existing doc id, search and graph backends overwrite by id, and a `NOTE_RENAMED` event fires with both src and dest paths.
  - source inside, destination outside: treat as deletion.
  - source outside, destination inside: treat as creation.
  - both outside: no-op.
- **New `events.NOTE_RENAMED` constant** (`"note.renamed"`).

### Tests

`tests/test_file_watcher_events.py` gains two regression tests:
- `test_file_rename_preserves_doc_id_and_emits_renamed` — same id after rename, old path mapping gone, `NOTE_RENAMED` fires with both paths
- `test_file_rename_updates_graph_path` — graph path-to-node lookup updates from old to new path

Closes #202.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] All 9 `tests/test_file_watcher_events.py` tests pass locally (incl. 2 new)
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
