### PR TITLE
perf(lcma): persistent SQLite connections in StatsStore + EdgeStore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage
+        env:
+          LITHOS_DETECT_THREAD_LEAKS: "1"
         run: uv run pytest tests/ -m "not integration" --cov=lithos --cov-report=xml -v --tb=short
 
       - name: Upload coverage

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -7,8 +7,10 @@ corrupt-DB quarantine with automatic recreation.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -64,10 +66,9 @@ class EdgeStore:
         self._opened = False
         # Persistent SQLite connection (#172). Same lifecycle as StatsStore.
         self._db: aiosqlite.Connection | None = None
-        # Same write-mutex pattern as StatsStore — see that class for the
-        # rationale. EdgeStore today has no multi-statement DML methods,
-        # but the lock is here for symmetry and future-proofing.
-        self._write_lock: asyncio.Lock | None = None
+        # Serialise every operation on the shared connection — see
+        # StatsStore for the full rationale.
+        self._op_lock: asyncio.Lock | None = None
 
     @property
     def config(self) -> LithosConfig:
@@ -136,11 +137,97 @@ class EdgeStore:
         assert self._db is not None, "EdgeStore.open() must be called before use"
         return self._db
 
-    def _write_mutex(self) -> asyncio.Lock:
-        """Return the lock that serialises mutating methods (#172)."""
-        if self._write_lock is None:
-            self._write_lock = asyncio.Lock()
-        return self._write_lock
+    def _operation_mutex(self) -> asyncio.Lock:
+        """Return the lock that serialises store methods on the shared handle."""
+        if self._op_lock is None:
+            self._op_lock = asyncio.Lock()
+        return self._op_lock
+
+    @staticmethod
+    def _is_recoverable_connection_error(exc: BaseException) -> bool:
+        """Return True when *exc* indicates the persistent handle is no longer usable."""
+        if not isinstance(exc, (ValueError, RuntimeError, aiosqlite.Error)):
+            return False
+        message = str(exc).lower()
+        return any(
+            fragment in message
+            for fragment in (
+                "closed database",
+                "closed connection",
+                "event loop is closed",
+                "no active connection",
+                "cannot operate on a closed database",
+            )
+        )
+
+    async def _reconnect_after_error(self) -> None:
+        """Drop the current handle and open a fresh one after a connection-liveness failure."""
+        db = self._db
+        self._db = None
+        self._opened = False
+        if db is not None:
+            with contextlib.suppress(Exception):
+                await db.close()
+        await self.open()
+
+    @contextlib.asynccontextmanager
+    async def _session(self, *, transactional: bool = False) -> AsyncIterator[aiosqlite.Connection]:
+        """Yield exclusive access to the shared connection, optionally in a transaction."""
+        async with self._operation_mutex():
+            await self._ensure_open()
+            db = self._conn()
+
+            if not transactional:
+                try:
+                    yield db
+                except Exception as exc:
+                    if self._is_recoverable_connection_error(exc):
+                        logger.warning(
+                            "EdgeStore operation hit a dead connection; reopening %s",
+                            self.db_path,
+                            exc_info=True,
+                        )
+                        await self._reconnect_after_error()
+                    raise
+                return
+
+            try:
+                await db.execute("BEGIN IMMEDIATE")
+            except Exception as exc:
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "EdgeStore transaction could not begin; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
+
+            try:
+                yield db
+            except Exception as exc:
+                with contextlib.suppress(Exception):
+                    await db.execute("ROLLBACK")
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "EdgeStore transaction lost its connection; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
+
+            try:
+                await db.execute("COMMIT")
+            except Exception as exc:
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "EdgeStore transaction could not commit; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -193,115 +280,106 @@ class EdgeStore:
         on the shared autocommit connection (#172) — without it, two
         concurrent upserts for the same (from_id, to_id, type, namespace)
         would both observe "no existing row" and race to INSERT, hitting
-        the UNIQUE constraint. The write mutex + BEGIN IMMEDIATE serialise
+        the UNIQUE constraint. The transactional :meth:`_session` serialises
         the read-modify-write so either both calls observe a single row and
         both UPDATE, or one INSERTs and the next UPDATEs.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
-            try:
-                cursor = await db.execute(
-                    "SELECT edge_id FROM edges "
-                    "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
-                    (from_id, to_id, edge_type, namespace),
-                )
-                row = await cursor.fetchone()
+        async with self._session(transactional=True) as db:
+            cursor = await db.execute(
+                "SELECT edge_id FROM edges "
+                "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
+                (from_id, to_id, edge_type, namespace),
+            )
+            row = await cursor.fetchone()
 
-                if row is not None:
-                    edge_id: str = row[0]
-                    await db.execute(
-                        "UPDATE edges SET weight = ?, updated_at = ?, "
-                        "provenance_actor = ?, provenance_type = ?, "
-                        "evidence = ?, conflict_state = ? "
-                        "WHERE edge_id = ?",
-                        (
-                            weight,
-                            now,
-                            provenance_actor,
-                            provenance_type,
-                            evidence,
-                            conflict_state,
-                            edge_id,
-                        ),
-                    )
-                    logger.debug(
-                        "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+            if row is not None:
+                edge_id: str = row[0]
+                await db.execute(
+                    "UPDATE edges SET weight = ?, updated_at = ?, "
+                    "provenance_actor = ?, provenance_type = ?, "
+                    "evidence = ?, conflict_state = ? "
+                    "WHERE edge_id = ?",
+                    (
+                        weight,
+                        now,
+                        provenance_actor,
+                        provenance_type,
+                        evidence,
+                        conflict_state,
+                        edge_id,
+                    ),
+                )
+                logger.debug(
+                    "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                    edge_id,
+                    from_id,
+                    to_id,
+                    edge_type,
+                    namespace,
+                    weight,
+                    extra={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "edge_type": edge_type,
+                        "namespace": namespace,
+                        "weight": weight,
+                    },
+                )
+            else:
+                edge_id = _generate_edge_id()
+                await db.execute(
+                    "INSERT INTO edges "
+                    "(edge_id, from_id, to_id, type, weight, namespace, "
+                    "created_at, updated_at, provenance_actor, provenance_type, "
+                    "evidence, conflict_state) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
                         edge_id,
                         from_id,
                         to_id,
                         edge_type,
-                        namespace,
                         weight,
-                        extra={
-                            "edge_id": edge_id,
-                            "from_id": from_id,
-                            "to_id": to_id,
-                            "edge_type": edge_type,
-                            "namespace": namespace,
-                            "weight": weight,
-                        },
-                    )
-                else:
-                    edge_id = _generate_edge_id()
-                    await db.execute(
-                        "INSERT INTO edges "
-                        "(edge_id, from_id, to_id, type, weight, namespace, "
-                        "created_at, updated_at, provenance_actor, provenance_type, "
-                        "evidence, conflict_state) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                        (
-                            edge_id,
-                            from_id,
-                            to_id,
-                            edge_type,
-                            weight,
-                            namespace,
-                            now,
-                            now,
-                            provenance_actor,
-                            provenance_type,
-                            evidence,
-                            conflict_state,
-                        ),
-                    )
-                    logger.info(
-                        "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
-                        edge_id,
-                        from_id,
-                        to_id,
-                        edge_type,
                         namespace,
-                        weight,
-                        extra={
-                            "edge_id": edge_id,
-                            "from_id": from_id,
-                            "to_id": to_id,
-                            "edge_type": edge_type,
-                            "namespace": namespace,
-                            "weight": weight,
-                        },
-                    )
-                await db.execute("COMMIT")
-            except Exception:
-                await db.execute("ROLLBACK")
-                raise
+                        now,
+                        now,
+                        provenance_actor,
+                        provenance_type,
+                        evidence,
+                        conflict_state,
+                    ),
+                )
+                logger.info(
+                    "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                    edge_id,
+                    from_id,
+                    to_id,
+                    edge_type,
+                    namespace,
+                    weight,
+                    extra={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "edge_type": edge_type,
+                        "namespace": namespace,
+                        "weight": weight,
+                    },
+                )
         return edge_id
 
     async def get_edge(self, edge_id: str) -> dict[str, object] | None:
         """Return a single edge by its ID, or ``None`` if not found."""
-        await self._ensure_open()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT edge_id, from_id, to_id, type, weight, namespace, "
-            "created_at, updated_at, provenance_actor, provenance_type, "
-            "evidence, conflict_state FROM edges WHERE edge_id = ?",
-            (edge_id,),
-        )
-        row = await cursor.fetchone()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT edge_id, from_id, to_id, type, weight, namespace, "
+                "created_at, updated_at, provenance_actor, provenance_type, "
+                "evidence, conflict_state FROM edges WHERE edge_id = ?",
+                (edge_id,),
+            )
+            row = await cursor.fetchone()
         if row is None:
             return None
         return {
@@ -330,15 +408,13 @@ class EdgeStore:
 
         Returns ``True`` if the edge was found and updated, ``False`` otherwise.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        cursor = await db.execute(
-            "UPDATE edges SET conflict_state = ?, provenance_actor = ?, updated_at = ? "
-            "WHERE edge_id = ?",
-            (conflict_state, provenance_actor, now, edge_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            cursor = await db.execute(
+                "UPDATE edges SET conflict_state = ?, provenance_actor = ?, updated_at = ? "
+                "WHERE edge_id = ?",
+                (conflict_state, provenance_actor, now, edge_id),
+            )
         return cursor.rowcount > 0
 
     async def list_edges(
@@ -350,7 +426,6 @@ class EdgeStore:
         namespace: str | None = None,
     ) -> list[dict[str, object]]:
         """Query edges by optional filter dimensions."""
-        await self._ensure_open()
         clauses: list[str] = []
         params: list[str] = []
         if from_id is not None:
@@ -369,10 +444,10 @@ class EdgeStore:
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"SELECT edge_id, from_id, to_id, type, weight, namespace, created_at, updated_at, provenance_actor, provenance_type, evidence, conflict_state FROM edges{where}"
 
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(sql, params)
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(sql, params)
+            rows = await cursor.fetchall()
 
         return [
             {
@@ -394,28 +469,28 @@ class EdgeStore:
 
     async def count(self, *, namespace: str | None = None) -> int:
         """Return total edge count, optionally filtered by namespace."""
-        await self._ensure_open()
         if namespace is not None:
             sql = "SELECT COUNT(*) FROM edges WHERE namespace = ?"
             params: tuple[str, ...] = (namespace,)
         else:
             sql = "SELECT COUNT(*) FROM edges"
             params = ()
-        db = self._conn()
-        cursor = await db.execute(sql, params)
-        row = await cursor.fetchone()
+        async with self._session() as db:
+            cursor = await db.execute(sql, params)
+            row = await cursor.fetchone()
         return row[0] if row else 0
 
     async def delete_edges(self, *, edge_ids: list[str]) -> int:
         """Delete edges by their IDs.  Returns the number of rows deleted."""
-        await self._ensure_open()
         if not edge_ids:
             return 0
         placeholders = ",".join("?" for _ in edge_ids)
-        db = self._conn()
-        cursor = await db.execute(f"DELETE FROM edges WHERE edge_id IN ({placeholders})", edge_ids)
-        await db.commit()
-        deleted = cursor.rowcount
+        async with self._session() as db:
+            cursor = await db.execute(
+                f"DELETE FROM edges WHERE edge_id IN ({placeholders})",
+                edge_ids,
+            )
+            deleted = cursor.rowcount
         logger.info(
             "edge delete_edges: requested=%d deleted=%d",
             len(edge_ids),
@@ -428,31 +503,22 @@ class EdgeStore:
         """Atomically adjust weight by *delta*, clamping to [0.0, 1.0].
 
         Returns the new weight, or ``None`` if the edge is not found. The
-        UPDATE+read-back pair is bracketed in BEGIN/COMMIT under the write
-        mutex so that the returned weight reflects this call's own write
-        even when another coroutine adjusts the same edge concurrently
-        (#172).
+        UPDATE+read-back pair is bracketed in BEGIN/COMMIT inside
+        :meth:`_session` so that the returned weight reflects this call's
+        own write even when another coroutine adjusts the same edge
+        concurrently (#172).
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
-            try:
-                cursor = await db.execute(
-                    "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
-                    "WHERE edge_id = ?",
-                    (delta, now, edge_id),
-                )
-                if cursor.rowcount == 0:
-                    await db.execute("ROLLBACK")
-                    return None
-                cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
-                row = await cursor.fetchone()
-                await db.execute("COMMIT")
-            except Exception:
-                await db.execute("ROLLBACK")
-                raise
+        async with self._session(transactional=True) as db:
+            cursor = await db.execute(
+                "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
+                "WHERE edge_id = ?",
+                (delta, now, edge_id),
+            )
+            if cursor.rowcount == 0:
+                return None
+            cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
+            row = await cursor.fetchone()
         assert row is not None
         return row[0]
 
@@ -464,7 +530,6 @@ class EdgeStore:
         namespace: str | None = None,
     ) -> list[dict[str, object]]:
         """Return all edges where both from_id and to_id are in *node_ids*."""
-        await self._ensure_open()
         if not node_ids:
             return []
         placeholders = ", ".join("?" for _ in node_ids)
@@ -480,10 +545,10 @@ class EdgeStore:
             clauses.append("namespace = ?")
             params.append(namespace)
         where = " AND ".join(clauses)
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(f"SELECT * FROM edges WHERE {where}", params)
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(f"SELECT * FROM edges WHERE {where}", params)
+            rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
 

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -6,6 +6,7 @@ corrupt-DB quarantine with automatic recreation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -63,6 +64,10 @@ class EdgeStore:
         self._opened = False
         # Persistent SQLite connection (#172). Same lifecycle as StatsStore.
         self._db: aiosqlite.Connection | None = None
+        # Same write-mutex pattern as StatsStore — see that class for the
+        # rationale. EdgeStore today has no multi-statement DML methods,
+        # but the lock is here for symmetry and future-proofing.
+        self._write_lock: asyncio.Lock | None = None
 
     @property
     def config(self) -> LithosConfig:
@@ -89,12 +94,12 @@ class EdgeStore:
             if not healthy:
                 self._quarantine(self.db_path)
 
-        db = await aiosqlite.connect(self.db_path)
+        # autocommit-per-statement on the shared connection — see StatsStore.
+        db = await aiosqlite.connect(self.db_path, isolation_level=None)
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("PRAGMA foreign_keys=ON")
         await db.executescript(SCHEMA)
-        await db.commit()
         self._db = db
         self._opened = True
 
@@ -106,14 +111,25 @@ class EdgeStore:
         self._opened = False
 
     async def _ensure_open(self) -> None:
-        """Lazily create the database on first use."""
-        if not self._opened:
-            await self.open()
+        """Lazily (re-)open the database on first use or after close().
+
+        See StatsStore._ensure_open for the recovery rationale (#172).
+        """
+        if self._opened and self._db is not None:
+            return
+        self._opened = False
+        await self.open()
 
     def _conn(self) -> aiosqlite.Connection:
         """Return the live connection. ``open()`` must have run first."""
         assert self._db is not None, "EdgeStore.open() must be called before use"
         return self._db
+
+    def _write_mutex(self) -> asyncio.Lock:
+        """Return the lock that serialises mutating methods (#172)."""
+        if self._write_lock is None:
+            self._write_lock = asyncio.Lock()
+        return self._write_lock
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -61,6 +61,8 @@ class EdgeStore:
     def __init__(self, config: LithosConfig | None = None) -> None:
         self._config = config
         self._opened = False
+        # Persistent SQLite connection (#172). Same lifecycle as StatsStore.
+        self._db: aiosqlite.Connection | None = None
 
     @property
     def config(self) -> LithosConfig:
@@ -71,10 +73,12 @@ class EdgeStore:
         return self.config.storage.edges_db_path
 
     async def open(self) -> None:
-        """Ensure edges.db exists with the correct schema.
+        """Ensure edges.db exists with the correct schema and a live connection.
 
         Idempotent — safe to call multiple times.  If the file is corrupt
-        it is quarantined and a fresh database is created.
+        it is quarantined and a fresh database is created. After this returns
+        :attr:`_db` is a persistent ``aiosqlite.Connection`` in WAL mode that
+        every method reuses (#172).
         """
         if self._opened:
             return
@@ -85,15 +89,31 @@ class EdgeStore:
             if not healthy:
                 self._quarantine(self.db_path)
 
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.executescript(SCHEMA)
-            await db.commit()
+        db = await aiosqlite.connect(self.db_path)
+        db.row_factory = aiosqlite.Row
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA foreign_keys=ON")
+        await db.executescript(SCHEMA)
+        await db.commit()
+        self._db = db
         self._opened = True
+
+    async def close(self) -> None:
+        """Close the persistent connection. Idempotent."""
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+        self._opened = False
 
     async def _ensure_open(self) -> None:
         """Lazily create the database on first use."""
         if not self._opened:
             await self.open()
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return the live connection. ``open()`` must have run first."""
+        assert self._db is not None, "EdgeStore.open() must be called before use"
+        return self._db
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -143,104 +163,104 @@ class EdgeStore:
         """Insert or update an edge.  Returns the ``edge_id``."""
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            # Check for existing edge by composite key
-            cursor = await db.execute(
-                "SELECT edge_id FROM edges "
-                "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
-                (from_id, to_id, edge_type, namespace),
-            )
-            row = await cursor.fetchone()
+        db = self._conn()
+        # Check for existing edge by composite key
+        cursor = await db.execute(
+            "SELECT edge_id FROM edges "
+            "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
+            (from_id, to_id, edge_type, namespace),
+        )
+        row = await cursor.fetchone()
 
-            if row is not None:
-                edge_id: str = row[0]
-                await db.execute(
-                    "UPDATE edges SET weight = ?, updated_at = ?, "
-                    "provenance_actor = ?, provenance_type = ?, "
-                    "evidence = ?, conflict_state = ? "
-                    "WHERE edge_id = ?",
-                    (
-                        weight,
-                        now,
-                        provenance_actor,
-                        provenance_type,
-                        evidence,
-                        conflict_state,
-                        edge_id,
-                    ),
-                )
-                logger.debug(
-                    "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+        if row is not None:
+            edge_id: str = row[0]
+            await db.execute(
+                "UPDATE edges SET weight = ?, updated_at = ?, "
+                "provenance_actor = ?, provenance_type = ?, "
+                "evidence = ?, conflict_state = ? "
+                "WHERE edge_id = ?",
+                (
+                    weight,
+                    now,
+                    provenance_actor,
+                    provenance_type,
+                    evidence,
+                    conflict_state,
+                    edge_id,
+                ),
+            )
+            logger.debug(
+                "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                edge_id,
+                from_id,
+                to_id,
+                edge_type,
+                namespace,
+                weight,
+                extra={
+                    "edge_id": edge_id,
+                    "from_id": from_id,
+                    "to_id": to_id,
+                    "edge_type": edge_type,
+                    "namespace": namespace,
+                    "weight": weight,
+                },
+            )
+        else:
+            edge_id = _generate_edge_id()
+            await db.execute(
+                "INSERT INTO edges "
+                "(edge_id, from_id, to_id, type, weight, namespace, "
+                "created_at, updated_at, provenance_actor, provenance_type, "
+                "evidence, conflict_state) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
                     edge_id,
                     from_id,
                     to_id,
                     edge_type,
-                    namespace,
                     weight,
-                    extra={
-                        "edge_id": edge_id,
-                        "from_id": from_id,
-                        "to_id": to_id,
-                        "edge_type": edge_type,
-                        "namespace": namespace,
-                        "weight": weight,
-                    },
-                )
-            else:
-                edge_id = _generate_edge_id()
-                await db.execute(
-                    "INSERT INTO edges "
-                    "(edge_id, from_id, to_id, type, weight, namespace, "
-                    "created_at, updated_at, provenance_actor, provenance_type, "
-                    "evidence, conflict_state) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        edge_id,
-                        from_id,
-                        to_id,
-                        edge_type,
-                        weight,
-                        namespace,
-                        now,
-                        now,
-                        provenance_actor,
-                        provenance_type,
-                        evidence,
-                        conflict_state,
-                    ),
-                )
-                logger.info(
-                    "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
-                    edge_id,
-                    from_id,
-                    to_id,
-                    edge_type,
                     namespace,
-                    weight,
-                    extra={
-                        "edge_id": edge_id,
-                        "from_id": from_id,
-                        "to_id": to_id,
-                        "edge_type": edge_type,
-                        "namespace": namespace,
-                        "weight": weight,
-                    },
-                )
-            await db.commit()
+                    now,
+                    now,
+                    provenance_actor,
+                    provenance_type,
+                    evidence,
+                    conflict_state,
+                ),
+            )
+            logger.info(
+                "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                edge_id,
+                from_id,
+                to_id,
+                edge_type,
+                namespace,
+                weight,
+                extra={
+                    "edge_id": edge_id,
+                    "from_id": from_id,
+                    "to_id": to_id,
+                    "edge_type": edge_type,
+                    "namespace": namespace,
+                    "weight": weight,
+                },
+            )
+        await db.commit()
         return edge_id
 
     async def get_edge(self, edge_id: str) -> dict[str, object] | None:
         """Return a single edge by its ID, or ``None`` if not found."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                "SELECT edge_id, from_id, to_id, type, weight, namespace, "
-                "created_at, updated_at, provenance_actor, provenance_type, "
-                "evidence, conflict_state FROM edges WHERE edge_id = ?",
-                (edge_id,),
-            )
-            row = await cursor.fetchone()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT edge_id, from_id, to_id, type, weight, namespace, "
+            "created_at, updated_at, provenance_actor, provenance_type, "
+            "evidence, conflict_state FROM edges WHERE edge_id = ?",
+            (edge_id,),
+        )
+        row = await cursor.fetchone()
         if row is None:
             return None
         return {
@@ -271,14 +291,14 @@ class EdgeStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "UPDATE edges SET conflict_state = ?, provenance_actor = ?, updated_at = ? "
-                "WHERE edge_id = ?",
-                (conflict_state, provenance_actor, now, edge_id),
-            )
-            await db.commit()
-            return cursor.rowcount > 0
+        db = self._conn()
+        cursor = await db.execute(
+            "UPDATE edges SET conflict_state = ?, provenance_actor = ?, updated_at = ? "
+            "WHERE edge_id = ?",
+            (conflict_state, provenance_actor, now, edge_id),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
 
     async def list_edges(
         self,
@@ -308,10 +328,10 @@ class EdgeStore:
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"SELECT edge_id, from_id, to_id, type, weight, namespace, created_at, updated_at, provenance_actor, provenance_type, evidence, conflict_state FROM edges{where}"
 
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(sql, params)
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(sql, params)
+        rows = await cursor.fetchall()
 
         return [
             {
@@ -340,10 +360,10 @@ class EdgeStore:
         else:
             sql = "SELECT COUNT(*) FROM edges"
             params = ()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(sql, params)
-            row = await cursor.fetchone()
-            return row[0] if row else 0
+        db = self._conn()
+        cursor = await db.execute(sql, params)
+        row = await cursor.fetchone()
+        return row[0] if row else 0
 
     async def delete_edges(self, *, edge_ids: list[str]) -> int:
         """Delete edges by their IDs.  Returns the number of rows deleted."""
@@ -351,19 +371,17 @@ class EdgeStore:
         if not edge_ids:
             return 0
         placeholders = ",".join("?" for _ in edge_ids)
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                f"DELETE FROM edges WHERE edge_id IN ({placeholders})", edge_ids
-            )
-            await db.commit()
-            deleted = cursor.rowcount
-            logger.info(
-                "edge delete_edges: requested=%d deleted=%d",
-                len(edge_ids),
-                deleted,
-                extra={"requested": len(edge_ids), "deleted": deleted},
-            )
-            return deleted
+        db = self._conn()
+        cursor = await db.execute(f"DELETE FROM edges WHERE edge_id IN ({placeholders})", edge_ids)
+        await db.commit()
+        deleted = cursor.rowcount
+        logger.info(
+            "edge delete_edges: requested=%d deleted=%d",
+            len(edge_ids),
+            deleted,
+            extra={"requested": len(edge_ids), "deleted": deleted},
+        )
+        return deleted
 
     async def adjust_weight(self, edge_id: str, delta: float) -> float | None:
         """Atomically adjust weight by *delta*, clamping to [0.0, 1.0].
@@ -372,18 +390,18 @@ class EdgeStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            # Single atomic UPDATE with clamping in SQL — no read-modify-write race.
-            cursor = await db.execute(
-                "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
-                "WHERE edge_id = ?",
-                (delta, now, edge_id),
-            )
-            if cursor.rowcount == 0:
-                return None
-            await db.commit()
-            cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
-            row = await cursor.fetchone()
+        db = self._conn()
+        # Single atomic UPDATE with clamping in SQL — no read-modify-write race.
+        cursor = await db.execute(
+            "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
+            "WHERE edge_id = ?",
+            (delta, now, edge_id),
+        )
+        if cursor.rowcount == 0:
+            return None
+        await db.commit()
+        cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
+        row = await cursor.fetchone()
         assert row is not None
         return row[0]
 
@@ -411,10 +429,10 @@ class EdgeStore:
             clauses.append("namespace = ?")
             params.append(namespace)
         where = " AND ".join(clauses)
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(f"SELECT * FROM edges WHERE {where}", params)
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(f"SELECT * FROM edges WHERE {where}", params)
+        rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
 

--- a/src/lithos/lcma/edges.py
+++ b/src/lithos/lcma/edges.py
@@ -111,13 +111,24 @@ class EdgeStore:
         self._opened = False
 
     async def _ensure_open(self) -> None:
-        """Lazily (re-)open the database on first use or after close().
+        """Lazily (re-)open the database on first use, after close, or after a dead worker.
 
-        See StatsStore._ensure_open for the recovery rationale (#172).
+        See :meth:`StatsStore._ensure_open` for the full recovery rationale (#172).
         """
-        if self._opened and self._db is not None:
+        if self._opened and self._db is not None and getattr(self._db, "_running", True):
             return
+        if self._db is not None and not getattr(self._db, "_running", True):
+            logger.warning(
+                "EdgeStore connection worker is no longer running; reopening %s",
+                self.db_path,
+            )
+            self._db = None
         self._opened = False
+        await self.open()
+
+    async def reconnect(self) -> None:
+        """Force a close + re-open of the underlying connection. Idempotent."""
+        await self.close()
         await self.open()
 
     def _conn(self) -> aiosqlite.Connection:
@@ -176,93 +187,107 @@ class EdgeStore:
         evidence: str | None = None,
         conflict_state: str | None = None,
     ) -> str:
-        """Insert or update an edge.  Returns the ``edge_id``."""
+        """Insert or update an edge.  Returns the ``edge_id``.
+
+        The SELECT-then-INSERT/UPDATE pattern needs cross-statement atomicity
+        on the shared autocommit connection (#172) — without it, two
+        concurrent upserts for the same (from_id, to_id, type, namespace)
+        would both observe "no existing row" and race to INSERT, hitting
+        the UNIQUE constraint. The write mutex + BEGIN IMMEDIATE serialise
+        the read-modify-write so either both calls observe a single row and
+        both UPDATE, or one INSERTs and the next UPDATEs.
+        """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
         db = self._conn()
-        # Check for existing edge by composite key
-        cursor = await db.execute(
-            "SELECT edge_id FROM edges "
-            "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
-            (from_id, to_id, edge_type, namespace),
-        )
-        row = await cursor.fetchone()
+        async with self._write_mutex():
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "SELECT edge_id FROM edges "
+                    "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
+                    (from_id, to_id, edge_type, namespace),
+                )
+                row = await cursor.fetchone()
 
-        if row is not None:
-            edge_id: str = row[0]
-            await db.execute(
-                "UPDATE edges SET weight = ?, updated_at = ?, "
-                "provenance_actor = ?, provenance_type = ?, "
-                "evidence = ?, conflict_state = ? "
-                "WHERE edge_id = ?",
-                (
-                    weight,
-                    now,
-                    provenance_actor,
-                    provenance_type,
-                    evidence,
-                    conflict_state,
-                    edge_id,
-                ),
-            )
-            logger.debug(
-                "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
-                edge_id,
-                from_id,
-                to_id,
-                edge_type,
-                namespace,
-                weight,
-                extra={
-                    "edge_id": edge_id,
-                    "from_id": from_id,
-                    "to_id": to_id,
-                    "edge_type": edge_type,
-                    "namespace": namespace,
-                    "weight": weight,
-                },
-            )
-        else:
-            edge_id = _generate_edge_id()
-            await db.execute(
-                "INSERT INTO edges "
-                "(edge_id, from_id, to_id, type, weight, namespace, "
-                "created_at, updated_at, provenance_actor, provenance_type, "
-                "evidence, conflict_state) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    edge_id,
-                    from_id,
-                    to_id,
-                    edge_type,
-                    weight,
-                    namespace,
-                    now,
-                    now,
-                    provenance_actor,
-                    provenance_type,
-                    evidence,
-                    conflict_state,
-                ),
-            )
-            logger.info(
-                "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
-                edge_id,
-                from_id,
-                to_id,
-                edge_type,
-                namespace,
-                weight,
-                extra={
-                    "edge_id": edge_id,
-                    "from_id": from_id,
-                    "to_id": to_id,
-                    "edge_type": edge_type,
-                    "namespace": namespace,
-                    "weight": weight,
-                },
-            )
-        await db.commit()
+                if row is not None:
+                    edge_id: str = row[0]
+                    await db.execute(
+                        "UPDATE edges SET weight = ?, updated_at = ?, "
+                        "provenance_actor = ?, provenance_type = ?, "
+                        "evidence = ?, conflict_state = ? "
+                        "WHERE edge_id = ?",
+                        (
+                            weight,
+                            now,
+                            provenance_actor,
+                            provenance_type,
+                            evidence,
+                            conflict_state,
+                            edge_id,
+                        ),
+                    )
+                    logger.debug(
+                        "edge upsert (update): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                        edge_id,
+                        from_id,
+                        to_id,
+                        edge_type,
+                        namespace,
+                        weight,
+                        extra={
+                            "edge_id": edge_id,
+                            "from_id": from_id,
+                            "to_id": to_id,
+                            "edge_type": edge_type,
+                            "namespace": namespace,
+                            "weight": weight,
+                        },
+                    )
+                else:
+                    edge_id = _generate_edge_id()
+                    await db.execute(
+                        "INSERT INTO edges "
+                        "(edge_id, from_id, to_id, type, weight, namespace, "
+                        "created_at, updated_at, provenance_actor, provenance_type, "
+                        "evidence, conflict_state) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            edge_id,
+                            from_id,
+                            to_id,
+                            edge_type,
+                            weight,
+                            namespace,
+                            now,
+                            now,
+                            provenance_actor,
+                            provenance_type,
+                            evidence,
+                            conflict_state,
+                        ),
+                    )
+                    logger.info(
+                        "edge upsert (insert): edge_id=%s from=%s to=%s type=%s ns=%s weight=%.3f",
+                        edge_id,
+                        from_id,
+                        to_id,
+                        edge_type,
+                        namespace,
+                        weight,
+                        extra={
+                            "edge_id": edge_id,
+                            "from_id": from_id,
+                            "to_id": to_id,
+                            "edge_type": edge_type,
+                            "namespace": namespace,
+                            "weight": weight,
+                        },
+                    )
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
         return edge_id
 
     async def get_edge(self, edge_id: str) -> dict[str, object] | None:
@@ -402,22 +427,32 @@ class EdgeStore:
     async def adjust_weight(self, edge_id: str, delta: float) -> float | None:
         """Atomically adjust weight by *delta*, clamping to [0.0, 1.0].
 
-        Returns the new weight, or ``None`` if the edge is not found.
+        Returns the new weight, or ``None`` if the edge is not found. The
+        UPDATE+read-back pair is bracketed in BEGIN/COMMIT under the write
+        mutex so that the returned weight reflects this call's own write
+        even when another coroutine adjusts the same edge concurrently
+        (#172).
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
         db = self._conn()
-        # Single atomic UPDATE with clamping in SQL — no read-modify-write race.
-        cursor = await db.execute(
-            "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
-            "WHERE edge_id = ?",
-            (delta, now, edge_id),
-        )
-        if cursor.rowcount == 0:
-            return None
-        await db.commit()
-        cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
-        row = await cursor.fetchone()
+        async with self._write_mutex():
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "UPDATE edges SET weight = MAX(0.0, MIN(1.0, weight + ?)), updated_at = ? "
+                    "WHERE edge_id = ?",
+                    (delta, now, edge_id),
+                )
+                if cursor.rowcount == 0:
+                    await db.execute("ROLLBACK")
+                    return None
+                cursor = await db.execute("SELECT weight FROM edges WHERE edge_id = ?", (edge_id,))
+                row = await cursor.fetchone()
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
         assert row is not None
         return row[0]
 

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -161,14 +161,19 @@ class StatsStore:
         # across the dozens of method calls per retrieval / drain cycle is
         # the whole point of this lifecycle.
         self._db: aiosqlite.Connection | None = None
-        # Serialise drain transactions on the shared connection (#172).
-        # When each method opened its own connection, BEGIN IMMEDIATE on
-        # connection B blocked until connection A committed — SQLite's
-        # write lock kept double-claim impossible. With one shared
-        # connection, two concurrent drains would interleave at the
-        # statement level and either error on a nested BEGIN or claim the
-        # same row twice. The lock restores per-drain atomicity.
-        self._drain_lock: asyncio.Lock | None = None
+        # Serialise every mutating method on the shared connection (#172).
+        #
+        # Python's sqlite3 default ``isolation_level=""`` auto-starts an
+        # implicit transaction on the first DML statement and ends it on
+        # ``commit()``. With per-call connections the implicit tx was
+        # scoped to one coroutine because each had its own connection. With
+        # one shared connection, two coroutines can interleave at ``await``
+        # points and join each other's auto-tx — coroutine B's commit then
+        # commits coroutine A's pending writes. The write lock prevents
+        # that interleave by holding for the full body of any method that
+        # touches DML. Pure-SELECT reads do not need the lock because
+        # SELECT does not start a write tx.
+        self._write_lock: asyncio.Lock | None = None
         self._cached_enrich_queue_depth: int = 0
         self._cached_coactivation_pairs: int = 0
         self._cached_working_memory_active_tasks: int = 0
@@ -198,7 +203,17 @@ class StatsStore:
             if not healthy:
                 self._quarantine(self.db_path)
 
-        db = await aiosqlite.connect(self.db_path)
+        # ``isolation_level=None`` puts the connection in autocommit-per-
+        # statement mode. With per-call connections the default
+        # ``isolation_level=""`` was safe — each coroutine had its own
+        # implicit transaction. With one shared connection across many
+        # coroutines, the implicit-tx state is shared too: coroutine B's
+        # DML can join coroutine A's open tx, and either commit can flush
+        # the other's pending writes. Autocommit makes single-statement
+        # writes self-contained; multi-statement transactions (drains,
+        # batched executemany) are bracketed with explicit BEGIN/COMMIT
+        # under :meth:`_write_mutex`.
+        db = await aiosqlite.connect(self.db_path, isolation_level=None)
         # Row access by name everywhere — sets default for the lifetime of
         # this connection. Methods that index by position keep working too.
         db.row_factory = aiosqlite.Row
@@ -210,7 +225,6 @@ class StatsStore:
         await self._migrate_add_cited_count(db)
         await self._migrate_add_last_decay_applied_at(db)
         await self._migrate_add_enrich_queue_attempts(db)
-        await db.commit()
         self._db = db
         self._opened = True
 
@@ -222,24 +236,37 @@ class StatsStore:
         self._opened = False
 
     async def _ensure_open(self) -> None:
-        """Lazily create the database on first use."""
-        if not self._opened:
-            await self.open()
+        """Lazily (re-)open the database on first use or after close().
+
+        Recovery path: if :meth:`close` ran but the store is reused, this
+        re-runs :meth:`open` so callers do not need to track lifecycle
+        externally. Per-call connection callers used to get this for free
+        because every method opened its own connection (#172).
+        """
+        if self._opened and self._db is not None:
+            return
+        # Either never opened, or close() reset the flag — either way,
+        # re-open clears any stale state and reconnects.
+        self._opened = False
+        await self.open()
 
     def _conn(self) -> aiosqlite.Connection:
         """Return the live connection. ``open()`` must have run first."""
         assert self._db is not None, "StatsStore.open() must be called before use"
         return self._db
 
-    def _drain_mutex(self) -> asyncio.Lock:
-        """Return the lock that serialises drain transactions (#172).
+    def _write_mutex(self) -> asyncio.Lock:
+        """Return the lock that serialises mutating methods (#172).
 
         Lazily constructed because :meth:`__init__` runs before any event
-        loop exists in some test/CLI flows.
+        loop exists in some test/CLI flows. Every method that issues an
+        INSERT/UPDATE/DELETE (including the explicit-transaction drains)
+        wraps its body in ``async with self._write_mutex():`` to keep the
+        shared connection's auto-transaction state coherent.
         """
-        if self._drain_lock is None:
-            self._drain_lock = asyncio.Lock()
-        return self._drain_lock
+        if self._write_lock is None:
+            self._write_lock = asyncio.Lock()
+        return self._write_lock
 
     # ------------------------------------------------------------------
     # Receipt operations
@@ -542,7 +569,7 @@ class StatsStore:
         # connection the lock state lives on the underlying sqlite3 handle,
         # so two concurrent drains would either error on a nested BEGIN or
         # interleave at the statement level.
-        async with self._drain_mutex():
+        async with self._write_mutex():
             await db.execute("BEGIN IMMEDIATE")
             if max_attempts is not None:
                 cursor = await db.execute(
@@ -618,7 +645,7 @@ class StatsStore:
         db = self._conn()
         db.row_factory = aiosqlite.Row
         # See drain_pending_nodes for why this needs a Python-level lock now.
-        async with self._drain_mutex():
+        async with self._write_mutex():
             await db.execute("BEGIN IMMEDIATE")
             if max_attempts is not None:
                 cursor = await db.execute(
@@ -742,21 +769,32 @@ class StatsStore:
         await db.commit()
 
     async def increment_node_stats_batch(self, node_ids: list[str]) -> None:
-        """Increment retrieval_count for multiple nodes in a single transaction."""
+        """Increment retrieval_count for multiple nodes in a single transaction.
+
+        Wrapped in BEGIN/COMMIT under the write mutex so the batch is atomic
+        on the shared autocommit connection (#172).
+        """
         if not node_ids:
             return
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
         db = self._conn()
-        await db.executemany(
-            """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
-               VALUES (?, 1, ?, 0.5)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 retrieval_count = retrieval_count + 1,
-                 last_retrieved_at = excluded.last_retrieved_at""",
-            [(nid, now) for nid in node_ids],
-        )
-        await db.commit()
+        async with self._write_mutex():
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.executemany(
+                    """INSERT INTO node_stats
+                       (node_id, retrieval_count, last_retrieved_at, salience)
+                       VALUES (?, 1, ?, 0.5)
+                       ON CONFLICT(node_id) DO UPDATE SET
+                         retrieval_count = retrieval_count + 1,
+                         last_retrieved_at = excluded.last_retrieved_at""",
+                    [(nid, now) for nid in node_ids],
+                )
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
         logger.debug(
             "node_stats batch increment: node_count=%d",
             len(node_ids),
@@ -768,7 +806,11 @@ class StatsStore:
         pairs: list[tuple[str, str]],
         namespace: str,
     ) -> None:
-        """Increment coactivation counts for multiple pairs in a single transaction."""
+        """Increment coactivation counts for multiple pairs in a single transaction.
+
+        Wrapped in BEGIN/COMMIT under the write mutex so the batch is atomic
+        on the shared autocommit connection (#172).
+        """
         if not pairs:
             return
         await self._ensure_open()
@@ -776,15 +818,22 @@ class StatsStore:
         # Canonicalize pairs so node_id_a <= node_id_b
         canonical = [(min(a, b), max(a, b)) for a, b in pairs]
         db = self._conn()
-        await db.executemany(
-            """INSERT INTO coactivation (node_id_a, node_id_b, namespace, count, last_at)
-               VALUES (?, ?, ?, 1, ?)
-               ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
-                 count = count + 1,
-                 last_at = excluded.last_at""",
-            [(a, b, namespace, now) for a, b in canonical],
-        )
-        await db.commit()
+        async with self._write_mutex():
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.executemany(
+                    """INSERT INTO coactivation
+                       (node_id_a, node_id_b, namespace, count, last_at)
+                       VALUES (?, ?, ?, 1, ?)
+                       ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
+                         count = count + 1,
+                         last_at = excluded.last_at""",
+                    [(a, b, namespace, now) for a, b in canonical],
+                )
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
 
     async def get_node_stats(self, node_id: str) -> dict[str, object] | None:
         """Return all node_stats columns for *node_id*, or ``None`` if absent."""

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -14,9 +14,11 @@ Tables (MVP 1):
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -161,19 +163,16 @@ class StatsStore:
         # across the dozens of method calls per retrieval / drain cycle is
         # the whole point of this lifecycle.
         self._db: aiosqlite.Connection | None = None
-        # Serialise every mutating method on the shared connection (#172).
+        # Serialise every operation on the shared connection (#172).
         #
-        # Python's sqlite3 default ``isolation_level=""`` auto-starts an
-        # implicit transaction on the first DML statement and ends it on
-        # ``commit()``. With per-call connections the implicit tx was
-        # scoped to one coroutine because each had its own connection. With
-        # one shared connection, two coroutines can interleave at ``await``
-        # points and join each other's auto-tx — coroutine B's commit then
-        # commits coroutine A's pending writes. The write lock prevents
-        # that interleave by holding for the full body of any method that
-        # touches DML. Pure-SELECT reads do not need the lock because
-        # SELECT does not start a write tx.
-        self._write_lock: asyncio.Lock | None = None
+        # A single sqlite3 connection cannot safely emulate the old
+        # per-call isolation unless each method keeps exclusive ownership
+        # of the handle for its full duration. Serialising only writes is
+        # not enough: a read can otherwise slip between BEGIN/UPDATE/COMMIT
+        # awaits on another coroutine and observe uncommitted state from
+        # that same connection. The operation lock restores per-method
+        # isolation while still amortising connection-open overhead.
+        self._op_lock: asyncio.Lock | None = None
         self._cached_enrich_queue_depth: int = 0
         self._cached_coactivation_pairs: int = 0
         self._cached_working_memory_active_tasks: int = 0
@@ -212,7 +211,7 @@ class StatsStore:
         # the other's pending writes. Autocommit makes single-statement
         # writes self-contained; multi-statement transactions (drains,
         # batched executemany) are bracketed with explicit BEGIN/COMMIT
-        # under :meth:`_write_mutex`.
+        # inside :meth:`_session`.
         db = await aiosqlite.connect(self.db_path, isolation_level=None)
         # Row access by name everywhere — sets default for the lifetime of
         # this connection. Methods that index by position keep working too.
@@ -247,8 +246,9 @@ class StatsStore:
            — drop the stale handle and re-open. Callers no longer need to
            reason about connection lifecycle.
 
-        For self-healing on a *live* but error-throwing handle, see
-        :meth:`reconnect` — that is the explicit recovery primitive.
+        A later operation may still discover a "live" handle that has gone
+        bad underneath us. Those failures are healed in :meth:`_session`
+        so the next call starts from a fresh connection automatically.
         """
         if self._opened and self._db is not None and getattr(self._db, "_running", True):
             return
@@ -278,18 +278,97 @@ class StatsStore:
         assert self._db is not None, "StatsStore.open() must be called before use"
         return self._db
 
-    def _write_mutex(self) -> asyncio.Lock:
-        """Return the lock that serialises mutating methods (#172).
+    def _operation_mutex(self) -> asyncio.Lock:
+        """Return the lock that serialises store methods on the shared handle."""
+        if self._op_lock is None:
+            self._op_lock = asyncio.Lock()
+        return self._op_lock
 
-        Lazily constructed because :meth:`__init__` runs before any event
-        loop exists in some test/CLI flows. Every method that issues an
-        INSERT/UPDATE/DELETE (including the explicit-transaction drains)
-        wraps its body in ``async with self._write_mutex():`` to keep the
-        shared connection's auto-transaction state coherent.
-        """
-        if self._write_lock is None:
-            self._write_lock = asyncio.Lock()
-        return self._write_lock
+    @staticmethod
+    def _is_recoverable_connection_error(exc: BaseException) -> bool:
+        """Return True when *exc* indicates the persistent handle is no longer usable."""
+        if not isinstance(exc, (ValueError, RuntimeError, aiosqlite.Error)):
+            return False
+        message = str(exc).lower()
+        return any(
+            fragment in message
+            for fragment in (
+                "closed database",
+                "closed connection",
+                "event loop is closed",
+                "no active connection",
+                "cannot operate on a closed database",
+            )
+        )
+
+    async def _reconnect_after_error(self) -> None:
+        """Drop the current handle and open a fresh one after a connection-liveness failure."""
+        db = self._db
+        self._db = None
+        self._opened = False
+        if db is not None:
+            with contextlib.suppress(Exception):
+                await db.close()
+        await self.open()
+
+    @contextlib.asynccontextmanager
+    async def _session(self, *, transactional: bool = False) -> AsyncIterator[aiosqlite.Connection]:
+        """Yield exclusive access to the shared connection, optionally in a transaction."""
+        async with self._operation_mutex():
+            await self._ensure_open()
+            db = self._conn()
+
+            if not transactional:
+                try:
+                    yield db
+                except Exception as exc:
+                    if self._is_recoverable_connection_error(exc):
+                        logger.warning(
+                            "StatsStore operation hit a dead connection; reopening %s",
+                            self.db_path,
+                            exc_info=True,
+                        )
+                        await self._reconnect_after_error()
+                    raise
+                return
+
+            try:
+                await db.execute("BEGIN IMMEDIATE")
+            except Exception as exc:
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "StatsStore transaction could not begin; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
+
+            try:
+                yield db
+            except Exception as exc:
+                with contextlib.suppress(Exception):
+                    await db.execute("ROLLBACK")
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "StatsStore transaction lost its connection; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
+
+            try:
+                await db.execute("COMMIT")
+            except Exception as exc:
+                if self._is_recoverable_connection_error(exc):
+                    logger.warning(
+                        "StatsStore transaction could not commit; reopening %s",
+                        self.db_path,
+                        exc_info=True,
+                    )
+                    await self._reconnect_after_error()
+                raise
 
     # ------------------------------------------------------------------
     # Receipt operations
@@ -320,33 +399,31 @@ class StatsStore:
         §4.6 so future ``lithos_receipts`` queries can render audit trails
         without re-walking the retrieval pipeline.
         """
-        await self._ensure_open()
         ns_json = json.dumps(namespace_filter) if namespace_filter is not None else None
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO receipts
-               (id, query, "limit", namespace_filter, scouts_fired,
-                candidates_considered, final_nodes, conflicts_surfaced,
-                surface_conflicts, temperature, terrace_reached,
-                agent_id, task_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                receipt_id,
-                query,
-                limit,
-                ns_json,
-                json.dumps(scouts_fired),
-                candidates_considered,
-                json.dumps(final_nodes),
-                json.dumps(conflicts_surfaced),
-                1 if surface_conflicts else 0,
-                temperature,
-                terrace_reached,
-                agent_id,
-                task_id,
-            ),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO receipts
+                   (id, query, "limit", namespace_filter, scouts_fired,
+                    candidates_considered, final_nodes, conflicts_surfaced,
+                    surface_conflicts, temperature, terrace_reached,
+                    agent_id, task_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    receipt_id,
+                    query,
+                    limit,
+                    ns_json,
+                    json.dumps(scouts_fired),
+                    candidates_considered,
+                    json.dumps(final_nodes),
+                    json.dumps(conflicts_surfaced),
+                    1 if surface_conflicts else 0,
+                    temperature,
+                    terrace_reached,
+                    agent_id,
+                    task_id,
+                ),
+            )
         logger.info(
             "receipt inserted: id=%s agent=%s task=%s candidates=%d final_nodes=%d scouts=%s",
             receipt_id,
@@ -382,32 +459,29 @@ class StatsStore:
         their original value so callers can distinguish first activation
         from subsequent touches.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO working_memory
-               (task_id, node_id, activation_count,
-                first_seen_at, last_seen_at, last_receipt_id)
-               VALUES (?, ?, 1, ?, ?, ?)
-               ON CONFLICT(task_id, node_id) DO UPDATE SET
-                 activation_count = activation_count + 1,
-                 last_seen_at = excluded.last_seen_at,
-                 last_receipt_id = excluded.last_receipt_id""",
-            (task_id, node_id, now, now, receipt_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO working_memory
+                   (task_id, node_id, activation_count,
+                    first_seen_at, last_seen_at, last_receipt_id)
+                   VALUES (?, ?, 1, ?, ?, ?)
+                   ON CONFLICT(task_id, node_id) DO UPDATE SET
+                     activation_count = activation_count + 1,
+                     last_seen_at = excluded.last_seen_at,
+                     last_receipt_id = excluded.last_receipt_id""",
+                (task_id, node_id, now, now, receipt_id),
+            )
 
     async def get_working_memory(self, task_id: str) -> list[dict[str, object]]:
         """Return all working_memory rows for *task_id*, ordered by activation_count descending."""
-        await self._ensure_open()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM working_memory WHERE task_id = ? ORDER BY activation_count DESC",
-            (task_id,),
-        )
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM working_memory WHERE task_id = ? ORDER BY activation_count DESC",
+                (task_id,),
+            )
+            rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     async def evict_working_memory(self, *, completed_task_ids: list[str], ttl_days: int) -> int:
@@ -417,22 +491,20 @@ class StatsStore:
         ``last_seen_at`` is older than *ttl_days* ago.  Returns the count
         of rows deleted.
         """
-        await self._ensure_open()
         cutoff = (datetime.now(timezone.utc) - timedelta(days=ttl_days)).isoformat()
-        db = self._conn()
-        if completed_task_ids:
-            placeholders = ", ".join("?" for _ in completed_task_ids)
-            cursor = await db.execute(
-                f"DELETE FROM working_memory WHERE task_id IN ({placeholders}) OR last_seen_at < ?",
-                (*completed_task_ids, cutoff),
-            )
-        else:
-            cursor = await db.execute(
-                "DELETE FROM working_memory WHERE last_seen_at < ?",
-                (cutoff,),
-            )
-        deleted = cursor.rowcount
-        await db.commit()
+        async with self._session() as db:
+            if completed_task_ids:
+                placeholders = ", ".join("?" for _ in completed_task_ids)
+                cursor = await db.execute(
+                    f"DELETE FROM working_memory WHERE task_id IN ({placeholders}) OR last_seen_at < ?",
+                    (*completed_task_ids, cutoff),
+                )
+            else:
+                cursor = await db.execute(
+                    "DELETE FROM working_memory WHERE last_seen_at < ?",
+                    (cutoff,),
+                )
+            deleted = cursor.rowcount
         logger.info(
             "working_memory evicted: deleted=%d ttl_days=%d completed_task_count=%d",
             deleted,
@@ -458,20 +530,18 @@ class StatsStore:
         namespace: str,
     ) -> None:
         """Increment coactivation count for an unordered pair."""
-        await self._ensure_open()
         a, b = (node_a, node_b) if node_a <= node_b else (node_b, node_a)
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO coactivation
-               (node_id_a, node_id_b, namespace, count, last_at)
-               VALUES (?, ?, ?, 1, ?)
-               ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
-                 count = count + 1,
-                 last_at = excluded.last_at""",
-            (a, b, namespace, now),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO coactivation
+                   (node_id_a, node_id_b, namespace, count, last_at)
+                   VALUES (?, ?, ?, 1, ?)
+                   ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
+                     count = count + 1,
+                     last_at = excluded.last_at""",
+                (a, b, namespace, now),
+            )
 
     async def get_coactivated(
         self,
@@ -494,45 +564,43 @@ class StatsStore:
         """
         if not node_ids:
             return []
-        await self._ensure_open()
         seed_set = set(node_ids)
         totals: dict[str, int] = {}
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            placeholders = ", ".join("?" for _ in node_ids)
 
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        placeholders = ", ".join("?" for _ in node_ids)
+            # Rows where a seed appears as node_id_a → other is node_id_b
+            if namespace is not None:
+                query_a = (
+                    f"SELECT node_id_b AS other, count FROM coactivation "
+                    f"WHERE node_id_a IN ({placeholders}) AND namespace = ?"
+                )
+                params_a: tuple[str, ...] = (*node_ids, namespace)
+                query_b = (
+                    f"SELECT node_id_a AS other, count FROM coactivation "
+                    f"WHERE node_id_b IN ({placeholders}) AND namespace = ?"
+                )
+                params_b: tuple[str, ...] = (*node_ids, namespace)
+            else:
+                query_a = (
+                    f"SELECT node_id_b AS other, count FROM coactivation "
+                    f"WHERE node_id_a IN ({placeholders})"
+                )
+                params_a = tuple(node_ids)
+                query_b = (
+                    f"SELECT node_id_a AS other, count FROM coactivation "
+                    f"WHERE node_id_b IN ({placeholders})"
+                )
+                params_b = tuple(node_ids)
 
-        # Rows where a seed appears as node_id_a → other is node_id_b
-        if namespace is not None:
-            query_a = (
-                f"SELECT node_id_b AS other, count FROM coactivation "
-                f"WHERE node_id_a IN ({placeholders}) AND namespace = ?"
-            )
-            params_a: tuple[str, ...] = (*node_ids, namespace)
-            query_b = (
-                f"SELECT node_id_a AS other, count FROM coactivation "
-                f"WHERE node_id_b IN ({placeholders}) AND namespace = ?"
-            )
-            params_b: tuple[str, ...] = (*node_ids, namespace)
-        else:
-            query_a = (
-                f"SELECT node_id_b AS other, count FROM coactivation "
-                f"WHERE node_id_a IN ({placeholders})"
-            )
-            params_a = tuple(node_ids)
-            query_b = (
-                f"SELECT node_id_a AS other, count FROM coactivation "
-                f"WHERE node_id_b IN ({placeholders})"
-            )
-            params_b = tuple(node_ids)
-
-        for query, params in [(query_a, params_a), (query_b, params_b)]:
-            cursor = await db.execute(query, params)
-            for row in await cursor.fetchall():
-                other = row["other"]
-                if other in seed_set:
-                    continue
-                totals[other] = totals.get(other, 0) + row["count"]
+            for query, params in [(query_a, params_a), (query_b, params_b)]:
+                cursor = await db.execute(query, params)
+                for row in await cursor.fetchall():
+                    other = row["other"]
+                    if other in seed_set:
+                        continue
+                    totals[other] = totals.get(other, 0) + row["count"]
 
         ranked = sorted(totals.items(), key=lambda t: t[1], reverse=True)
         return ranked[:limit]
@@ -554,13 +622,11 @@ class StatsStore:
         """
         if (node_id is None) == (task_id is None):
             raise ValueError("Exactly one of node_id or task_id must be provided")
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            "INSERT INTO enrich_queue (trigger_type, node_id, task_id) VALUES (?, ?, ?)",
-            (trigger_type, node_id, task_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                "INSERT INTO enrich_queue (trigger_type, node_id, task_id) VALUES (?, ?, ?)",
+                (trigger_type, node_id, task_id),
+            )
         logger.debug(
             "enrich_queue enqueued: trigger=%s node_id=%s task_id=%s",
             trigger_type,
@@ -582,18 +648,12 @@ class StatsStore:
             max_attempts: When provided, only claim rows whose ``attempts``
                 column is strictly less than this value.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        # Serialise drains on the shared connection (#172). BEGIN IMMEDIATE
-        # used to be enough — separate connections meant SQLite's write lock
-        # forced one to block until the other committed. With one shared
-        # connection the lock state lives on the underlying sqlite3 handle,
-        # so two concurrent drains would either error on a nested BEGIN or
-        # interleave at the statement level.
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
+        # BEGIN IMMEDIATE alone is not enough on one shared connection:
+        # another coroutine can otherwise queue a read between this
+        # transaction's awaits and observe uncommitted state.
+        async with self._session(transactional=True) as db:
+            db.row_factory = aiosqlite.Row
             if max_attempts is not None:
                 cursor = await db.execute(
                     "SELECT id, node_id, trigger_type FROM enrich_queue "
@@ -608,7 +668,6 @@ class StatsStore:
                 )
             rows = list(await cursor.fetchall())
             if not rows:
-                await db.execute("COMMIT")
                 return []
 
             # Mark as processed within the same transaction
@@ -618,7 +677,6 @@ class StatsStore:
                 f"UPDATE enrich_queue SET processed_at = ? WHERE id IN ({placeholders})",
                 (now, *ids),
             )
-            await db.commit()
 
         # Deduplicate by node_id
         by_node: dict[str, dict[str, object]] = {}
@@ -663,13 +721,10 @@ class StatsStore:
             max_attempts: When provided, only claim rows whose ``attempts``
                 column is strictly less than this value.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
         # See drain_pending_nodes for why this needs a Python-level lock now.
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
+        async with self._session(transactional=True) as db:
+            db.row_factory = aiosqlite.Row
             if max_attempts is not None:
                 cursor = await db.execute(
                     "SELECT id, task_id FROM enrich_queue "
@@ -684,7 +739,6 @@ class StatsStore:
                 )
             rows = await cursor.fetchall()
             if not rows:
-                await db.execute("COMMIT")
                 return []
 
             ids = [row["id"] for row in rows]
@@ -693,7 +747,6 @@ class StatsStore:
                 f"UPDATE enrich_queue SET processed_at = ? WHERE id IN ({placeholders})",
                 (now, *ids),
             )
-            await db.commit()
 
         # Deduplicate by task_id
         by_task: dict[str, dict[str, object]] = {}
@@ -714,16 +767,14 @@ class StatsStore:
         """
         if not claimed_ids:
             return 0
-        await self._ensure_open()
         placeholders = ", ".join("?" for _ in claimed_ids)
-        db = self._conn()
-        cursor = await db.execute(
-            "UPDATE enrich_queue SET processed_at = NULL, attempts = attempts + 1 "
-            f"WHERE id IN ({placeholders})",
-            tuple(claimed_ids),
-        )
-        count = cursor.rowcount
-        await db.commit()
+        async with self._session() as db:
+            cursor = await db.execute(
+                "UPDATE enrich_queue SET processed_at = NULL, attempts = attempts + 1 "
+                f"WHERE id IN ({placeholders})",
+                tuple(claimed_ids),
+            )
+            count = cursor.rowcount
         logger.warning(
             "enrich_queue requeue_failed: requeued=%d requested=%d",
             count,
@@ -738,16 +789,15 @@ class StatsStore:
         """Return enrich_queue rows among *claimed_ids* whose attempts >= *max_attempts*."""
         if not claimed_ids:
             return []
-        await self._ensure_open()
         placeholders = ", ".join("?" for _ in claimed_ids)
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            f"SELECT id, node_id, task_id, attempts FROM enrich_queue "
-            f"WHERE id IN ({placeholders}) AND attempts >= ?",
-            (*claimed_ids, max_attempts),
-        )
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                f"SELECT id, node_id, task_id, attempts FROM enrich_queue "
+                f"WHERE id IN ({placeholders}) AND attempts >= ?",
+                (*claimed_ids, max_attempts),
+            )
+            rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     async def get_enrich_items_by_ids(self, item_ids: list[int]) -> list[dict[str, object]]:
@@ -757,16 +807,15 @@ class StatsStore:
         """
         if not item_ids:
             return []
-        await self._ensure_open()
         placeholders = ", ".join("?" for _ in item_ids)
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            f"SELECT id, triggered_at, processed_at, attempts FROM enrich_queue "
-            f"WHERE id IN ({placeholders})",
-            tuple(item_ids),
-        )
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                f"SELECT id, triggered_at, processed_at, attempts FROM enrich_queue "
+                f"WHERE id IN ({placeholders})",
+                tuple(item_ids),
+            )
+            rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -778,46 +827,36 @@ class StatsStore:
 
         Inserts with salience=0.5 on first touch.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
-               VALUES (?, 1, ?, 0.5)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 retrieval_count = retrieval_count + 1,
-                 last_retrieved_at = excluded.last_retrieved_at""",
-            (node_id, now),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
+                   VALUES (?, 1, ?, 0.5)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     retrieval_count = retrieval_count + 1,
+                     last_retrieved_at = excluded.last_retrieved_at""",
+                (node_id, now),
+            )
 
     async def increment_node_stats_batch(self, node_ids: list[str]) -> None:
         """Increment retrieval_count for multiple nodes in a single transaction.
 
-        Wrapped in BEGIN/COMMIT under the write mutex so the batch is atomic
-        on the shared autocommit connection (#172).
+        Wrapped in BEGIN/COMMIT inside :meth:`_session` so the batch is
+        atomic on the shared autocommit connection (#172).
         """
         if not node_ids:
             return
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
-            try:
-                await db.executemany(
-                    """INSERT INTO node_stats
-                       (node_id, retrieval_count, last_retrieved_at, salience)
-                       VALUES (?, 1, ?, 0.5)
-                       ON CONFLICT(node_id) DO UPDATE SET
-                         retrieval_count = retrieval_count + 1,
-                         last_retrieved_at = excluded.last_retrieved_at""",
-                    [(nid, now) for nid in node_ids],
-                )
-                await db.execute("COMMIT")
-            except Exception:
-                await db.execute("ROLLBACK")
-                raise
+        async with self._session(transactional=True) as db:
+            await db.executemany(
+                """INSERT INTO node_stats
+                   (node_id, retrieval_count, last_retrieved_at, salience)
+                   VALUES (?, 1, ?, 0.5)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     retrieval_count = retrieval_count + 1,
+                     last_retrieved_at = excluded.last_retrieved_at""",
+                [(nid, now) for nid in node_ids],
+            )
         logger.debug(
             "node_stats batch increment: node_count=%d",
             len(node_ids),
@@ -831,40 +870,31 @@ class StatsStore:
     ) -> None:
         """Increment coactivation counts for multiple pairs in a single transaction.
 
-        Wrapped in BEGIN/COMMIT under the write mutex so the batch is atomic
-        on the shared autocommit connection (#172).
+        Wrapped in BEGIN/COMMIT inside :meth:`_session` so the batch is
+        atomic on the shared autocommit connection (#172).
         """
         if not pairs:
             return
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
         # Canonicalize pairs so node_id_a <= node_id_b
         canonical = [(min(a, b), max(a, b)) for a, b in pairs]
-        db = self._conn()
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
-            try:
-                await db.executemany(
-                    """INSERT INTO coactivation
-                       (node_id_a, node_id_b, namespace, count, last_at)
-                       VALUES (?, ?, ?, 1, ?)
-                       ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
-                         count = count + 1,
-                         last_at = excluded.last_at""",
-                    [(a, b, namespace, now) for a, b in canonical],
-                )
-                await db.execute("COMMIT")
-            except Exception:
-                await db.execute("ROLLBACK")
-                raise
+        async with self._session(transactional=True) as db:
+            await db.executemany(
+                """INSERT INTO coactivation
+                   (node_id_a, node_id_b, namespace, count, last_at)
+                   VALUES (?, ?, ?, 1, ?)
+                   ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
+                     count = count + 1,
+                     last_at = excluded.last_at""",
+                [(a, b, namespace, now) for a, b in canonical],
+            )
 
     async def get_node_stats(self, node_id: str) -> dict[str, object] | None:
         """Return all node_stats columns for *node_id*, or ``None`` if absent."""
-        await self._ensure_open()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute("SELECT * FROM node_stats WHERE node_id = ?", (node_id,))
-        row = await cursor.fetchone()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM node_stats WHERE node_id = ?", (node_id,))
+            row = await cursor.fetchone()
         if row is None:
             return None
         return dict(row)
@@ -877,23 +907,21 @@ class StatsStore:
         """
         if not node_ids:
             return {}
-        await self._ensure_open()
         placeholders = ",".join("?" for _ in node_ids)
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            f"SELECT * FROM node_stats WHERE node_id IN ({placeholders})",
-            node_ids,
-        )
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                f"SELECT * FROM node_stats WHERE node_id IN ({placeholders})",
+                node_ids,
+            )
+            rows = await cursor.fetchall()
         return {row["node_id"]: dict(row) for row in rows}
 
     async def list_all_node_ids(self) -> list[str]:
         """Return all node_id values from node_stats."""
-        await self._ensure_open()
-        db = self._conn()
-        cursor = await db.execute("SELECT node_id FROM node_stats")
-        rows = await cursor.fetchall()
+        async with self._session() as db:
+            cursor = await db.execute("SELECT node_id FROM node_stats")
+            rows = await cursor.fetchall()
         return [row[0] for row in rows]
 
     # ------------------------------------------------------------------
@@ -922,41 +950,38 @@ class StatsStore:
         observable gauges always report a recent value without requiring async
         callbacks in the SDK metric collection path.
         """
-        await self._ensure_open()
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
-        db = self._conn()
-        row = await (
-            await db.execute("SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL")
-        ).fetchone()
-        self._cached_enrich_queue_depth = int(row[0]) if row else 0
+        async with self._session() as db:
+            row = await (
+                await db.execute("SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL")
+            ).fetchone()
+            self._cached_enrich_queue_depth = int(row[0]) if row else 0
 
-        row = await (await db.execute("SELECT COUNT(*) FROM coactivation")).fetchone()
-        self._cached_coactivation_pairs = int(row[0]) if row else 0
+            row = await (await db.execute("SELECT COUNT(*) FROM coactivation")).fetchone()
+            self._cached_coactivation_pairs = int(row[0]) if row else 0
 
-        row = await (
-            await db.execute(
-                "SELECT COUNT(DISTINCT task_id) FROM working_memory WHERE last_seen_at >= ?",
-                (cutoff,),
-            )
-        ).fetchone()
-        self._cached_working_memory_active_tasks = int(row[0]) if row else 0
+            row = await (
+                await db.execute(
+                    "SELECT COUNT(DISTINCT task_id) FROM working_memory WHERE last_seen_at >= ?",
+                    (cutoff,),
+                )
+            ).fetchone()
+            self._cached_working_memory_active_tasks = int(row[0]) if row else 0
 
     async def update_salience(self, node_id: str, delta: float) -> None:
         """Atomically adjust salience by *delta*, clamping to [0.0, 1.0].
 
         Creates the row with ``salience = 0.5 + delta`` (clamped) if absent.
         """
-        await self._ensure_open()
         initial = max(0.0, min(1.0, 0.5 + delta))
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, salience)
-               VALUES (?, ?)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 salience = MAX(0.0, MIN(1.0, salience + ?))""",
-            (node_id, initial, delta),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, salience)
+                   VALUES (?, ?)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     salience = MAX(0.0, MIN(1.0, salience + ?))""",
+                (node_id, initial, delta),
+            )
         if _HAS_TELEMETRY and _lithos_metrics is not None:
             _lithos_metrics.lcma_salience_updates.add(1)
         logger.debug(
@@ -968,42 +993,36 @@ class StatsStore:
 
     async def increment_ignored(self, node_id: str) -> None:
         """Atomically increment ignored_count; creates row if absent."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, ignored_count)
-               VALUES (?, 1)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 ignored_count = ignored_count + 1""",
-            (node_id,),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, ignored_count)
+                   VALUES (?, 1)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     ignored_count = ignored_count + 1""",
+                (node_id,),
+            )
 
     async def increment_cited(self, node_id: str) -> None:
         """Atomically increment cited_count; creates row if absent."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, cited_count)
-               VALUES (?, 1)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 cited_count = cited_count + 1""",
-            (node_id,),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, cited_count)
+                   VALUES (?, 1)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     cited_count = cited_count + 1""",
+                (node_id,),
+            )
 
     async def increment_misleading(self, node_id: str) -> None:
         """Atomically increment misleading_count; creates row if absent."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, misleading_count)
-               VALUES (?, 1)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 misleading_count = misleading_count + 1""",
-            (node_id,),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, misleading_count)
+                   VALUES (?, 1)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     misleading_count = misleading_count + 1""",
+                (node_id,),
+            )
 
     async def update_spaced_rep_strength(self, node_id: str, delta: float) -> None:
         """Atomically adjust spaced_rep_strength by *delta*, clamping to [0.0, 1.0].
@@ -1011,45 +1030,39 @@ class StatsStore:
         Creates the row with ``spaced_rep_strength = max(0, min(1, 0 + delta))``
         if absent (default is 0.0).
         """
-        await self._ensure_open()
         initial = max(0.0, min(1.0, delta))
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, spaced_rep_strength)
-               VALUES (?, ?)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 spaced_rep_strength = MAX(0.0, MIN(1.0, spaced_rep_strength + ?))""",
-            (node_id, initial, delta),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, spaced_rep_strength)
+                   VALUES (?, ?)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     spaced_rep_strength = MAX(0.0, MIN(1.0, spaced_rep_strength + ?))""",
+                (node_id, initial, delta),
+            )
 
     async def update_last_decay_applied_at(self, node_id: str) -> None:
         """Set ``last_decay_applied_at`` to now for *node_id*."""
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        await db.execute(
-            "UPDATE node_stats SET last_decay_applied_at = ? WHERE node_id = ?",
-            (now, node_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                "UPDATE node_stats SET last_decay_applied_at = ? WHERE node_id = ?",
+                (now, node_id),
+            )
 
     async def update_last_used_at(self, node_id: str) -> None:
         """Set ``last_used_at`` to now for *node_id*.
 
         Creates the row with default salience if absent.
         """
-        await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, last_used_at)
-               VALUES (?, ?)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 last_used_at = excluded.last_used_at""",
-            (node_id, now),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, last_used_at)
+                   VALUES (?, ?)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     last_used_at = excluded.last_used_at""",
+                (node_id, now),
+            )
 
     # ------------------------------------------------------------------
     # Consolidation tracking operations
@@ -1057,64 +1070,55 @@ class StatsStore:
 
     async def is_task_consolidated(self, task_id: str) -> bool:
         """Return ``True`` if *task_id* exists in ``task_consolidation_log``."""
-        await self._ensure_open()
-        db = self._conn()
-        cursor = await db.execute(
-            "SELECT 1 FROM task_consolidation_log WHERE task_id = ?",
-            (task_id,),
-        )
-        return await cursor.fetchone() is not None
+        async with self._session() as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM task_consolidation_log WHERE task_id = ?",
+                (task_id,),
+            )
+            return await cursor.fetchone() is not None
 
     async def mark_task_consolidated(self, task_id: str) -> None:
         """Insert *task_id* into ``task_consolidation_log`` (INSERT OR IGNORE)."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            "INSERT OR IGNORE INTO task_consolidation_log (task_id) VALUES (?)",
-            (task_id,),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO task_consolidation_log (task_id) VALUES (?)",
+                (task_id,),
+            )
 
     async def has_consolidation_edge_op(self, task_id: str, from_id: str, to_id: str) -> bool:
         """Return ``True`` if the edge op has already been recorded."""
-        await self._ensure_open()
-        db = self._conn()
-        cursor = await db.execute(
-            "SELECT 1 FROM consolidation_edge_ops WHERE task_id = ? AND from_id = ? AND to_id = ?",
-            (task_id, from_id, to_id),
-        )
-        return await cursor.fetchone() is not None
+        async with self._session() as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM consolidation_edge_ops WHERE task_id = ? AND from_id = ? AND to_id = ?",
+                (task_id, from_id, to_id),
+            )
+            return await cursor.fetchone() is not None
 
     async def record_consolidation_edge_op(self, task_id: str, from_id: str, to_id: str) -> None:
         """Record an edge consolidation op (INSERT OR IGNORE)."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            "INSERT OR IGNORE INTO consolidation_edge_ops (task_id, from_id, to_id) "
-            "VALUES (?, ?, ?)",
-            (task_id, from_id, to_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO consolidation_edge_ops (task_id, from_id, to_id) "
+                "VALUES (?, ?, ?)",
+                (task_id, from_id, to_id),
+            )
 
     async def has_consolidation_salience_op(self, task_id: str, node_id: str) -> bool:
         """Return ``True`` if the salience op has already been recorded."""
-        await self._ensure_open()
-        db = self._conn()
-        cursor = await db.execute(
-            "SELECT 1 FROM consolidation_salience_ops WHERE task_id = ? AND node_id = ?",
-            (task_id, node_id),
-        )
-        return await cursor.fetchone() is not None
+        async with self._session() as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM consolidation_salience_ops WHERE task_id = ? AND node_id = ?",
+                (task_id, node_id),
+            )
+            return await cursor.fetchone() is not None
 
     async def record_consolidation_salience_op(self, task_id: str, node_id: str) -> None:
         """Record a salience consolidation op (INSERT OR IGNORE)."""
-        await self._ensure_open()
-        db = self._conn()
-        await db.execute(
-            "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
-            (task_id, node_id),
-        )
-        await db.commit()
+        async with self._session() as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
+                (task_id, node_id),
+            )
 
     async def update_salience_and_record_consolidation(
         self, *, node_id: str, delta: float, task_id: str
@@ -1124,32 +1128,23 @@ class StatsStore:
         Both writes happen in a single stats.db transaction so that a crash
         between them cannot cause double-boosting on retry. With autocommit
         mode (#172) the atomicity is enforced by an explicit BEGIN/COMMIT
-        bracket under :meth:`_write_mutex` — without it, the salience update
+        bracket inside :meth:`_session` — without it, the salience update
         would commit before the consolidation marker is recorded and a
         retry would re-apply the delta.
         """
-        await self._ensure_open()
         initial = max(0.0, min(1.0, 0.5 + delta))
-        db = self._conn()
-        async with self._write_mutex():
-            await db.execute("BEGIN IMMEDIATE")
-            try:
-                await db.execute(
-                    """INSERT INTO node_stats (node_id, salience)
-                       VALUES (?, ?)
-                       ON CONFLICT(node_id) DO UPDATE SET
-                         salience = MAX(0.0, MIN(1.0, salience + ?))""",
-                    (node_id, initial, delta),
-                )
-                await db.execute(
-                    "INSERT OR IGNORE INTO consolidation_salience_ops "
-                    "(task_id, node_id) VALUES (?, ?)",
-                    (task_id, node_id),
-                )
-                await db.execute("COMMIT")
-            except Exception:
-                await db.execute("ROLLBACK")
-                raise
+        async with self._session(transactional=True) as db:
+            await db.execute(
+                """INSERT INTO node_stats (node_id, salience)
+                   VALUES (?, ?)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     salience = MAX(0.0, MIN(1.0, salience + ?))""",
+                (node_id, initial, delta),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
+                (task_id, node_id),
+            )
 
     # ------------------------------------------------------------------
     # Receipt lookup operations
@@ -1162,11 +1157,10 @@ class StatsStore:
         field (``list[str]``), or ``None`` if no matching receipt exists or
         the task_id does not match.
         """
-        await self._ensure_open()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute("SELECT * FROM receipts WHERE id = ?", (receipt_id,))
-        row = await cursor.fetchone()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM receipts WHERE id = ?", (receipt_id,))
+            row = await cursor.fetchone()
         if row is None:
             return None
         result = dict(row)
@@ -1182,14 +1176,13 @@ class StatsStore:
         receipt row as a dict with an added ``final_node_ids`` field, or
         ``None`` if no receipt matches.
         """
-        await self._ensure_open()
-        db = self._conn()
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM receipts WHERE task_id = ? AND agent_id = ? ORDER BY rowid DESC LIMIT 1",
-            (task_id, agent_id),
-        )
-        row = await cursor.fetchone()
+        async with self._session() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM receipts WHERE task_id = ? AND agent_id = ? ORDER BY rowid DESC LIMIT 1",
+                (task_id, agent_id),
+            )
+            row = await cursor.fetchone()
         if row is None:
             return None
         result = dict(row)

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -13,6 +13,7 @@ Tables (MVP 1):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -155,6 +156,19 @@ class StatsStore:
     def __init__(self, config: LithosConfig | None = None) -> None:
         self._config = config
         self._opened = False
+        # Persistent SQLite connection (#172). One handle per StatsStore;
+        # WAL mode enables concurrent readers, and amortising the open cost
+        # across the dozens of method calls per retrieval / drain cycle is
+        # the whole point of this lifecycle.
+        self._db: aiosqlite.Connection | None = None
+        # Serialise drain transactions on the shared connection (#172).
+        # When each method opened its own connection, BEGIN IMMEDIATE on
+        # connection B blocked until connection A committed — SQLite's
+        # write lock kept double-claim impossible. With one shared
+        # connection, two concurrent drains would interleave at the
+        # statement level and either error on a nested BEGIN or claim the
+        # same row twice. The lock restores per-drain atomicity.
+        self._drain_lock: asyncio.Lock | None = None
         self._cached_enrich_queue_depth: int = 0
         self._cached_coactivation_pairs: int = 0
         self._cached_working_memory_active_tasks: int = 0
@@ -168,10 +182,12 @@ class StatsStore:
         return self.config.storage.stats_db_path
 
     async def open(self) -> None:
-        """Ensure stats.db exists with the correct schema.
+        """Ensure stats.db exists with the correct schema and a live connection.
 
         Idempotent — safe to call multiple times.  If the file is corrupt
-        it is quarantined and a fresh database is created.
+        it is quarantined and a fresh database is created. After this returns
+        :attr:`_db` is a persistent ``aiosqlite.Connection`` in WAL mode that
+        every method reuses (#172).
         """
         if self._opened:
             return
@@ -182,18 +198,48 @@ class StatsStore:
             if not healthy:
                 self._quarantine(self.db_path)
 
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.executescript(SCHEMA)
-            await self._migrate_add_cited_count(db)
-            await self._migrate_add_last_decay_applied_at(db)
-            await self._migrate_add_enrich_queue_attempts(db)
-            await db.commit()
+        db = await aiosqlite.connect(self.db_path)
+        # Row access by name everywhere — sets default for the lifetime of
+        # this connection. Methods that index by position keep working too.
+        db.row_factory = aiosqlite.Row
+        # WAL gives us concurrent readers and bounded fsync cost. Foreign-key
+        # enforcement matches the constraints declared in SCHEMA.
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA foreign_keys=ON")
+        await db.executescript(SCHEMA)
+        await self._migrate_add_cited_count(db)
+        await self._migrate_add_last_decay_applied_at(db)
+        await self._migrate_add_enrich_queue_attempts(db)
+        await db.commit()
+        self._db = db
         self._opened = True
+
+    async def close(self) -> None:
+        """Close the persistent connection. Idempotent."""
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+        self._opened = False
 
     async def _ensure_open(self) -> None:
         """Lazily create the database on first use."""
         if not self._opened:
             await self.open()
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return the live connection. ``open()`` must have run first."""
+        assert self._db is not None, "StatsStore.open() must be called before use"
+        return self._db
+
+    def _drain_mutex(self) -> asyncio.Lock:
+        """Return the lock that serialises drain transactions (#172).
+
+        Lazily constructed because :meth:`__init__` runs before any event
+        loop exists in some test/CLI flows.
+        """
+        if self._drain_lock is None:
+            self._drain_lock = asyncio.Lock()
+        return self._drain_lock
 
     # ------------------------------------------------------------------
     # Receipt operations
@@ -226,31 +272,31 @@ class StatsStore:
         """
         await self._ensure_open()
         ns_json = json.dumps(namespace_filter) if namespace_filter is not None else None
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO receipts
-                   (id, query, "limit", namespace_filter, scouts_fired,
-                    candidates_considered, final_nodes, conflicts_surfaced,
-                    surface_conflicts, temperature, terrace_reached,
-                    agent_id, task_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    receipt_id,
-                    query,
-                    limit,
-                    ns_json,
-                    json.dumps(scouts_fired),
-                    candidates_considered,
-                    json.dumps(final_nodes),
-                    json.dumps(conflicts_surfaced),
-                    1 if surface_conflicts else 0,
-                    temperature,
-                    terrace_reached,
-                    agent_id,
-                    task_id,
-                ),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO receipts
+               (id, query, "limit", namespace_filter, scouts_fired,
+                candidates_considered, final_nodes, conflicts_surfaced,
+                surface_conflicts, temperature, terrace_reached,
+                agent_id, task_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                receipt_id,
+                query,
+                limit,
+                ns_json,
+                json.dumps(scouts_fired),
+                candidates_considered,
+                json.dumps(final_nodes),
+                json.dumps(conflicts_surfaced),
+                1 if surface_conflicts else 0,
+                temperature,
+                terrace_reached,
+                agent_id,
+                task_id,
+            ),
+        )
+        await db.commit()
         logger.info(
             "receipt inserted: id=%s agent=%s task=%s candidates=%d final_nodes=%d scouts=%s",
             receipt_id,
@@ -288,30 +334,30 @@ class StatsStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO working_memory
-                   (task_id, node_id, activation_count,
-                    first_seen_at, last_seen_at, last_receipt_id)
-                   VALUES (?, ?, 1, ?, ?, ?)
-                   ON CONFLICT(task_id, node_id) DO UPDATE SET
-                     activation_count = activation_count + 1,
-                     last_seen_at = excluded.last_seen_at,
-                     last_receipt_id = excluded.last_receipt_id""",
-                (task_id, node_id, now, now, receipt_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO working_memory
+               (task_id, node_id, activation_count,
+                first_seen_at, last_seen_at, last_receipt_id)
+               VALUES (?, ?, 1, ?, ?, ?)
+               ON CONFLICT(task_id, node_id) DO UPDATE SET
+                 activation_count = activation_count + 1,
+                 last_seen_at = excluded.last_seen_at,
+                 last_receipt_id = excluded.last_receipt_id""",
+            (task_id, node_id, now, now, receipt_id),
+        )
+        await db.commit()
 
     async def get_working_memory(self, task_id: str) -> list[dict[str, object]]:
         """Return all working_memory rows for *task_id*, ordered by activation_count descending."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                "SELECT * FROM working_memory WHERE task_id = ? ORDER BY activation_count DESC",
-                (task_id,),
-            )
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM working_memory WHERE task_id = ? ORDER BY activation_count DESC",
+            (task_id,),
+        )
+        rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     async def evict_working_memory(self, *, completed_task_ids: list[str], ttl_days: int) -> int:
@@ -323,21 +369,20 @@ class StatsStore:
         """
         await self._ensure_open()
         cutoff = (datetime.now(timezone.utc) - timedelta(days=ttl_days)).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            if completed_task_ids:
-                placeholders = ", ".join("?" for _ in completed_task_ids)
-                cursor = await db.execute(
-                    f"DELETE FROM working_memory "
-                    f"WHERE task_id IN ({placeholders}) OR last_seen_at < ?",
-                    (*completed_task_ids, cutoff),
-                )
-            else:
-                cursor = await db.execute(
-                    "DELETE FROM working_memory WHERE last_seen_at < ?",
-                    (cutoff,),
-                )
-            deleted = cursor.rowcount
-            await db.commit()
+        db = self._conn()
+        if completed_task_ids:
+            placeholders = ", ".join("?" for _ in completed_task_ids)
+            cursor = await db.execute(
+                f"DELETE FROM working_memory WHERE task_id IN ({placeholders}) OR last_seen_at < ?",
+                (*completed_task_ids, cutoff),
+            )
+        else:
+            cursor = await db.execute(
+                "DELETE FROM working_memory WHERE last_seen_at < ?",
+                (cutoff,),
+            )
+        deleted = cursor.rowcount
+        await db.commit()
         logger.info(
             "working_memory evicted: deleted=%d ttl_days=%d completed_task_count=%d",
             deleted,
@@ -366,17 +411,17 @@ class StatsStore:
         await self._ensure_open()
         a, b = (node_a, node_b) if node_a <= node_b else (node_b, node_a)
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO coactivation
-                   (node_id_a, node_id_b, namespace, count, last_at)
-                   VALUES (?, ?, ?, 1, ?)
-                   ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
-                     count = count + 1,
-                     last_at = excluded.last_at""",
-                (a, b, namespace, now),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO coactivation
+               (node_id_a, node_id_b, namespace, count, last_at)
+               VALUES (?, ?, ?, 1, ?)
+               ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
+                 count = count + 1,
+                 last_at = excluded.last_at""",
+            (a, b, namespace, now),
+        )
+        await db.commit()
 
     async def get_coactivated(
         self,
@@ -403,41 +448,41 @@ class StatsStore:
         seed_set = set(node_ids)
         totals: dict[str, int] = {}
 
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            placeholders = ", ".join("?" for _ in node_ids)
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        placeholders = ", ".join("?" for _ in node_ids)
 
-            # Rows where a seed appears as node_id_a → other is node_id_b
-            if namespace is not None:
-                query_a = (
-                    f"SELECT node_id_b AS other, count FROM coactivation "
-                    f"WHERE node_id_a IN ({placeholders}) AND namespace = ?"
-                )
-                params_a: tuple[str, ...] = (*node_ids, namespace)
-                query_b = (
-                    f"SELECT node_id_a AS other, count FROM coactivation "
-                    f"WHERE node_id_b IN ({placeholders}) AND namespace = ?"
-                )
-                params_b: tuple[str, ...] = (*node_ids, namespace)
-            else:
-                query_a = (
-                    f"SELECT node_id_b AS other, count FROM coactivation "
-                    f"WHERE node_id_a IN ({placeholders})"
-                )
-                params_a = tuple(node_ids)
-                query_b = (
-                    f"SELECT node_id_a AS other, count FROM coactivation "
-                    f"WHERE node_id_b IN ({placeholders})"
-                )
-                params_b = tuple(node_ids)
+        # Rows where a seed appears as node_id_a → other is node_id_b
+        if namespace is not None:
+            query_a = (
+                f"SELECT node_id_b AS other, count FROM coactivation "
+                f"WHERE node_id_a IN ({placeholders}) AND namespace = ?"
+            )
+            params_a: tuple[str, ...] = (*node_ids, namespace)
+            query_b = (
+                f"SELECT node_id_a AS other, count FROM coactivation "
+                f"WHERE node_id_b IN ({placeholders}) AND namespace = ?"
+            )
+            params_b: tuple[str, ...] = (*node_ids, namespace)
+        else:
+            query_a = (
+                f"SELECT node_id_b AS other, count FROM coactivation "
+                f"WHERE node_id_a IN ({placeholders})"
+            )
+            params_a = tuple(node_ids)
+            query_b = (
+                f"SELECT node_id_a AS other, count FROM coactivation "
+                f"WHERE node_id_b IN ({placeholders})"
+            )
+            params_b = tuple(node_ids)
 
-            for query, params in [(query_a, params_a), (query_b, params_b)]:
-                cursor = await db.execute(query, params)
-                for row in await cursor.fetchall():
-                    other = row["other"]
-                    if other in seed_set:
-                        continue
-                    totals[other] = totals.get(other, 0) + row["count"]
+        for query, params in [(query_a, params_a), (query_b, params_b)]:
+            cursor = await db.execute(query, params)
+            for row in await cursor.fetchall():
+                other = row["other"]
+                if other in seed_set:
+                    continue
+                totals[other] = totals.get(other, 0) + row["count"]
 
         ranked = sorted(totals.items(), key=lambda t: t[1], reverse=True)
         return ranked[:limit]
@@ -460,12 +505,12 @@ class StatsStore:
         if (node_id is None) == (task_id is None):
             raise ValueError("Exactly one of node_id or task_id must be provided")
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                "INSERT INTO enrich_queue (trigger_type, node_id, task_id) VALUES (?, ?, ?)",
-                (trigger_type, node_id, task_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            "INSERT INTO enrich_queue (trigger_type, node_id, task_id) VALUES (?, ?, ?)",
+            (trigger_type, node_id, task_id),
+        )
+        await db.commit()
         logger.debug(
             "enrich_queue enqueued: trigger=%s node_id=%s task_id=%s",
             trigger_type,
@@ -489,10 +534,15 @@ class StatsStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            # BEGIN IMMEDIATE acquires a write lock before the SELECT,
-            # preventing concurrent callers from reading the same rows.
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        # Serialise drains on the shared connection (#172). BEGIN IMMEDIATE
+        # used to be enough — separate connections meant SQLite's write lock
+        # forced one to block until the other committed. With one shared
+        # connection the lock state lives on the underlying sqlite3 handle,
+        # so two concurrent drains would either error on a nested BEGIN or
+        # interleave at the statement level.
+        async with self._drain_mutex():
             await db.execute("BEGIN IMMEDIATE")
             if max_attempts is not None:
                 cursor = await db.execute(
@@ -565,10 +615,10 @@ class StatsStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            # BEGIN IMMEDIATE acquires a write lock before the SELECT,
-            # preventing concurrent callers from reading the same rows.
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        # See drain_pending_nodes for why this needs a Python-level lock now.
+        async with self._drain_mutex():
             await db.execute("BEGIN IMMEDIATE")
             if max_attempts is not None:
                 cursor = await db.execute(
@@ -616,14 +666,14 @@ class StatsStore:
             return 0
         await self._ensure_open()
         placeholders = ", ".join("?" for _ in claimed_ids)
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "UPDATE enrich_queue SET processed_at = NULL, attempts = attempts + 1 "
-                f"WHERE id IN ({placeholders})",
-                tuple(claimed_ids),
-            )
-            count = cursor.rowcount
-            await db.commit()
+        db = self._conn()
+        cursor = await db.execute(
+            "UPDATE enrich_queue SET processed_at = NULL, attempts = attempts + 1 "
+            f"WHERE id IN ({placeholders})",
+            tuple(claimed_ids),
+        )
+        count = cursor.rowcount
+        await db.commit()
         logger.warning(
             "enrich_queue requeue_failed: requeued=%d requested=%d",
             count,
@@ -640,14 +690,14 @@ class StatsStore:
             return []
         await self._ensure_open()
         placeholders = ", ".join("?" for _ in claimed_ids)
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                f"SELECT id, node_id, task_id, attempts FROM enrich_queue "
-                f"WHERE id IN ({placeholders}) AND attempts >= ?",
-                (*claimed_ids, max_attempts),
-            )
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            f"SELECT id, node_id, task_id, attempts FROM enrich_queue "
+            f"WHERE id IN ({placeholders}) AND attempts >= ?",
+            (*claimed_ids, max_attempts),
+        )
+        rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     async def get_enrich_items_by_ids(self, item_ids: list[int]) -> list[dict[str, object]]:
@@ -659,14 +709,14 @@ class StatsStore:
             return []
         await self._ensure_open()
         placeholders = ", ".join("?" for _ in item_ids)
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                f"SELECT id, triggered_at, processed_at, attempts FROM enrich_queue "
-                f"WHERE id IN ({placeholders})",
-                tuple(item_ids),
-            )
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            f"SELECT id, triggered_at, processed_at, attempts FROM enrich_queue "
+            f"WHERE id IN ({placeholders})",
+            tuple(item_ids),
+        )
+        rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -680,16 +730,16 @@ class StatsStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
-                   VALUES (?, 1, ?, 0.5)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     retrieval_count = retrieval_count + 1,
-                     last_retrieved_at = excluded.last_retrieved_at""",
-                (node_id, now),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
+               VALUES (?, 1, ?, 0.5)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 retrieval_count = retrieval_count + 1,
+                 last_retrieved_at = excluded.last_retrieved_at""",
+            (node_id, now),
+        )
+        await db.commit()
 
     async def increment_node_stats_batch(self, node_ids: list[str]) -> None:
         """Increment retrieval_count for multiple nodes in a single transaction."""
@@ -697,16 +747,16 @@ class StatsStore:
             return
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.executemany(
-                """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
-                   VALUES (?, 1, ?, 0.5)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     retrieval_count = retrieval_count + 1,
-                     last_retrieved_at = excluded.last_retrieved_at""",
-                [(nid, now) for nid in node_ids],
-            )
-            await db.commit()
+        db = self._conn()
+        await db.executemany(
+            """INSERT INTO node_stats (node_id, retrieval_count, last_retrieved_at, salience)
+               VALUES (?, 1, ?, 0.5)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 retrieval_count = retrieval_count + 1,
+                 last_retrieved_at = excluded.last_retrieved_at""",
+            [(nid, now) for nid in node_ids],
+        )
+        await db.commit()
         logger.debug(
             "node_stats batch increment: node_count=%d",
             len(node_ids),
@@ -725,24 +775,24 @@ class StatsStore:
         now = datetime.now(timezone.utc).isoformat()
         # Canonicalize pairs so node_id_a <= node_id_b
         canonical = [(min(a, b), max(a, b)) for a, b in pairs]
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.executemany(
-                """INSERT INTO coactivation (node_id_a, node_id_b, namespace, count, last_at)
-                   VALUES (?, ?, ?, 1, ?)
-                   ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
-                     count = count + 1,
-                     last_at = excluded.last_at""",
-                [(a, b, namespace, now) for a, b in canonical],
-            )
-            await db.commit()
+        db = self._conn()
+        await db.executemany(
+            """INSERT INTO coactivation (node_id_a, node_id_b, namespace, count, last_at)
+               VALUES (?, ?, ?, 1, ?)
+               ON CONFLICT(node_id_a, node_id_b, namespace) DO UPDATE SET
+                 count = count + 1,
+                 last_at = excluded.last_at""",
+            [(a, b, namespace, now) for a, b in canonical],
+        )
+        await db.commit()
 
     async def get_node_stats(self, node_id: str) -> dict[str, object] | None:
         """Return all node_stats columns for *node_id*, or ``None`` if absent."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute("SELECT * FROM node_stats WHERE node_id = ?", (node_id,))
-            row = await cursor.fetchone()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT * FROM node_stats WHERE node_id = ?", (node_id,))
+        row = await cursor.fetchone()
         if row is None:
             return None
         return dict(row)
@@ -757,21 +807,21 @@ class StatsStore:
             return {}
         await self._ensure_open()
         placeholders = ",".join("?" for _ in node_ids)
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                f"SELECT * FROM node_stats WHERE node_id IN ({placeholders})",
-                node_ids,
-            )
-            rows = await cursor.fetchall()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            f"SELECT * FROM node_stats WHERE node_id IN ({placeholders})",
+            node_ids,
+        )
+        rows = await cursor.fetchall()
         return {row["node_id"]: dict(row) for row in rows}
 
     async def list_all_node_ids(self) -> list[str]:
         """Return all node_id values from node_stats."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute("SELECT node_id FROM node_stats")
-            rows = await cursor.fetchall()
+        db = self._conn()
+        cursor = await db.execute("SELECT node_id FROM node_stats")
+        rows = await cursor.fetchall()
         return [row[0] for row in rows]
 
     # ------------------------------------------------------------------
@@ -802,22 +852,22 @@ class StatsStore:
         """
         await self._ensure_open()
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            row = await (
-                await db.execute("SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL")
-            ).fetchone()
-            self._cached_enrich_queue_depth = int(row[0]) if row else 0
+        db = self._conn()
+        row = await (
+            await db.execute("SELECT COUNT(*) FROM enrich_queue WHERE processed_at IS NULL")
+        ).fetchone()
+        self._cached_enrich_queue_depth = int(row[0]) if row else 0
 
-            row = await (await db.execute("SELECT COUNT(*) FROM coactivation")).fetchone()
-            self._cached_coactivation_pairs = int(row[0]) if row else 0
+        row = await (await db.execute("SELECT COUNT(*) FROM coactivation")).fetchone()
+        self._cached_coactivation_pairs = int(row[0]) if row else 0
 
-            row = await (
-                await db.execute(
-                    "SELECT COUNT(DISTINCT task_id) FROM working_memory WHERE last_seen_at >= ?",
-                    (cutoff,),
-                )
-            ).fetchone()
-            self._cached_working_memory_active_tasks = int(row[0]) if row else 0
+        row = await (
+            await db.execute(
+                "SELECT COUNT(DISTINCT task_id) FROM working_memory WHERE last_seen_at >= ?",
+                (cutoff,),
+            )
+        ).fetchone()
+        self._cached_working_memory_active_tasks = int(row[0]) if row else 0
 
     async def update_salience(self, node_id: str, delta: float) -> None:
         """Atomically adjust salience by *delta*, clamping to [0.0, 1.0].
@@ -826,15 +876,15 @@ class StatsStore:
         """
         await self._ensure_open()
         initial = max(0.0, min(1.0, 0.5 + delta))
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, salience)
-                   VALUES (?, ?)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     salience = MAX(0.0, MIN(1.0, salience + ?))""",
-                (node_id, initial, delta),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, salience)
+               VALUES (?, ?)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 salience = MAX(0.0, MIN(1.0, salience + ?))""",
+            (node_id, initial, delta),
+        )
+        await db.commit()
         if _HAS_TELEMETRY and _lithos_metrics is not None:
             _lithos_metrics.lcma_salience_updates.add(1)
         logger.debug(
@@ -847,41 +897,41 @@ class StatsStore:
     async def increment_ignored(self, node_id: str) -> None:
         """Atomically increment ignored_count; creates row if absent."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, ignored_count)
-                   VALUES (?, 1)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     ignored_count = ignored_count + 1""",
-                (node_id,),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, ignored_count)
+               VALUES (?, 1)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 ignored_count = ignored_count + 1""",
+            (node_id,),
+        )
+        await db.commit()
 
     async def increment_cited(self, node_id: str) -> None:
         """Atomically increment cited_count; creates row if absent."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, cited_count)
-                   VALUES (?, 1)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     cited_count = cited_count + 1""",
-                (node_id,),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, cited_count)
+               VALUES (?, 1)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 cited_count = cited_count + 1""",
+            (node_id,),
+        )
+        await db.commit()
 
     async def increment_misleading(self, node_id: str) -> None:
         """Atomically increment misleading_count; creates row if absent."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, misleading_count)
-                   VALUES (?, 1)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     misleading_count = misleading_count + 1""",
-                (node_id,),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, misleading_count)
+               VALUES (?, 1)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 misleading_count = misleading_count + 1""",
+            (node_id,),
+        )
+        await db.commit()
 
     async def update_spaced_rep_strength(self, node_id: str, delta: float) -> None:
         """Atomically adjust spaced_rep_strength by *delta*, clamping to [0.0, 1.0].
@@ -891,26 +941,26 @@ class StatsStore:
         """
         await self._ensure_open()
         initial = max(0.0, min(1.0, delta))
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, spaced_rep_strength)
-                   VALUES (?, ?)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     spaced_rep_strength = MAX(0.0, MIN(1.0, spaced_rep_strength + ?))""",
-                (node_id, initial, delta),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, spaced_rep_strength)
+               VALUES (?, ?)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 spaced_rep_strength = MAX(0.0, MIN(1.0, spaced_rep_strength + ?))""",
+            (node_id, initial, delta),
+        )
+        await db.commit()
 
     async def update_last_decay_applied_at(self, node_id: str) -> None:
         """Set ``last_decay_applied_at`` to now for *node_id*."""
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                "UPDATE node_stats SET last_decay_applied_at = ? WHERE node_id = ?",
-                (now, node_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            "UPDATE node_stats SET last_decay_applied_at = ? WHERE node_id = ?",
+            (now, node_id),
+        )
+        await db.commit()
 
     async def update_last_used_at(self, node_id: str) -> None:
         """Set ``last_used_at`` to now for *node_id*.
@@ -919,15 +969,15 @@ class StatsStore:
         """
         await self._ensure_open()
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, last_used_at)
-                   VALUES (?, ?)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     last_used_at = excluded.last_used_at""",
-                (node_id, now),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, last_used_at)
+               VALUES (?, ?)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 last_used_at = excluded.last_used_at""",
+            (node_id, now),
+        )
+        await db.commit()
 
     # ------------------------------------------------------------------
     # Consolidation tracking operations
@@ -936,64 +986,63 @@ class StatsStore:
     async def is_task_consolidated(self, task_id: str) -> bool:
         """Return ``True`` if *task_id* exists in ``task_consolidation_log``."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "SELECT 1 FROM task_consolidation_log WHERE task_id = ?",
-                (task_id,),
-            )
-            return await cursor.fetchone() is not None
+        db = self._conn()
+        cursor = await db.execute(
+            "SELECT 1 FROM task_consolidation_log WHERE task_id = ?",
+            (task_id,),
+        )
+        return await cursor.fetchone() is not None
 
     async def mark_task_consolidated(self, task_id: str) -> None:
         """Insert *task_id* into ``task_consolidation_log`` (INSERT OR IGNORE)."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                "INSERT OR IGNORE INTO task_consolidation_log (task_id) VALUES (?)",
-                (task_id,),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            "INSERT OR IGNORE INTO task_consolidation_log (task_id) VALUES (?)",
+            (task_id,),
+        )
+        await db.commit()
 
     async def has_consolidation_edge_op(self, task_id: str, from_id: str, to_id: str) -> bool:
         """Return ``True`` if the edge op has already been recorded."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "SELECT 1 FROM consolidation_edge_ops "
-                "WHERE task_id = ? AND from_id = ? AND to_id = ?",
-                (task_id, from_id, to_id),
-            )
-            return await cursor.fetchone() is not None
+        db = self._conn()
+        cursor = await db.execute(
+            "SELECT 1 FROM consolidation_edge_ops WHERE task_id = ? AND from_id = ? AND to_id = ?",
+            (task_id, from_id, to_id),
+        )
+        return await cursor.fetchone() is not None
 
     async def record_consolidation_edge_op(self, task_id: str, from_id: str, to_id: str) -> None:
         """Record an edge consolidation op (INSERT OR IGNORE)."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                "INSERT OR IGNORE INTO consolidation_edge_ops (task_id, from_id, to_id) "
-                "VALUES (?, ?, ?)",
-                (task_id, from_id, to_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            "INSERT OR IGNORE INTO consolidation_edge_ops (task_id, from_id, to_id) "
+            "VALUES (?, ?, ?)",
+            (task_id, from_id, to_id),
+        )
+        await db.commit()
 
     async def has_consolidation_salience_op(self, task_id: str, node_id: str) -> bool:
         """Return ``True`` if the salience op has already been recorded."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "SELECT 1 FROM consolidation_salience_ops WHERE task_id = ? AND node_id = ?",
-                (task_id, node_id),
-            )
-            return await cursor.fetchone() is not None
+        db = self._conn()
+        cursor = await db.execute(
+            "SELECT 1 FROM consolidation_salience_ops WHERE task_id = ? AND node_id = ?",
+            (task_id, node_id),
+        )
+        return await cursor.fetchone() is not None
 
     async def record_consolidation_salience_op(self, task_id: str, node_id: str) -> None:
         """Record a salience consolidation op (INSERT OR IGNORE)."""
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
-                (task_id, node_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
+            (task_id, node_id),
+        )
+        await db.commit()
 
     async def update_salience_and_record_consolidation(
         self, *, node_id: str, delta: float, task_id: str
@@ -1005,19 +1054,19 @@ class StatsStore:
         """
         await self._ensure_open()
         initial = max(0.0, min(1.0, 0.5 + delta))
-        async with aiosqlite.connect(self.db_path) as db:
-            await db.execute(
-                """INSERT INTO node_stats (node_id, salience)
-                   VALUES (?, ?)
-                   ON CONFLICT(node_id) DO UPDATE SET
-                     salience = MAX(0.0, MIN(1.0, salience + ?))""",
-                (node_id, initial, delta),
-            )
-            await db.execute(
-                "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
-                (task_id, node_id),
-            )
-            await db.commit()
+        db = self._conn()
+        await db.execute(
+            """INSERT INTO node_stats (node_id, salience)
+               VALUES (?, ?)
+               ON CONFLICT(node_id) DO UPDATE SET
+                 salience = MAX(0.0, MIN(1.0, salience + ?))""",
+            (node_id, initial, delta),
+        )
+        await db.execute(
+            "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
+            (task_id, node_id),
+        )
+        await db.commit()
 
     # ------------------------------------------------------------------
     # Receipt lookup operations
@@ -1031,10 +1080,10 @@ class StatsStore:
         the task_id does not match.
         """
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute("SELECT * FROM receipts WHERE id = ?", (receipt_id,))
-            row = await cursor.fetchone()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT * FROM receipts WHERE id = ?", (receipt_id,))
+        row = await cursor.fetchone()
         if row is None:
             return None
         result = dict(row)
@@ -1051,14 +1100,13 @@ class StatsStore:
         ``None`` if no receipt matches.
         """
         await self._ensure_open()
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                "SELECT * FROM receipts WHERE task_id = ? AND agent_id = ? "
-                "ORDER BY rowid DESC LIMIT 1",
-                (task_id, agent_id),
-            )
-            row = await cursor.fetchone()
+        db = self._conn()
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM receipts WHERE task_id = ? AND agent_id = ? ORDER BY rowid DESC LIMIT 1",
+            (task_id, agent_id),
+        )
+        row = await cursor.fetchone()
         if row is None:
             return None
         result = dict(row)

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -236,18 +236,41 @@ class StatsStore:
         self._opened = False
 
     async def _ensure_open(self) -> None:
-        """Lazily (re-)open the database on first use or after close().
+        """Lazily (re-)open the database on first use, after close, or after a dead worker.
 
-        Recovery path: if :meth:`close` ran but the store is reused, this
-        re-runs :meth:`open` so callers do not need to track lifecycle
-        externally. Per-call connection callers used to get this for free
-        because every method opened its own connection (#172).
+        Three recovery cases are handled here:
+
+        1. Never opened — call :meth:`open`.
+        2. :meth:`close` ran but the store was reused — re-open transparently.
+        3. The aiosqlite worker thread is no longer running (the connection
+           was closed externally, the loop was torn down underneath us, etc.)
+           — drop the stale handle and re-open. Callers no longer need to
+           reason about connection lifecycle.
+
+        For self-healing on a *live* but error-throwing handle, see
+        :meth:`reconnect` — that is the explicit recovery primitive.
         """
-        if self._opened and self._db is not None:
+        if self._opened and self._db is not None and getattr(self._db, "_running", True):
             return
-        # Either never opened, or close() reset the flag — either way,
-        # re-open clears any stale state and reconnects.
+        if self._db is not None and not getattr(self._db, "_running", True):
+            logger.warning(
+                "StatsStore connection worker is no longer running; reopening %s",
+                self.db_path,
+            )
+            # Drop the dead handle so open() reconstructs from scratch.
+            self._db = None
         self._opened = False
+        await self.open()
+
+    async def reconnect(self) -> None:
+        """Force a close + re-open of the underlying connection.
+
+        Recovery primitive for callers that have detected the live handle is
+        misbehaving (operational errors, lock-stuck transactions, etc.) and
+        want to start fresh without waiting for the next garbage collection.
+        Idempotent.
+        """
+        await self.close()
         await self.open()
 
     def _conn(self) -> aiosqlite.Connection:
@@ -1099,23 +1122,34 @@ class StatsStore:
         """Atomically update salience and record the consolidation salience op.
 
         Both writes happen in a single stats.db transaction so that a crash
-        between them cannot cause double-boosting on retry.
+        between them cannot cause double-boosting on retry. With autocommit
+        mode (#172) the atomicity is enforced by an explicit BEGIN/COMMIT
+        bracket under :meth:`_write_mutex` — without it, the salience update
+        would commit before the consolidation marker is recorded and a
+        retry would re-apply the delta.
         """
         await self._ensure_open()
         initial = max(0.0, min(1.0, 0.5 + delta))
         db = self._conn()
-        await db.execute(
-            """INSERT INTO node_stats (node_id, salience)
-               VALUES (?, ?)
-               ON CONFLICT(node_id) DO UPDATE SET
-                 salience = MAX(0.0, MIN(1.0, salience + ?))""",
-            (node_id, initial, delta),
-        )
-        await db.execute(
-            "INSERT OR IGNORE INTO consolidation_salience_ops (task_id, node_id) VALUES (?, ?)",
-            (task_id, node_id),
-        )
-        await db.commit()
+        async with self._write_mutex():
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    """INSERT INTO node_stats (node_id, salience)
+                       VALUES (?, ?)
+                       ON CONFLICT(node_id) DO UPDATE SET
+                         salience = MAX(0.0, MIN(1.0, salience + ?))""",
+                    (node_id, initial, delta),
+                )
+                await db.execute(
+                    "INSERT OR IGNORE INTO consolidation_salience_ops "
+                    "(task_id, node_id) VALUES (?, ?)",
+                    (task_id, node_id),
+                )
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
 
     # ------------------------------------------------------------------
     # Receipt lookup operations

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -406,6 +406,12 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
             failed=1,
             failures=[{"code": "internal_error", "detail": str(exc)}],
         )
+    finally:
+        # Close the persistent connection so the aiosqlite worker thread
+        # exits cleanly. Otherwise it survives function return, eventually
+        # touches a torn-down event loop, and emits "Event loop is closed"
+        # warnings (and on CI, hangs the whole job until timeout) (#172).
+        await edge_store.close()
 
     created = int(counts.get("created", 0))
     removed = int(counts.get("removed", 0))

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -888,6 +888,21 @@ class LithosServer:
         if self.edge_store is not None:
             await self.edge_store.close()
 
+    async def shutdown(self) -> None:
+        """Stop every background worker and close every persistent handle.
+
+        Idempotent. Aggregates :meth:`stop_coordination_stats_refresh`,
+        :meth:`stop_enrich_worker`, and :meth:`stop_file_watcher` so callers
+        — especially test fixtures — do not need to track which subsystems
+        own which handles. Forgetting any one of these used to leave
+        aiosqlite worker threads alive past test event-loop teardown,
+        which surfaced as ``RuntimeError: Event loop is closed``
+        warnings and (on CI) job-hanging orphan processes.
+        """
+        await self.stop_coordination_stats_refresh()
+        await self.stop_enrich_worker()
+        self.stop_file_watcher()
+
     async def handle_file_change(self, path: Path, deleted: bool = False) -> None:
         """Handle a file change event."""
         if path.suffix != ".md":

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -876,9 +876,17 @@ class LithosServer:
             self.graph.save_cache()
 
     async def stop_enrich_worker(self) -> None:
-        """Stop the enrichment background worker."""
+        """Stop the enrichment background worker and close LCMA stores.
+
+        StatsStore and EdgeStore now hold persistent connections (#172); they
+        must be closed to release the SQLite WAL handles cleanly.
+        """
         if self._enrich_worker is not None:
             await self._enrich_worker.stop()
+        if self.stats_store is not None:
+            await self.stats_store.close()
+        if self.edge_store is not None:
+            await self.edge_store.close()
 
     async def handle_file_change(self, path: Path, deleted: bool = False) -> None:
         """Handle a file change event."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """Pytest configuration and fixtures."""
 
 import logging
+import os
 import shutil
+import sys
 import tempfile
+import threading
 from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
 
@@ -25,6 +28,51 @@ _LITHOS_ENV_VARS = (
     "LITHOS_OTEL_ENABLED",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
 )
+
+
+def _aiosqlite_worker_threads() -> list[threading.Thread]:
+    """Return all currently-alive aiosqlite worker threads.
+
+    aiosqlite's Connection class subclasses threading.Thread; its instances
+    are named after the class (``Connection``) when not given an explicit
+    name, so we filter by target-class name.
+    """
+    workers: list[threading.Thread] = []
+    for t in threading.enumerate():
+        if not t.is_alive():
+            continue
+        # aiosqlite.core.Connection sets name to class name by default
+        cls_name = type(t).__name__
+        if cls_name == "Connection" and type(t).__module__.startswith("aiosqlite"):
+            workers.append(t)
+    return workers
+
+
+@pytest.fixture(autouse=True)
+def _detect_aiosqlite_thread_leaks(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Fail tests that leak aiosqlite worker threads.
+
+    Aiosqlite spawns a non-daemon worker thread per Connection, joined only
+    via ``await db.close()``. A leaked connection keeps the thread alive
+    past test teardown, eventually blocking process exit on CI (#172).
+
+    Only active when LITHOS_DETECT_THREAD_LEAKS=1 to keep normal runs fast.
+    """
+    if os.environ.get("LITHOS_DETECT_THREAD_LEAKS") != "1":
+        yield
+        return
+
+    before = {t.ident for t in _aiosqlite_worker_threads()}
+    yield
+    after = _aiosqlite_worker_threads()
+    leaked = [t for t in after if t.ident not in before]
+    if leaked:
+        names = ", ".join(t.name for t in leaked)
+        print(
+            f"\n[THREAD LEAK] {request.node.nodeid} leaked {len(leaked)} aiosqlite "
+            f"worker thread(s): {names}",
+            file=sys.stderr,
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,9 +112,7 @@ async def server(test_config: LithosConfig) -> AsyncGenerator[LithosServer, None
     srv = LithosServer(test_config)
     await srv.initialize()
     yield srv
-    await srv.stop_coordination_stats_refresh()
-    await srv.stop_enrich_worker()
-    srv.stop_file_watcher()
+    await srv.shutdown()
 
 
 # Sample test data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 """Pytest configuration and fixtures."""
 
+import gc
 import logging
 import os
 import shutil
-import sys
 import tempfile
 import threading
 from collections.abc import AsyncGenerator, Generator
@@ -67,11 +67,16 @@ def _detect_aiosqlite_thread_leaks(request: pytest.FixtureRequest) -> Generator[
     after = _aiosqlite_worker_threads()
     leaked = [t for t in after if t.ident not in before]
     if leaked:
+        # Some leaked Connection objects become collectible only after the test
+        # frame unwinds; give them one GC cycle before declaring a leak.
+        gc.collect()
+        after_gc = _aiosqlite_worker_threads()
+        leaked = [t for t in after_gc if t.ident not in before]
+    if leaked:
         names = ", ".join(t.name for t in leaked)
-        print(
-            f"\n[THREAD LEAK] {request.node.nodeid} leaked {len(leaked)} aiosqlite "
-            f"worker thread(s): {names}",
-            file=sys.stderr,
+        pytest.fail(
+            f"{request.node.nodeid} leaked {len(leaked)} aiosqlite worker thread(s): {names}",
+            pytrace=False,
         )
 
 

--- a/tests/test_coactivation.py
+++ b/tests/test_coactivation.py
@@ -129,17 +129,23 @@ async def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
 
 
 @pytest.fixture
-async def edge_store(seeded_config: LithosConfig) -> EdgeStore:
+async def edge_store(seeded_config: LithosConfig):
     store = EdgeStore(seeded_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest.fixture
-async def stats_store(seeded_config: LithosConfig) -> StatsStore:
+async def stats_store(seeded_config: LithosConfig):
     store = StatsStore(seeded_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest.fixture

--- a/tests/test_conflict_resolve.py
+++ b/tests/test_conflict_resolve.py
@@ -80,7 +80,11 @@ async def server_with_notes(test_config: LithosConfig) -> LithosServer:
     srv._related_edge_id = non_c["edge_id"]  # type: ignore[attr-defined]
 
     yield srv  # type: ignore[misc]
-    srv.stop_file_watcher()
+    # Aggregate teardown closes the persistent LCMA SQLite connections so
+    # the aiosqlite worker threads exit before the test event loop tears
+    # down (#172) — otherwise the workers emit "Event loop is closed"
+    # warnings and hang CI on orphan processes.
+    await srv.shutdown()
 
 
 class TestConflictResolveValidResolutions:

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -410,3 +410,67 @@ class TestAdjustWeightConcurrency:
         # Final weight should reflect all 10 deltas
         edges = await edge_store.list_edges(from_id="a")
         assert edges[0]["weight"] == pytest.approx(0.6, abs=1e-9)
+
+
+class TestPersistentConnectionHardening:
+    """Shared-connection isolation and recovery regressions for #172."""
+
+    async def test_reads_wait_for_inflight_transaction(self, edge_store: EdgeStore) -> None:
+        edge_id = await edge_store.upsert(
+            from_id="a",
+            to_id="b",
+            edge_type="rel",
+            weight=0.5,
+            namespace="ns",
+        )
+        db = edge_store._conn()
+        original_execute = db.execute
+        txn_statement_applied = asyncio.Event()
+        release_transaction = asyncio.Event()
+        paused = False
+
+        async def execute(sql: str, params=()) -> object:
+            nonlocal paused
+            result = await original_execute(sql, params)
+            if not paused and "UPDATE edges SET weight = MAX" in sql:
+                paused = True
+                txn_statement_applied.set()
+                await release_transaction.wait()
+            return result
+
+        db.execute = execute  # type: ignore[method-assign]
+
+        writer = asyncio.create_task(edge_store.adjust_weight(edge_id, 0.2))
+        await asyncio.wait_for(txn_statement_applied.wait(), timeout=1)
+
+        reader = asyncio.create_task(edge_store.get_edge(edge_id))
+        done, pending = await asyncio.wait({reader}, timeout=0.05)
+        assert not done
+        assert pending == {reader}
+
+        release_transaction.set()
+        assert await writer == pytest.approx(0.7)
+
+        edge = await asyncio.wait_for(reader, timeout=1)
+        assert edge is not None
+        assert edge["weight"] == pytest.approx(0.7)
+
+    async def test_reopens_after_connection_liveness_error(self, edge_store: EdgeStore) -> None:
+        db = edge_store._conn()
+        original_execute = db.execute
+        fail_once = True
+
+        async def execute(sql: str, params=()) -> object:
+            nonlocal fail_once
+            if fail_once:
+                fail_once = False
+                raise ValueError("no active connection")
+            return await original_execute(sql, params)
+
+        db.execute = execute  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="no active connection"):
+            await edge_store.count()
+
+        assert edge_store._db is not db
+        assert await edge_store.count() == 0

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -11,11 +11,14 @@ from lithos.lcma.edges import EdgeStore
 
 
 @pytest_asyncio.fixture
-async def edge_store(test_config: LithosConfig) -> EdgeStore:
-    """Create and open an EdgeStore for testing."""
+async def edge_store(test_config: LithosConfig):
+    """Create, open, and close an EdgeStore around the test."""
     store = EdgeStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 class TestEdgeStoreCreation:
@@ -25,7 +28,10 @@ class TestEdgeStoreCreation:
         store = EdgeStore(test_config)
         assert not store.db_path.exists()
         await store.open()
-        assert store.db_path.exists()
+        try:
+            assert store.db_path.exists()
+        finally:
+            await store.close()
 
     async def test_schema_has_edges_table(self, edge_store: EdgeStore) -> None:
         conn = sqlite3.connect(str(edge_store.db_path))
@@ -90,20 +96,26 @@ class TestIdempotentReopen:
     async def test_reopen_preserves_rows(self, test_config: LithosConfig) -> None:
         store = EdgeStore(test_config)
         await store.open()
-        edge_id = await store.upsert(
-            from_id="n1",
-            to_id="n2",
-            edge_type="derived_from",
-            weight=1.0,
-            namespace="default",
-        )
+        try:
+            edge_id = await store.upsert(
+                from_id="n1",
+                to_id="n2",
+                edge_type="derived_from",
+                weight=1.0,
+                namespace="default",
+            )
+        finally:
+            await store.close()
 
         # Re-open
         store2 = EdgeStore(test_config)
         await store2.open()
-        edges = await store2.list_edges(from_id="n1")
-        assert len(edges) == 1
-        assert edges[0]["edge_id"] == edge_id
+        try:
+            edges = await store2.list_edges(from_id="n1")
+            assert len(edges) == 1
+            assert edges[0]["edge_id"] == edge_id
+        finally:
+            await store2.close()
 
 
 class TestNoopWhenExists:
@@ -112,15 +124,17 @@ class TestNoopWhenExists:
     async def test_open_does_not_drop_data(self, test_config: LithosConfig) -> None:
         store = EdgeStore(test_config)
         await store.open()
+        try:
+            # Insert multiple edges
+            await store.upsert(from_id="a", to_id="b", edge_type="t1", weight=1.0, namespace="ns")
+            await store.upsert(from_id="c", to_id="d", edge_type="t2", weight=0.5, namespace="ns")
+            assert await store.count() == 2
 
-        # Insert multiple edges
-        await store.upsert(from_id="a", to_id="b", edge_type="t1", weight=1.0, namespace="ns")
-        await store.upsert(from_id="c", to_id="d", edge_type="t2", weight=0.5, namespace="ns")
-        assert await store.count() == 2
-
-        # Re-open and verify
-        await store.open()
-        assert await store.count() == 2
+            # Re-open (idempotent — short-circuits because already opened)
+            await store.open()
+            assert await store.count() == 2
+        finally:
+            await store.close()
 
 
 class TestCorruptRecovery:
@@ -133,11 +147,14 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(b"not a sqlite database at all")
 
         await store.open()
-        # DB should now be healthy
-        assert store.db_path.exists()
-        # Quarantine file should exist
-        quarantined = list(store.db_path.parent.glob("edges.db.corrupt-*"))
-        assert len(quarantined) == 1
+        try:
+            # DB should now be healthy
+            assert store.db_path.exists()
+            # Quarantine file should exist
+            quarantined = list(store.db_path.parent.glob("edges.db.corrupt-*"))
+            assert len(quarantined) == 1
+        finally:
+            await store.close()
 
     async def test_quarantined_db_contains_original_bytes(self, test_config: LithosConfig) -> None:
         store = EdgeStore(test_config)
@@ -146,8 +163,11 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(garbage)
 
         await store.open()
-        quarantined = list(store.db_path.parent.glob("edges.db.corrupt-*"))
-        assert quarantined[0].read_bytes() == garbage
+        try:
+            quarantined = list(store.db_path.parent.glob("edges.db.corrupt-*"))
+            assert quarantined[0].read_bytes() == garbage
+        finally:
+            await store.close()
 
     async def test_recreated_db_has_schema(self, test_config: LithosConfig) -> None:
         store = EdgeStore(test_config)
@@ -155,15 +175,18 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(b"garbage")
 
         await store.open()
-        # Should be able to upsert into the fresh DB
-        edge_id = await store.upsert(
-            from_id="x",
-            to_id="y",
-            edge_type="test",
-            weight=1.0,
-            namespace="default",
-        )
-        assert edge_id.startswith("edge_")
+        try:
+            # Should be able to upsert into the fresh DB
+            edge_id = await store.upsert(
+                from_id="x",
+                to_id="y",
+                edge_type="test",
+                weight=1.0,
+                namespace="default",
+            )
+            assert edge_id.startswith("edge_")
+        finally:
+            await store.close()
 
 
 class TestStoreLocation:

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -27,17 +27,23 @@ from lithos.lcma.stats import StatsStore
 
 
 @pytest_asyncio.fixture
-async def stats_store(test_config: LithosConfig) -> StatsStore:
+async def stats_store(test_config: LithosConfig):
     store = StatsStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest_asyncio.fixture
-async def edge_store(test_config: LithosConfig) -> EdgeStore:
+async def edge_store(test_config: LithosConfig):
     store = EdgeStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest.fixture

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -1357,15 +1357,17 @@ class TestAttemptsColumnMigration:
         store = StatsStore(test_config)
         store._opened = False  # force re-open
         await store.open()
-
-        # Now drain and requeue should work without errors
-        await store.enqueue(trigger_type="note.created", node_id="test-node")
-        entries = await store.drain_pending_nodes(max_attempts=3)
-        assert len(entries) == 1
-        claimed_ids = entries[0]["claimed_ids"]
-        assert isinstance(claimed_ids, list)
-        count = await store.requeue_failed(claimed_ids)
-        assert count == len(claimed_ids)
+        try:
+            # Now drain and requeue should work without errors
+            await store.enqueue(trigger_type="note.created", node_id="test-node")
+            entries = await store.drain_pending_nodes(max_attempts=3)
+            assert len(entries) == 1
+            claimed_ids = entries[0]["claimed_ids"]
+            assert isinstance(claimed_ids, list)
+            count = await store.requeue_failed(claimed_ids)
+            assert count == len(claimed_ids)
+        finally:
+            await store.close()
 
 
 class TestRetryCapWarning:

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -226,7 +226,7 @@ async def sse_server(temp_dir: Path) -> AsyncGenerator[LithosServer, None]:
     server = LithosServer(config)
     await server.initialize()
     yield server
-    server.stop_file_watcher()
+    await server.shutdown()
 
 
 class TestSSEReceivesEvents:
@@ -464,7 +464,7 @@ class TestMaxClients:
 
             assert response.status_code == 429
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_below_limit_returns_streaming_response(self, temp_dir: Path) -> None:
@@ -481,7 +481,7 @@ class TestMaxClients:
             assert isinstance(response, StreamingResponse)
             assert response.media_type == "text/event-stream"
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
 
 class TestSSEDisabled:
@@ -497,7 +497,7 @@ class TestSSEDisabled:
 
             assert response.status_code == 503
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_sse_enabled_returns_stream(self, temp_dir: Path) -> None:
@@ -512,7 +512,7 @@ class TestSSEDisabled:
             assert response.status_code != 503
             assert isinstance(response, StreamingResponse)
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
 
 class TestSSEClientCount:
@@ -532,7 +532,7 @@ class TestSSEClientCount:
             # After streaming completes the count should return to 0
             assert server._sse_client_count == 0
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
 
 class TestSSEConfig:
@@ -580,7 +580,7 @@ class TestSSERouteIntegration:
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(_check(), timeout=2.0)
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_401_without_token_when_auth_configured(self, temp_dir: Path) -> None:
@@ -599,7 +599,7 @@ class TestSSERouteIntegration:
                 resp = await client.get("/events")
                 assert resp.status_code == 401
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_200_with_valid_token_when_auth_configured(self, temp_dir: Path) -> None:
@@ -630,7 +630,7 @@ class TestSSERouteIntegration:
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(_check(), timeout=2.0)
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_open_when_no_auth(self, temp_dir: Path) -> None:
@@ -655,4 +655,4 @@ class TestSSERouteIntegration:
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(_check(), timeout=2.0)
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -319,7 +319,7 @@ class TestRestartPersistence:
                 "ttl_minutes": 30,
             },
         )
-        first.stop_file_watcher()
+        await first.shutdown()
 
         second = LithosServer(test_config)
         await second.initialize()
@@ -333,7 +333,7 @@ class TestRestartPersistence:
         assert len(status_payload["tasks"]) == 1
         assert status_payload["tasks"][0]["id"] == task_id
         assert any(c["aspect"] == "verification" for c in status_payload["tasks"][0]["claims"])
-        second.stop_file_watcher()
+        await second.shutdown()
 
     @pytest.mark.asyncio
     async def test_rebuild_skips_malformed_files(self, test_config: LithosConfig):
@@ -353,7 +353,7 @@ class TestRestartPersistence:
                 },
             )
             ids.append(payload["id"])
-        first.stop_file_watcher()
+        await first.shutdown()
 
         # Inject malformed markdown files into the knowledge directory.
         # broken-yaml.md has invalid YAML and will be skipped by _rebuild_indices.
@@ -387,7 +387,7 @@ class TestRestartPersistence:
         for doc_id in ids:
             assert second.graph.has_node(doc_id)
 
-        second.stop_file_watcher()
+        await second.shutdown()
 
 
 class TestFileWatcherRace:

--- a/tests/test_integration_mcp_sse.py
+++ b/tests/test_integration_mcp_sse.py
@@ -60,7 +60,7 @@ async def _local_sse_endpoint(temp_dir: Path):
     finally:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
-        server.stop_file_watcher()
+        await server.shutdown()
 
 
 @asynccontextmanager

--- a/tests/test_node_stats_tool.py
+++ b/tests/test_node_stats_tool.py
@@ -16,7 +16,7 @@ async def srv(test_config: LithosConfig) -> LithosServer:
     server = LithosServer(test_config)
     await server.initialize()
     yield server  # type: ignore[misc]
-    server.stop_file_watcher()
+    await server.shutdown()
 
 
 async def _call(server: LithosServer, tool_name: str, **kwargs: Any) -> dict[str, Any]:

--- a/tests/test_provenance_projection.py
+++ b/tests/test_provenance_projection.py
@@ -96,10 +96,13 @@ def seeded_km(seeded_config: LithosConfig) -> KnowledgeManager:
 
 
 @pytest.fixture
-async def edge_store(seeded_config: LithosConfig) -> EdgeStore:
+async def edge_store(seeded_config: LithosConfig):
     store = EdgeStore(seeded_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provenance_projection.py
+++ b/tests/test_provenance_projection.py
@@ -346,19 +346,22 @@ class TestReconcileWireUp:
         # considers provenance_projection supported.
         store = EdgeStore(seeded_config)
         await store.open()
-        # Reference seeded_km so the fixture runs and writes notes to disk.
-        _ = seeded_km
+        try:
+            # Reference seeded_km so the fixture runs and writes notes to disk.
+            _ = seeded_km
 
-        result = await reconcile(scope="provenance_projection", config=seeded_config)
+            result = await reconcile(scope="provenance_projection", config=seeded_config)
 
-        assert result["supported"] is True
-        assert result["status"] == "ok"
-        assert result["summary"]["repaired"] >= 1
-        # Action payload carries the (created, removed) counts.
-        assert any("created" in a for a in result["actions"])
+            assert result["supported"] is True
+            assert result["status"] == "ok"
+            assert result["summary"]["repaired"] >= 1
+            # Action payload carries the (created, removed) counts.
+            assert any("created" in a for a in result["actions"])
 
-        edges = await store.list_edges(edge_type="derived_from")
-        assert len(edges) >= 1
+            edges = await store.list_edges(edge_type="derived_from")
+            assert len(edges) >= 1
+        finally:
+            await store.close()
 
     @pytest.mark.asyncio
     async def test_reconcile_dry_run_reports_plan_without_mutating(
@@ -371,19 +374,24 @@ class TestReconcileWireUp:
 
         store = EdgeStore(seeded_config)
         await store.open()
-        _ = seeded_km  # seed Alpha/Beta/Gamma; Gamma derives from Alpha
+        try:
+            _ = seeded_km  # seed Alpha/Beta/Gamma; Gamma derives from Alpha
 
-        result = await reconcile(scope="provenance_projection", dry_run=True, config=seeded_config)
-        assert result["supported"] is True
-        # Dry-run reports the planned non-zero delta — status is "ok"
-        # because there is real work the run would have done.
-        assert result["status"] == "ok"
-        assert result["summary"]["repaired"] == 1
-        assert result["actions"] == [{"created": 1, "removed": 0}]
+            result = await reconcile(
+                scope="provenance_projection", dry_run=True, config=seeded_config
+            )
+            assert result["supported"] is True
+            # Dry-run reports the planned non-zero delta — status is "ok"
+            # because there is real work the run would have done.
+            assert result["status"] == "ok"
+            assert result["summary"]["repaired"] == 1
+            assert result["actions"] == [{"created": 1, "removed": 0}]
 
-        # No edges were actually written.
-        edges = await store.list_edges(edge_type="derived_from")
-        assert len(edges) == 0
+            # No edges were actually written.
+            edges = await store.list_edges(edge_type="derived_from")
+            assert len(edges) == 0
+        finally:
+            await store.close()
 
     @pytest.mark.asyncio
     async def test_reconcile_dry_run_noop_when_already_in_sync(
@@ -396,18 +404,23 @@ class TestReconcileWireUp:
 
         store = EdgeStore(seeded_config)
         await store.open()
-        _ = seeded_km
+        try:
+            _ = seeded_km
 
-        # Apply the projection so the store is in sync.
-        await reconcile(scope="provenance_projection", config=seeded_config)
-        edges_after_real = await store.list_edges(edge_type="derived_from")
-        assert len(edges_after_real) == 1
+            # Apply the projection so the store is in sync.
+            await reconcile(scope="provenance_projection", config=seeded_config)
+            edges_after_real = await store.list_edges(edge_type="derived_from")
+            assert len(edges_after_real) == 1
 
-        # Dry-run now plans nothing.
-        result = await reconcile(scope="provenance_projection", dry_run=True, config=seeded_config)
-        assert result["status"] == "noop"
-        assert result["summary"]["repaired"] == 0
-        assert result["actions"] == [{"created": 0, "removed": 0}]
+            # Dry-run now plans nothing.
+            result = await reconcile(
+                scope="provenance_projection", dry_run=True, config=seeded_config
+            )
+            assert result["status"] == "noop"
+            assert result["summary"]["repaired"] == 0
+            assert result["actions"] == [{"created": 0, "removed": 0}]
+        finally:
+            await store.close()
 
     @pytest.mark.asyncio
     async def test_reconcile_unsupported_when_edges_db_missing(

--- a/tests/test_reinforcement.py
+++ b/tests/test_reinforcement.py
@@ -17,19 +17,25 @@ from lithos.lcma.stats import StatsStore
 
 
 @pytest_asyncio.fixture
-async def edge_store(test_config: LithosConfig) -> EdgeStore:
-    """Create and open an EdgeStore for testing."""
+async def edge_store(test_config: LithosConfig):
+    """Create, open, and close an EdgeStore around the test."""
     store = EdgeStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest_asyncio.fixture
-async def stats_store(test_config: LithosConfig) -> StatsStore:
-    """Create and open a StatsStore for testing."""
+async def stats_store(test_config: LithosConfig):
+    """Create, open, and close a StatsStore around the test."""
     store = StatsStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 async def _create_note(

--- a/tests/test_reinforcement.py
+++ b/tests/test_reinforcement.py
@@ -514,4 +514,4 @@ class TestQuarantineFiltering:
             assert good_id in retrieved_ids, "Active note should appear in retrieval"
             assert bad_id not in retrieved_ids, "Quarantined note must be excluded from retrieval"
         finally:
-            server.stop_file_watcher()
+            await server.shutdown()

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -133,17 +133,23 @@ async def seeded_search(seeded_config: LithosConfig) -> SearchEngine:
 
 
 @pytest.fixture
-async def edge_store(seeded_config: LithosConfig) -> EdgeStore:
+async def edge_store(seeded_config: LithosConfig):
     store = EdgeStore(seeded_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest.fixture
-async def stats_store(seeded_config: LithosConfig) -> StatsStore:
+async def stats_store(seeded_config: LithosConfig):
     store = StatsStore(seeded_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 @pytest.fixture

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -684,7 +684,7 @@ def graph_with_links(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -
 
 
 @pytest.fixture
-async def seeded_edge_store(seeded_config: LithosConfig) -> EdgeStore:
+async def seeded_edge_store(seeded_config: LithosConfig):
     """EdgeStore with some typed edges seeded."""
     store = EdgeStore(seeded_config)
     await store.open()
@@ -704,7 +704,10 @@ async def seeded_edge_store(seeded_config: LithosConfig) -> EdgeStore:
         weight=0.6,
         namespace="default",
     )
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 class TestScoutGraph:
@@ -816,7 +819,7 @@ class TestScoutGraph:
 @pytest.fixture
 async def coactivation_stats_store(
     seeded_config: LithosConfig, seeded_km: KnowledgeManager
-) -> StatsStore:
+):
     """StatsStore with seeded coactivation data."""
     store = StatsStore(seeded_config)
     await store.open()
@@ -824,7 +827,10 @@ async def coactivation_stats_store(
     for _ in range(3):
         await store.increment_coactivation(node_a=_ID1, node_b=_ID2, namespace="default")
     await store.increment_coactivation(node_a=_ID1, node_b=_ID5, namespace="default")
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 class TestScoutCoactivation:
@@ -860,16 +866,22 @@ class TestScoutCoactivation:
         even when the candidate note itself lives in the allowed namespace."""
         store = StatsStore(seeded_config)
         await store.open()
-        # Record coactivation under namespace "other" — the candidate note (_ID2)
-        # lives in the "default" namespace, but the evidence is from "other".
-        for _ in range(5):
-            await store.increment_coactivation(node_a=_ID1, node_b=_ID2, namespace="other")
-        candidates = await scout_coactivation(
-            [_ID1], store, seeded_km, namespace_filter=["default"]
-        )
-        # _ID2 coactivation data is under "other", so it should NOT surface
-        node_ids = {c.node_id for c in candidates}
-        assert _ID2 not in node_ids
+        try:
+            # Record coactivation under namespace "other" — the candidate
+            # note (_ID2) lives in the "default" namespace, but the
+            # evidence is from "other".
+            for _ in range(5):
+                await store.increment_coactivation(
+                    node_a=_ID1, node_b=_ID2, namespace="other"
+                )
+            candidates = await scout_coactivation(
+                [_ID1], store, seeded_km, namespace_filter=["default"]
+            )
+            # _ID2 coactivation data is under "other", so it should NOT surface
+            node_ids = {c.node_id for c in candidates}
+            assert _ID2 not in node_ids
+        finally:
+            await store.close()
 
     async def test_empty_seeds(
         self, coactivation_stats_store: StatsStore, seeded_km: KnowledgeManager
@@ -1039,8 +1051,11 @@ class TestScoutContradictions:
         """No contradiction edges → empty list."""
         edge_store = EdgeStore(seeded_config)
         await edge_store.open()
-        result = await scout_contradictions([_ID1], edge_store, seeded_km)
-        assert result == []
+        try:
+            result = await scout_contradictions([_ID1], edge_store, seeded_km)
+            assert result == []
+        finally:
+            await edge_store.close()
 
     @pytest.mark.asyncio
     async def test_surfaces_contradiction_edge(
@@ -1049,19 +1064,22 @@ class TestScoutContradictions:
         """Seeded contradiction edge is surfaced."""
         edge_store = EdgeStore(seeded_config)
         await edge_store.open()
-        eid = await edge_store.upsert(
-            from_id=_ID1,
-            to_id=_ID2,
-            edge_type="contradicts",
-            weight=1.0,
-            namespace="default",
-        )
-        result = await scout_contradictions([_ID1], edge_store, seeded_km)
-        assert len(result) == 1
-        assert result[0]["edge_id"] == eid
-        assert result[0]["from_id"] == _ID1
-        assert result[0]["to_id"] == _ID2
-        assert result[0]["conflict_state"] is None
+        try:
+            eid = await edge_store.upsert(
+                from_id=_ID1,
+                to_id=_ID2,
+                edge_type="contradicts",
+                weight=1.0,
+                namespace="default",
+            )
+            result = await scout_contradictions([_ID1], edge_store, seeded_km)
+            assert len(result) == 1
+            assert result[0]["edge_id"] == eid
+            assert result[0]["from_id"] == _ID1
+            assert result[0]["to_id"] == _ID2
+            assert result[0]["conflict_state"] is None
+        finally:
+            await edge_store.close()
 
     @pytest.mark.asyncio
     async def test_excludes_resolved_edges(
@@ -1070,17 +1088,20 @@ class TestScoutContradictions:
         """Edges with resolved conflict_state are excluded."""
         edge_store = EdgeStore(seeded_config)
         await edge_store.open()
-        for state in ("superseded", "refuted", "merged"):
-            await edge_store.upsert(
-                from_id=_ID1,
-                to_id=_ID2,
-                edge_type="contradicts",
-                weight=1.0,
-                namespace=f"ns-{state}",
-                conflict_state=state,
-            )
-        result = await scout_contradictions([_ID1], edge_store, seeded_km)
-        assert result == []
+        try:
+            for state in ("superseded", "refuted", "merged"):
+                await edge_store.upsert(
+                    from_id=_ID1,
+                    to_id=_ID2,
+                    edge_type="contradicts",
+                    weight=1.0,
+                    namespace=f"ns-{state}",
+                    conflict_state=state,
+                )
+            result = await scout_contradictions([_ID1], edge_store, seeded_km)
+            assert result == []
+        finally:
+            await edge_store.close()
 
     @pytest.mark.asyncio
     async def test_excludes_different_namespace(
@@ -1089,19 +1110,22 @@ class TestScoutContradictions:
         """Contradiction edge to a note in a different namespace is excluded when filter is set."""
         edge_store = EdgeStore(seeded_config)
         await edge_store.open()
-        # _ID1 is in "default" namespace, _ID2 is in "projects" namespace
-        await edge_store.upsert(
-            from_id=_ID1,
-            to_id=_ID2,
-            edge_type="contradicts",
-            weight=1.0,
-            namespace="default",
-        )
-        # Filter to only "default" — _ID2 is in "projects" so should be excluded
-        result = await scout_contradictions(
-            [_ID1], edge_store, seeded_km, namespace_filter=["default"]
-        )
-        assert result == []
+        try:
+            # _ID1 is in "default" namespace, _ID2 is in "projects" namespace
+            await edge_store.upsert(
+                from_id=_ID1,
+                to_id=_ID2,
+                edge_type="contradicts",
+                weight=1.0,
+                namespace="default",
+            )
+            # Filter to only "default" — _ID2 is in "projects" so should be excluded
+            result = await scout_contradictions(
+                [_ID1], edge_store, seeded_km, namespace_filter=["default"]
+            )
+            assert result == []
+        finally:
+            await edge_store.close()
 
     @pytest.mark.asyncio
     async def test_excludes_quarantined_note(
@@ -1110,33 +1134,35 @@ class TestScoutContradictions:
         """Contradiction edge pointing to a quarantined note is excluded."""
         edge_store = EdgeStore(seeded_config)
         await edge_store.open()
+        try:
+            # Create a quarantined note
+            quarantined_id = "qqqqqqqq-qqqq-4qqq-qqqq-qqqqqqqqqqqq"
+            note = fm.Post(
+                "# Quarantined\n\nBad content",
+                id=quarantined_id,
+                title="Quarantined Note",
+                author="agent-alpha",
+                created_at=datetime.now(timezone.utc).isoformat(),
+                updated_at=datetime.now(timezone.utc).isoformat(),
+                access_scope="shared",
+                namespace="default",
+                status="quarantined",
+            )
+            kp = seeded_config.storage.knowledge_path
+            (kp / "quarantined-note.md").write_text(fm.dumps(note))
+            seeded_km._scan_existing()
 
-        # Create a quarantined note
-        quarantined_id = "qqqqqqqq-qqqq-4qqq-qqqq-qqqqqqqqqqqq"
-        note = fm.Post(
-            "# Quarantined\n\nBad content",
-            id=quarantined_id,
-            title="Quarantined Note",
-            author="agent-alpha",
-            created_at=datetime.now(timezone.utc).isoformat(),
-            updated_at=datetime.now(timezone.utc).isoformat(),
-            access_scope="shared",
-            namespace="default",
-            status="quarantined",
-        )
-        kp = seeded_config.storage.knowledge_path
-        (kp / "quarantined-note.md").write_text(fm.dumps(note))
-        seeded_km._scan_existing()
-
-        await edge_store.upsert(
-            from_id=_ID1,
-            to_id=quarantined_id,
-            edge_type="contradicts",
-            weight=1.0,
-            namespace="default",
-        )
-        result = await scout_contradictions([_ID1], edge_store, seeded_km)
-        assert result == []
+            await edge_store.upsert(
+                from_id=_ID1,
+                to_id=quarantined_id,
+                edge_type="contradicts",
+                weight=1.0,
+                namespace="default",
+            )
+            result = await scout_contradictions([_ID1], edge_store, seeded_km)
+            assert result == []
+        finally:
+            await edge_store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -817,9 +817,7 @@ class TestScoutGraph:
 
 
 @pytest.fixture
-async def coactivation_stats_store(
-    seeded_config: LithosConfig, seeded_km: KnowledgeManager
-):
+async def coactivation_stats_store(seeded_config: LithosConfig, seeded_km: KnowledgeManager):
     """StatsStore with seeded coactivation data."""
     store = StatsStore(seeded_config)
     await store.open()
@@ -871,9 +869,7 @@ class TestScoutCoactivation:
             # note (_ID2) lives in the "default" namespace, but the
             # evidence is from "other".
             for _ in range(5):
-                await store.increment_coactivation(
-                    node_a=_ID1, node_b=_ID2, namespace="other"
-                )
+                await store.increment_coactivation(node_a=_ID1, node_b=_ID2, namespace="other")
             candidates = await scout_coactivation(
                 [_ID1], store, seeded_km, namespace_filter=["default"]
             )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -116,9 +116,11 @@ class TestServerInitialization:
         server = LithosServer(test_config)
         rebuild = AsyncMock()
         server._rebuild_indices = rebuild  # type: ignore[assignment]
-
-        await server.initialize()
-        rebuild.assert_awaited_once()
+        try:
+            await server.initialize()
+            rebuild.assert_awaited_once()
+        finally:
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_initialize_rebuilds_after_semantic_store_quarantine(self, test_config):
@@ -135,11 +137,12 @@ class TestServerInitialization:
         mock_search.needs_initial_rebuild.return_value = False
         server.search = mock_search
         server._rebuild_indices = rebuild  # type: ignore[assignment]
-
-        await server.initialize()
-
-        rebuild.assert_awaited_once()
-        mock_search.ensure_semantic_backend_healthy.assert_called_once_with()
+        try:
+            await server.initialize()
+            rebuild.assert_awaited_once()
+            mock_search.ensure_semantic_backend_healthy.assert_called_once_with()
+        finally:
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_initialize_warns_but_stays_up_when_semantic_backend_unavailable(
@@ -156,13 +159,15 @@ class TestServerInitialization:
         server.search = mock_search
         server._rebuild_indices = rebuild  # type: ignore[assignment]
         server.graph.load_cache = MagicMock(return_value=True)  # type: ignore[method-assign]
+        try:
+            with caplog.at_level(logging.WARNING, logger="lithos.server"):
+                await server.initialize()
 
-        with caplog.at_level(logging.WARNING, logger="lithos.server"):
-            await server.initialize()
-
-        rebuild.assert_not_awaited()
-        server.graph.load_cache.assert_called_once_with()
-        assert "Semantic search backend remains unavailable after repair attempt" in caplog.text
+            rebuild.assert_not_awaited()
+            server.graph.load_cache.assert_called_once_with()
+            assert "Semantic search backend remains unavailable after repair attempt" in caplog.text
+        finally:
+            await server.shutdown()
 
     def test_start_file_watcher_requires_running_loop(self, test_config):
         """Watcher startup without a running loop raises a clear RuntimeError."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,11 +12,14 @@ from lithos.lcma.stats import StatsStore
 
 
 @pytest_asyncio.fixture
-async def stats_store(test_config: LithosConfig) -> StatsStore:
-    """Create and open a StatsStore for testing."""
+async def stats_store(test_config: LithosConfig):
+    """Create, open, and close a StatsStore around the test."""
     store = StatsStore(test_config)
     await store.open()
-    return store
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 class TestStatsStoreCreation:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -408,9 +408,12 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(b"not a sqlite database at all")
 
         await store.open()
-        assert store.db_path.exists()
-        quarantined = list(store.db_path.parent.glob("stats.db.corrupt-*"))
-        assert len(quarantined) == 1
+        try:
+            assert store.db_path.exists()
+            quarantined = list(store.db_path.parent.glob("stats.db.corrupt-*"))
+            assert len(quarantined) == 1
+        finally:
+            await store.close()
 
     async def test_quarantined_db_contains_original_bytes(self, test_config: LithosConfig) -> None:
         store = StatsStore(test_config)
@@ -419,8 +422,11 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(garbage)
 
         await store.open()
-        quarantined = list(store.db_path.parent.glob("stats.db.corrupt-*"))
-        assert quarantined[0].read_bytes() == garbage
+        try:
+            quarantined = list(store.db_path.parent.glob("stats.db.corrupt-*"))
+            assert quarantined[0].read_bytes() == garbage
+        finally:
+            await store.close()
 
     async def test_recreated_db_has_all_tables(self, test_config: LithosConfig) -> None:
         store = StatsStore(test_config)
@@ -428,23 +434,26 @@ class TestCorruptRecovery:
         store.db_path.write_bytes(b"garbage")
 
         await store.open()
-        conn = sqlite3.connect(str(store.db_path))
-        cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
-        )
-        tables = {row[0] for row in cursor.fetchall()}
-        conn.close()
-        assert tables == {
-            "node_stats",
-            "coactivation",
-            "enrich_queue",
-            "working_memory",
-            "receipts",
-            "task_consolidation_log",
-            "consolidation_edge_ops",
-            "consolidation_salience_ops",
-        }
+        try:
+            conn = sqlite3.connect(str(store.db_path))
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+            conn.close()
+            assert tables == {
+                "node_stats",
+                "coactivation",
+                "enrich_queue",
+                "working_memory",
+                "receipts",
+                "task_consolidation_log",
+                "consolidation_edge_ops",
+                "consolidation_salience_ops",
+            }
+        finally:
+            await store.close()
 
 
 class TestStoreLocation:
@@ -626,10 +635,12 @@ class TestCitedCountMigration:
         # Open via StatsStore — should run migration
         store = StatsStore(test_config)
         await store.open()
-
-        row = await store.get_node_stats("old_node")
-        assert row is not None
-        assert row["cited_count"] == 0
+        try:
+            row = await store.get_node_stats("old_node")
+            assert row is not None
+            assert row["cited_count"] == 0
+        finally:
+            await store.close()
 
 
 class TestGetWorkingMemory:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -29,7 +29,10 @@ class TestStatsStoreCreation:
         store = StatsStore(test_config)
         assert not store.db_path.exists()
         await store.open()
-        assert store.db_path.exists()
+        try:
+            assert store.db_path.exists()
+        finally:
+            await store.close()
 
     async def test_schema_has_all_tables(self, stats_store: StatsStore) -> None:
         conn = sqlite3.connect(str(stats_store.db_path))
@@ -168,8 +171,10 @@ class TestIdempotentReopen:
     async def test_reopen_preserves_rows(self, test_config: LithosConfig) -> None:
         store = StatsStore(test_config)
         await store.open()
+        # Close the first store so its persistent WAL writer does not
+        # contend with the standalone insert below for the same DB file.
+        await store.close()
 
-        # Insert a row into node_stats
         async with __import__("aiosqlite").connect(store.db_path) as db:
             await db.execute(
                 "INSERT INTO node_stats (node_id, retrieval_count, salience) VALUES (?, ?, ?)",
@@ -177,18 +182,21 @@ class TestIdempotentReopen:
             )
             await db.commit()
 
-        # Re-open
+        # Re-open and verify rows are preserved.
         store2 = StatsStore(test_config)
         await store2.open()
-
-        async with __import__("aiosqlite").connect(store2.db_path) as db:
-            cursor = await db.execute(
-                "SELECT retrieval_count, salience FROM node_stats WHERE node_id = ?", ("n1",)
-            )
-            row = await cursor.fetchone()
-        assert row is not None
-        assert row[0] == 5
-        assert row[1] == 0.8
+        try:
+            async with __import__("aiosqlite").connect(store2.db_path) as db:
+                cursor = await db.execute(
+                    "SELECT retrieval_count, salience FROM node_stats WHERE node_id = ?",
+                    ("n1",),
+                )
+                row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == 5
+            assert row[1] == 0.8
+        finally:
+            await store2.close()
 
 
 class TestInsertSelectRoundTrip:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1096,3 +1096,70 @@ class TestConsolidationTracking:
         # Idempotent
         await stats_store.record_consolidation_salience_op("t1", "node-1")
         assert await stats_store.has_consolidation_salience_op("t1", "node-1")
+
+
+class TestPersistentConnectionHardening:
+    """Shared-connection isolation and recovery regressions for #172."""
+
+    async def test_reads_wait_for_inflight_transaction(self, stats_store: StatsStore) -> None:
+        db = stats_store._conn()
+        original_execute = db.execute
+        txn_statement_applied = asyncio.Event()
+        release_transaction = asyncio.Event()
+        paused = False
+
+        async def execute(sql: str, params=()) -> object:
+            nonlocal paused
+            result = await original_execute(sql, params)
+            if not paused and "INSERT INTO node_stats (node_id, salience)" in sql:
+                paused = True
+                txn_statement_applied.set()
+                await release_transaction.wait()
+            return result
+
+        db.execute = execute  # type: ignore[method-assign]
+
+        writer = asyncio.create_task(
+            stats_store.update_salience_and_record_consolidation(
+                node_id="node-1",
+                delta=0.3,
+                task_id="task-1",
+            )
+        )
+        await asyncio.wait_for(txn_statement_applied.wait(), timeout=1)
+
+        reader = asyncio.create_task(stats_store.get_node_stats("node-1"))
+        done, pending = await asyncio.wait({reader}, timeout=0.05)
+        assert not done
+        assert pending == {reader}
+
+        release_transaction.set()
+        await writer
+
+        row = await asyncio.wait_for(reader, timeout=1)
+        assert row is not None
+        assert row["salience"] == pytest.approx(0.8)
+
+    async def test_reopens_after_connection_liveness_error(self, stats_store: StatsStore) -> None:
+        db = stats_store._conn()
+        original_execute = db.execute
+        fail_once = True
+
+        async def execute(sql: str, params=()) -> object:
+            nonlocal fail_once
+            if fail_once:
+                fail_once = False
+                raise ValueError("no active connection")
+            return await original_execute(sql, params)
+
+        db.execute = execute  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="no active connection"):
+            await stats_store.increment_node_stats(node_id="node-1")
+
+        assert stats_store._db is not db
+
+        await stats_store.increment_node_stats(node_id="node-1")
+        row = await stats_store.get_node_stats("node-1")
+        assert row is not None
+        assert row["retrieval_count"] == 1

--- a/tests/test_task_complete_feedback.py
+++ b/tests/test_task_complete_feedback.py
@@ -23,7 +23,7 @@ async def srv(test_config: LithosConfig) -> LithosServer:
     server = LithosServer(test_config)
     await server.initialize()
     yield server  # type: ignore[misc]
-    server.stop_file_watcher()
+    await server.shutdown()
 
 
 async def _call(server: LithosServer, tool_name: str, **kwargs: Any) -> dict[str, Any]:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -206,7 +206,7 @@ class TestTelemetryIntegration:
         await srv.initialize()
         yield srv, exporter
 
-        srv.stop_file_watcher()
+        await srv.shutdown()
         shutdown_telemetry()
         _reset_for_testing()
 
@@ -1057,7 +1057,7 @@ class TestStartupDurationMetric:
         try:
             srv = LithosServer(test_config)
             await srv.initialize()
-            srv.stop_file_watcher()
+            await srv.shutdown()
         finally:
             tel_module.lithos_metrics._startup_duration = orig
 


### PR DESCRIPTION
## Summary

Every method on `StatsStore` and `EdgeStore` opened a fresh `aiosqlite.connect(self.db_path)` per call. Setup is filesystem open, header read, shared lock acquisition — repeated dozens of times per retrieval and drain cycle.

Both stores now hold a single persistent `aiosqlite.Connection` in WAL mode, opened by `open()` and released by `close()`.

### Lifecycle

- `__init__` adds `self._db: aiosqlite.Connection | None`.
- `open()` creates the connection once, sets `row_factory=Row`, enables `journal_mode=WAL` + `foreign_keys=ON`, runs schema + migrations, then publishes the handle. Idempotent.
- `close()` shuts the connection down. Idempotent.
- `_conn()` returns the live handle (asserts `open()` ran).
- Every `async with aiosqlite.connect(self.db_path) as db:` block (**35 in `stats.py`, 9 in `edges.py`**) replaced with `db = self._conn()`.

### Drain serialisation

The per-method connection model had two coroutines ending up on two SQLite connections — `BEGIN IMMEDIATE` on connection B blocked until A committed, so the no-double-claim guarantee fell out of SQLite's write lock. With one shared connection that's no longer enough; two concurrent drains would interleave at the statement level. A lazy `asyncio.Lock` (`_drain_mutex`) now wraps both `drain_pending_nodes` and `drain_pending_tasks` to restore the guarantee. `TestDrainConcurrency` exercises this directly.

### Server lifecycle

`LithosServer.stop_enrich_worker` now also closes both stores so the WAL handles are released cleanly on shutdown.

### Test fixtures

Six fixtures (`test_stats`, `test_reinforcement`, `test_provenance_projection`, `test_coactivation`, `test_retrieve`, `test_enrich_worker`) converted from `return store` to `yield store` with `try/finally close`. Eliminates the "Event loop is closed" warnings that appeared when aiosqlite tried to clean up a persistent connection during garbage collection on a dead event loop.

Closes #172.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] All 184 LCMA-related tests pass locally (`test_edges`, `test_stats`, `test_enrich_worker`, `test_provenance_projection`, `test_coactivation`)
- [x] `TestDrainConcurrency::test_concurrent_drain_nodes_no_double_claim` and `_tasks_no_double_claim` both green after the lock fix
- [ ] `make test` (CI authoritative)
- [ ] `make test-integration` (CI authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
