### PR TITLE
Fix Tantivy writer lock contention

### DIFF
--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -307,6 +307,10 @@ class TantivyIndex:
     SCHEMA_VERSION = "3"
     """Bumped when fields are added/removed. Triggers automatic rebuild."""
 
+    WRITER_RETRY_ATTEMPTS = 8
+    WRITER_RETRY_BASE_SECONDS = 0.05
+    WRITER_RETRY_MAX_SECONDS = 1.0
+
     def __init__(self, index_path: Path):
         """Initialize Tantivy index.
 
@@ -316,6 +320,7 @@ class TantivyIndex:
         self.index_path = index_path
         self._index: tantivy.Index | None = None
         self._schema: tantivy.Schema | None = None
+        self._write_lock = threading.RLock()
         self.needs_rebuild: bool = False
 
     @property
@@ -403,42 +408,33 @@ class TantivyIndex:
             self._schema = self._build_schema()
         return self._schema
 
+    def _acquire_writer(self):
+        """Acquire Tantivy's single writer with bounded LockBusy retry."""
+        delay = self.WRITER_RETRY_BASE_SECONDS
+        for attempt in range(self.WRITER_RETRY_ATTEMPTS + 1):
+            try:
+                return self.index.writer(heap_size=15_000_000)
+            except Exception as exc:
+                if "LockBusy" not in str(exc) or attempt >= self.WRITER_RETRY_ATTEMPTS:
+                    raise
+                logger.info(
+                    "Tantivy writer lock busy; retrying",
+                    extra={"attempt": attempt + 1, "delay_seconds": delay},
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, self.WRITER_RETRY_MAX_SECONDS)
+
+        raise RuntimeError("unreachable: Tantivy writer retry loop exhausted")
+
     def add_document(self, doc: IndexableDocument) -> None:
         """Add or update a document in the index."""
-        writer = self.index.writer(heap_size=15_000_000)
+        with self._write_lock:
+            writer = self._acquire_writer()
 
-        # Delete existing document with same ID
-        writer.delete_documents("id", doc.id)
+            # Delete existing document with same ID
+            writer.delete_documents("id", doc.id)
 
-        # Add new document
-        writer.add_document(
-            tantivy.Document(
-                id=doc.id,
-                title=doc.title,
-                content=doc.full_content,
-                path=doc.path,
-                author=doc.author,
-                tags=" ".join(doc.tags),
-                source_url=doc.source_url,
-                updated_at=doc.updated_at,
-                expires_at=doc.expires_at,
-            )
-        )
-
-        writer.commit()
-        del writer  # Release lock
-        # Reload to see changes immediately
-        self.index.reload()
-
-    def rebuild_from_docs(self, docs: Iterable[IndexableDocument]) -> None:
-        """Clear the index and re-index *docs* in a single commit.
-
-        Prefer this over calling ``clear()`` + ``add_document()`` in a loop to
-        avoid O(n) writer acquisitions and commits.
-        """
-        writer = self.index.writer(heap_size=15_000_000)
-        writer.delete_all_documents()
-        for doc in docs:
+            # Add new document
             writer.add_document(
                 tantivy.Document(
                     id=doc.id,
@@ -452,18 +448,48 @@ class TantivyIndex:
                     expires_at=doc.expires_at,
                 )
             )
-        writer.commit()
-        del writer  # Release lock
-        self.index.reload()
+
+            writer.commit()
+            del writer  # Release lock
+            # Reload to see changes immediately
+            self.index.reload()
+
+    def rebuild_from_docs(self, docs: Iterable[IndexableDocument]) -> None:
+        """Clear the index and re-index *docs* in a single commit.
+
+        Prefer this over calling ``clear()`` + ``add_document()`` in a loop to
+        avoid O(n) writer acquisitions and commits.
+        """
+        with self._write_lock:
+            writer = self._acquire_writer()
+            writer.delete_all_documents()
+            for doc in docs:
+                writer.add_document(
+                    tantivy.Document(
+                        id=doc.id,
+                        title=doc.title,
+                        content=doc.full_content,
+                        path=doc.path,
+                        author=doc.author,
+                        tags=" ".join(doc.tags),
+                        source_url=doc.source_url,
+                        updated_at=doc.updated_at,
+                        expires_at=doc.expires_at,
+                    )
+                )
+            writer.commit()
+            del writer  # Release lock
+            self.index.reload()
 
     def remove_document(self, doc_id: str) -> None:
         """Remove a document from the index."""
-        writer = self.index.writer(heap_size=15_000_000)
-        writer.delete_documents("id", doc_id)
-        writer.commit()
-        del writer  # Release lock
-        # Reload to see changes immediately
-        self.index.reload()
+        with self._write_lock:
+            writer = self._acquire_writer()
+            writer.delete_documents("id", doc_id)
+            writer.commit()
+            del writer  # Release lock
+            # Reload to see changes immediately
+            self.index.reload()
 
     def search(
         self,
@@ -592,11 +618,12 @@ class TantivyIndex:
 
     def clear(self) -> None:
         """Clear the entire index."""
-        writer = self.index.writer(heap_size=15_000_000)
-        writer.delete_all_documents()
-        writer.commit()
-        del writer  # Release lock
-        self.index.reload()
+        with self._write_lock:
+            writer = self._acquire_writer()
+            writer.delete_all_documents()
+            writer.commit()
+            del writer  # Release lock
+            self.index.reload()
 
 
 def generate_snippet(content: str, query: str, context_chars: int = 150) -> str:
@@ -1102,6 +1129,9 @@ class SearchEngine:
             self._tantivy.add_document(doc)
         except Exception as exc:
             logger.warning("Full-text indexing failed for doc %s: %s", doc.id, exc)
+            lithos_metrics.fts_index_dropped.add(
+                1, {"operation": "index", "reason": type(exc).__name__}
+            )
             errors["tantivy"] = exc
 
         chunks = 0
@@ -1157,6 +1187,9 @@ class SearchEngine:
             self._tantivy.remove_document(doc_id)
         except Exception as exc:
             logger.warning("Full-text removal failed for doc %s: %s", doc_id, exc)
+            lithos_metrics.fts_index_dropped.add(
+                1, {"operation": "remove", "reason": type(exc).__name__}
+            )
             errors["tantivy"] = exc
 
         healthy, _ = self.ensure_semantic_backend_healthy()

--- a/src/lithos/telemetry.py
+++ b/src/lithos/telemetry.py
@@ -605,6 +605,7 @@ class _LithosMetrics:
         self._knowledge_write_duration: Any = None
         self._search_ops: Any = None
         self._search_duration: Any = None
+        self._fts_index_dropped: Any = None
         self._coordination_ops: Any = None
         self._event_bus_ops: Any = None
         self._event_bus_subscriber_drops: Any = None
@@ -670,6 +671,24 @@ class _LithosMetrics:
                 description="Search latency in milliseconds",
             )
         return self._search_duration
+
+    @property
+    def fts_index_dropped(self) -> Any:
+        """Counter incremented when a full-text write ultimately fails.
+
+        Contended Tantivy writer locks are retried before this counter is
+        touched, so a non-zero value means an FTS mutation was not applied.
+
+        Attributes:
+            operation: "index" | "remove"
+            reason: Exception class name.
+        """
+        if self._fts_index_dropped is None:
+            self._fts_index_dropped = get_meter().create_counter(
+                "lithos.fts_index.dropped_total",
+                description="Full-text index mutations dropped after retries",
+            )
+        return self._fts_index_dropped
 
     @property
     def coordination_ops(self) -> Any:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,8 @@
 """Tests for search module - Tantivy and ChromaDB search."""
 
+import concurrent.futures
 import logging
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +10,9 @@ import pytest
 from lithos.errors import IndexingError, SearchBackendError
 from lithos.knowledge import KnowledgeManager
 from lithos.search import (
+    IndexableDocument,
     SearchEngine,
+    TantivyIndex,
     chunk_text,
     reciprocal_rank_fusion,
 )
@@ -74,6 +78,19 @@ Third paragraph to complete the text."""
 
 class TestTantivyIndex:
     """Tests for Tantivy full-text search."""
+
+    def _indexable_doc(self, doc_id: str, content: str | None = None) -> IndexableDocument:
+        return IndexableDocument(
+            id=doc_id,
+            title=f"Doc {doc_id}",
+            content=content or f"Unique concurrent content for {doc_id}.",
+            path=f"{doc_id}.md",
+            author="agent",
+            tags=(),
+            source_url="",
+            updated_at="",
+            expires_at="",
+        )
 
     @pytest.mark.asyncio
     async def test_index_and_search(
@@ -380,6 +397,39 @@ class TestTantivyIndex:
         # Should no longer appear
         results = search_engine.full_text_search("Temporary")
         assert not any(r.id == doc.id for r in results)
+
+    def test_concurrent_tantivy_writes_are_serialized(self, tmp_path):
+        """Concurrent writes through one TantivyIndex do not lose documents."""
+        idx = TantivyIndex(tmp_path / "tantivy")
+        idx.open_or_create()
+
+        docs = [self._indexable_doc(f"doc-{i}") for i in range(12)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+            futures = [pool.submit(idx.add_document, doc) for doc in docs]
+            for future in futures:
+                future.result(timeout=5)
+
+        assert idx.get_indexed_doc_ids() == {doc.id for doc in docs}
+
+    def test_tantivy_write_retries_external_lock_busy(self, tmp_path, monkeypatch):
+        """A transient external writer lock is retried instead of dropping the write."""
+        idx = TantivyIndex(tmp_path / "tantivy")
+        idx.open_or_create()
+        monkeypatch.setattr(idx, "WRITER_RETRY_ATTEMPTS", 20)
+        monkeypatch.setattr(idx, "WRITER_RETRY_BASE_SECONDS", 0.01)
+        monkeypatch.setattr(idx, "WRITER_RETRY_MAX_SECONDS", 0.02)
+
+        external_writer = idx.index.writer(heap_size=15_000_000)
+        doc = self._indexable_doc("eventual-doc", "eventual lock retry content")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(idx.add_document, doc)
+            threading.Event().wait(0.03)
+            external_writer.commit()
+            del external_writer
+            future.result(timeout=5)
+
+        assert idx.get_indexed_doc_ids() == {doc.id}
 
 
 class TestChromaIndex:


### PR DESCRIPTION
## Summary
- serialize Tantivy writer mutations behind a per-index lock
- retry transient Tantivy LockBusy writer acquisition with bounded exponential backoff
- add lithos.fts_index.dropped_total for FTS mutations that still fail after retries
- add focused tests for concurrent in-process writes and transient external writer lock contention

Fixes #244

## Verification
- uv run pytest tests/test_search.py::TestTantivyIndex -q: 18 passed
- uv run ruff check src/lithos/search.py src/lithos/telemetry.py tests/test_search.py: passed
- uv run ruff format --check src/lithos/search.py src/lithos/telemetry.py tests/test_search.py: passed
- uv run pyright src/lithos/search.py src/lithos/telemetry.py: passed
- make lint: passed
- make typecheck: passed
- CUDA_VISIBLE_DEVICES= make test: 1074 passed, 342 deselected
- CUDA_VISIBLE_DEVICES= make check: lint/typecheck passed, 1074 unit tests passed
- CUDA_VISIBLE_DEVICES= make test-integration: failed with 14 existing conformance failures outside this change area (freshness/LCMA write/provenance/server expectations); earlier non-CPU runs also hit CUDA OOM in SentenceTransformer setup
