### PR TITLE
fix(search): harden natural-language Tantivy callers

### DIFF
--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -212,6 +212,7 @@ async def scout_lexical(
         limit=limit * 3,
         tags=tags,
         path_prefix=path_prefix,
+        query_mode="literal",
     )
     candidates: list[Candidate] = []
     for r in results:

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import chromadb
 import networkx as nx
@@ -34,6 +34,18 @@ if TYPE_CHECKING:
     from lithos.graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
+
+_TANTIVY_RESERVED_CHAR_RE = re.compile(r'([+\-!(){}\[\]^"~*?:\\/|&])')
+
+
+def _literalize_tantivy_query(query: str) -> str:
+    """Escape Tantivy metacharacters in natural-language input.
+
+    This keeps BM25 tokenization on the indexed fields while preventing paper
+    titles and other ordinary prose from being parsed as explicit Tantivy
+    syntax.
+    """
+    return _TANTIVY_RESERVED_CHAR_RE.sub(r"\\\1", query)
 
 
 @dataclass
@@ -460,15 +472,18 @@ class TantivyIndex:
         tags: list[str] | None = None,
         author: str | None = None,
         path_prefix: str | None = None,
+        query_mode: Literal["syntax", "literal"] = "syntax",
     ) -> list[SearchResult]:
         """Search the index.
 
         Args:
-            query: Search query (Tantivy query syntax)
+            query: Search query
             limit: Maximum results
             tags: Filter by tags (AND)
             author: Filter by author
             path_prefix: Filter by path prefix
+            query_mode: ``syntax`` for raw Tantivy syntax, ``literal`` for
+                natural-language text that must be parser-safe
 
         Returns:
             List of search results
@@ -476,23 +491,17 @@ class TantivyIndex:
         self.index.reload()
         searcher = self.index.searcher()
 
-        # Build query with filters. Tags and path_prefix are applied as
-        # post-filters below; including them in the Tantivy query string is
-        # unsafe because values may contain reserved characters (e.g. a colon
-        # in ``project:lithos-core`` is parsed as a field separator, which
-        # then raises a parse error and silently returns no results — see
-        # GitHub #191).
-        query_parts = [query]
-        if author:
-            query_parts.append(f"author:{author}")
+        # Tags, author, and path_prefix are applied as post-filters below.
+        # Including their values in the Tantivy query string is unsafe because
+        # reserved characters like ``:`` and ``(`` are parsed as query syntax
+        # rather than literal text (see GitHub #191 and #240).
+        full_query = query if query_mode == "syntax" else _literalize_tantivy_query(query)
 
-        full_query = " AND ".join(f"({p})" for p in query_parts)
-
-        # When filtering by tags or path_prefix we may discard hits after
+        # When filtering by tags, author, or path_prefix we may discard hits after
         # the fact, so request extra results to reduce the chance of returning
         # fewer than ``limit`` when matches do exist. Tantivy still caps this
         # at the number of documents in the index.
-        effective_limit = limit * 5 if (tags or path_prefix) else limit
+        effective_limit = limit * 5 if (tags or author or path_prefix) else limit
 
         try:
             parsed_query = self.index.parse_query(full_query, ["title", "content"])
@@ -505,6 +514,10 @@ class TantivyIndex:
         for score, doc_address in results:
             doc = searcher.doc(doc_address)
             doc_path = doc.get_first("path")
+
+            # Apply author filter
+            if author is not None and str(doc.get_first("author") or "") != author:
+                continue
 
             # Apply path prefix filter
             if path_prefix and not str(doc_path).startswith(path_prefix):
@@ -1177,8 +1190,13 @@ class SearchEngine:
         tags: list[str] | None = None,
         author: str | None = None,
         path_prefix: str | None = None,
+        query_mode: Literal["syntax", "literal"] = "syntax",
     ) -> list[SearchResult]:
         """Full-text search using Tantivy.
+
+        ``query_mode="syntax"`` preserves the historical explicit Tantivy
+        query syntax contract. ``query_mode="literal"`` hardens natural-
+        language callers by escaping parser metacharacters before execution.
 
         Raises:
             SearchBackendError: If the Tantivy backend raises an exception.
@@ -1194,13 +1212,20 @@ class SearchEngine:
                 tags=tags,
                 author=author,
                 path_prefix=path_prefix,
+                query_mode=query_mode,
             )
             logger.debug(
-                "full_text_search: query_len=%d limit=%d result_count=%d",
+                "full_text_search: query_len=%d limit=%d query_mode=%s result_count=%d",
                 len(query),
                 limit,
+                query_mode,
                 len(results),
-                extra={"query_len": len(query), "limit": limit, "result_count": len(results)},
+                extra={
+                    "query_len": len(query),
+                    "limit": limit,
+                    "query_mode": query_mode,
+                    "result_count": len(results),
+                },
             )
             return results
         except Exception as exc:
@@ -1328,6 +1353,7 @@ class SearchEngine:
                     tags=tags,
                     author=author,
                     path_prefix=path_prefix,
+                    query_mode="literal",
                 )
             except Exception as exc:
                 logger.warning("Hybrid search: full-text backend failed: %s", exc)

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_TANTIVY_RESERVED_CHAR_RE = re.compile(r'([+\-!(){}\[\]^"~*?:\\/|&])')
+_TANTIVY_RESERVED_CHAR_RE = re.compile(r'([+\-!(){}\[\]^"~*?:\\/|&\'])')
 
 
 def _literalize_tantivy_query(query: str) -> str:

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -6,6 +6,7 @@ Unit tests for the retrieval pipeline, reranking, temperature, and receipt/WM lo
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1205,6 +1206,50 @@ class TestScoutsFiredAuditTrail:
         fired = json.loads(row["scouts_fired"])
         assert "scout_vector" not in fired  # raised
         assert "scout_lexical" in fired  # ran cleanly with []
+
+    @pytest.mark.asyncio
+    async def test_literal_safe_lexical_retrieve_handles_paper_title_punctuation(
+        self,
+        seeded_km: KnowledgeManager,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        stats_store: StatsStore,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Regression for #240: natural-language retrieve must not parse-fail."""
+        title = "When LLMs Stop Following Steps: A Diagnostic Study"
+        doc = (
+            await seeded_km.create(
+                title=title,
+                content="A paper about why LLMs stop following multi-step instructions.",
+                agent="agent-paper",
+                tags=["paper"],
+            )
+        ).document
+        seeded_search.index(KnowledgeManager.to_indexable(doc))
+
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="lithos.search"),
+        ):
+            result = await run_retrieve(
+                query=title,
+                search=seeded_search,
+                knowledge=seeded_km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        assert any(node["id"] == doc.id for node in result["results"])
+        assert not any(
+            "Tantivy query parse/search failed" in record.getMessage() for record in caplog.records
+        )
 
 
 class TestReceiptFinalNodesShape:

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -319,6 +319,36 @@ class TestScoutLexical:
         assert candidates[0].score == 5.0
 
     @pytest.mark.asyncio
+    async def test_uses_literal_query_mode(
+        self, seeded_km: KnowledgeManager, seeded_search: SearchEngine
+    ) -> None:
+        from unittest.mock import patch
+
+        from lithos.search import SearchResult
+
+        mock_results = [
+            SearchResult(
+                id=_ID1,
+                title="When LLMs Stop Following Steps: A Diagnostic Study",
+                snippet="content",
+                score=5.0,
+                path="note-one.md",
+            ),
+        ]
+        with patch.object(
+            seeded_search, "full_text_search", return_value=mock_results
+        ) as mock_search:
+            await scout_lexical(
+                "When LLMs Stop Following Steps: A Diagnostic Study",
+                seeded_search,
+                seeded_km,
+                limit=10,
+            )
+
+        assert mock_search.call_args is not None
+        assert mock_search.call_args.kwargs["query_mode"] == "literal"
+
+    @pytest.mark.asyncio
     async def test_namespace_filter(
         self, seeded_km: KnowledgeManager, seeded_search: SearchEngine
     ) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,8 @@
 """Tests for search module - Tantivy and ChromaDB search."""
 
+import logging
+from unittest.mock import patch
+
 import pytest
 
 from lithos.errors import IndexingError, SearchBackendError
@@ -159,6 +162,78 @@ class TestTantivyIndex:
 
         assert len(results) == 1
         assert results[0].id == doc1.id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("title", "query"),
+        [
+            (
+                "When LLMs Stop Following Steps: A Diagnostic Study",
+                "When LLMs Stop Following Steps: A Diagnostic Study",
+            ),
+            ("Why Agents Don't 'Just Work'", "Why Agents Don't 'Just Work'"),
+            ("Observability (for) Retrieval", "Observability (for) Retrieval"),
+            ('He Said "Quote This"', 'He Said "Quote This"'),
+            (r"Windows \ Paths for Agents", r"Windows \ Paths for Agents"),
+        ],
+    )
+    async def test_full_text_search_literal_mode_handles_natural_language_punctuation(
+        self,
+        knowledge_manager: KnowledgeManager,
+        search_engine: SearchEngine,
+        caplog: pytest.LogCaptureFixture,
+        title: str,
+        query: str,
+    ):
+        """Regression for #240: literal-mode full-text search must not parse-fail."""
+        doc = (
+            await knowledge_manager.create(
+                title=title,
+                content=f"{title}\n\nSupporting discussion of the paper title.",
+                agent="agent",
+            )
+        ).document
+        search_engine.index(KnowledgeManager.to_indexable(doc))
+
+        with caplog.at_level(logging.WARNING, logger="lithos.search"):
+            results = search_engine.full_text_search(query, query_mode="literal")
+
+        assert any(r.id == doc.id for r in results)
+        assert not any(
+            "Tantivy query parse/search failed" in record.getMessage() for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_text_search_author_filter_treats_author_as_literal(
+        self, knowledge_manager: KnowledgeManager, search_engine: SearchEngine
+    ):
+        """Author filters must not depend on Tantivy query syntax parsing."""
+        target = (
+            await knowledge_manager.create(
+                title="Knowledge graph note",
+                content="Building a knowledge graph from linked notes.",
+                agent="team:alpha",
+            )
+        ).document
+        other = (
+            await knowledge_manager.create(
+                title="Knowledge graph note two",
+                content="Building a knowledge graph from linked notes.",
+                agent="team:beta",
+            )
+        ).document
+        search_engine.index(KnowledgeManager.to_indexable(target))
+        search_engine.index(KnowledgeManager.to_indexable(other))
+
+        results = search_engine.full_text_search(
+            "knowledge graph",
+            author="team:alpha",
+            query_mode="literal",
+        )
+        result_ids = {r.id for r in results}
+
+        assert target.id in result_ids
+        assert other.id not in result_ids
 
     @pytest.mark.asyncio
     async def test_search_with_tag_containing_colon(
@@ -1271,3 +1346,16 @@ class TestHybridSearch:
         # doc should appear at most once
         ids = [r.id for r in results]
         assert ids.count(doc.id) <= 1
+
+    def test_hybrid_uses_literal_mode_for_tantivy_leg(self, search_engine: SearchEngine):
+        """Hybrid search is a natural-language surface, not a raw Tantivy API."""
+        with (
+            patch.object(search_engine._tantivy, "search", return_value=[]) as tantivy_search,
+            patch.object(
+                search_engine, "ensure_semantic_backend_healthy", return_value=(False, None)
+            ),
+        ):
+            search_engine.hybrid_search("When LLMs Stop Following Steps: A Diagnostic Study")
+
+        assert tantivy_search.call_args is not None
+        assert tantivy_search.call_args.kwargs["query_mode"] == "literal"


### PR DESCRIPTION
## Summary
- add a literal-safe Tantivy query mode for natural-language callers
- use that mode from LCMA lexical retrieval and the hybrid Tantivy leg
- move author filtering out of the Tantivy query string and add regressions for reserved characters

Closes #240