### PR TITLE
test: add validation guards for persistent sqlite lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
 
       - name: Run integration pytest suite
         env:
+          LITHOS_DETECT_THREAD_LEAKS: "1"
           LITHOS_MCP_URL: http://localhost:8765/sse
         run: |
           uv run pytest \

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -412,6 +412,33 @@ class TestAdjustWeightConcurrency:
         assert edges[0]["weight"] == pytest.approx(0.6, abs=1e-9)
 
 
+class TestUpsertConcurrency:
+    """Concurrent same-key upserts must converge on one logical edge."""
+
+    async def test_concurrent_same_key_upserts_keep_single_row(self, edge_store: EdgeStore) -> None:
+        weights = [0.1 + (i * 0.01) for i in range(25)]
+        edge_ids = await asyncio.gather(
+            *[
+                edge_store.upsert(
+                    from_id="same-from",
+                    to_id="same-to",
+                    edge_type="same-type",
+                    weight=weight,
+                    namespace="same-ns",
+                )
+                for weight in weights
+            ]
+        )
+
+        assert len(set(edge_ids)) == 1
+        assert await edge_store.count() == 1
+
+        edges = await edge_store.list_edges(from_id="same-from")
+        assert len(edges) == 1
+        assert edges[0]["edge_id"] == edge_ids[0]
+        assert any(edges[0]["weight"] == pytest.approx(weight) for weight in weights)
+
+
 class TestPersistentConnectionHardening:
     """Shared-connection isolation and recovery regressions for #172."""
 

--- a/tests/test_server_lifecycle.py
+++ b/tests/test_server_lifecycle.py
@@ -1,0 +1,96 @@
+"""Process-lifecycle validation for server startup and shutdown."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+class TestServerLifecycleValidation:
+    """Validation checks that catch process-exit regressions from leaked handles."""
+
+    def test_initialize_shutdown_exits_cleanly_in_subprocess(self, temp_dir: Path) -> None:
+        """A real server init/shutdown cycle should let the interpreter exit promptly.
+
+        Regression guard for #172: persistent aiosqlite connections can leave
+        worker threads alive after test completion if shutdown misses a handle.
+        Running the lifecycle in a subprocess lets this test fail on the exact
+        symptom CI saw: the process never exits even though the test body ended.
+        """
+        repo_root = Path(__file__).resolve().parents[1]
+        script = textwrap.dedent(
+            f"""
+            import asyncio
+            from pathlib import Path
+
+            from lithos.config import LithosConfig, StorageConfig
+            from lithos.server import LithosServer
+
+
+            class DummySearch:
+                def ensure_semantic_backend_healthy(self):
+                    return True, None
+
+                def needs_initial_rebuild(self):
+                    return False
+
+
+            async def main() -> None:
+                root = Path({str(temp_dir)!r})
+                for index in range(3):
+                    config = LithosConfig(
+                        storage=StorageConfig(data_dir=root / f"run-{{index}}")
+                    )
+                    config.ensure_directories()
+                    server = LithosServer(config)
+                    server.search = DummySearch()
+                    server.graph.load_cache = lambda: True
+                    server._enrich_worker = None
+
+                    await server.initialize()
+
+                    assert server.stats_store._db is not None
+                    assert server.edge_store._db is not None
+
+                    await server.stats_store.increment_node_stats(node_id=f"node-{{index}}")
+                    await server.edge_store.upsert(
+                        from_id=f"from-{{index}}",
+                        to_id=f"to-{{index}}",
+                        edge_type="related",
+                        weight=0.5,
+                        namespace="default",
+                    )
+
+                    await server.shutdown()
+
+                    assert server.stats_store._db is None
+                    assert server.edge_store._db is None
+
+                print("lifecycle-ok")
+
+
+            asyncio.run(main())
+            """
+        )
+        env = os.environ.copy()
+        src_path = str(repo_root / "src")
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            src_path
+            if not existing_pythonpath
+            else os.pathsep.join((src_path, existing_pythonpath))
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "lifecycle-ok" in result.stdout


### PR DESCRIPTION
## Summary
- add a subprocess lifecycle test that initializes and shuts down a real LithosServer and fails if the interpreter does not exit promptly
- add a concurrent same-key EdgeStore upsert regression test to harden the shared-connection transaction path
- enable the existing aiosqlite thread-leak detector in the integration pytest job as well

## Testing
- uv run ruff check tests/test_server_lifecycle.py tests/test_edges.py
- uv run ruff format --check tests/test_server_lifecycle.py tests/test_edges.py
- uv run python -m py_compile tests/test_server_lifecycle.py tests/test_edges.py
- uv run pytest tests/test_server_lifecycle.py tests/test_edges.py -q