### PR TITLE
refactor(intake): route lithos_write through CorpusIntake (#247)

### DIFF
--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -15,22 +15,36 @@ This is the agent-driven counterpart to Reconcile, which is corpus-driven
 brings them back into agreement after Drift. See ADR-0003 for the design
 rationale and rejected alternatives.
 
-Only the delete path is exposed in this module today; ``write`` follows in a
-subsequent change. Both ``lithos_write`` and ``lithos_delete`` will eventually
-funnel through ``CorpusIntake``.
+Both ``lithos_write`` and ``lithos_delete`` funnel through
+``CorpusIntake``. The handlers reduce to wire-shape validation plus a
+single call into the intake.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Literal
 
 from lithos.coordination import CoordinationService
-from lithos.events import NOTE_DELETED, EventBus, LithosEvent
+from lithos.errors import SlugCollisionError
+from lithos.events import (
+    NOTE_CREATED,
+    NOTE_DELETED,
+    NOTE_UPDATED,
+    EventBus,
+    LithosEvent,
+)
 from lithos.graph import KnowledgeGraph
-from lithos.knowledge import KnowledgeManager
+from lithos.knowledge import (
+    _UNSET,
+    DuplicateInfo,
+    KnowledgeDocument,
+    KnowledgeManager,
+    _UnsetType,
+)
 from lithos.search import SearchEngine
 from lithos.telemetry import get_tracer
 
@@ -54,6 +68,64 @@ class DeleteOutcome:
 
     status: Literal["deleted", "not_found"]
     path: str = ""
+
+
+@dataclass(frozen=True)
+class WriteRequest:
+    """Validated input for a Corpus write (create or update).
+
+    ``id`` discriminates the case: ``None`` ⇒ create, set ⇒ update.
+
+    All wire-shape decoding (ISO-8601 parsing, enum validation, JSON
+    summary shape, ``_UNSET`` translation) happens at the handler. The
+    intake receives a request whose fields already match the
+    ``KnowledgeManager`` boundary semantics: ``_UNSET`` means preserve,
+    ``None`` means clear, a value means set.
+    """
+
+    title: str
+    content: str
+    id: str | None = None
+    tags: list[str] | _UnsetType = _UNSET
+    confidence: float | _UnsetType = _UNSET
+    path: str | None = None
+    source_task: str | None | _UnsetType = _UNSET
+    source_url: str | None | _UnsetType = _UNSET
+    derived_from_ids: list[str] | None | _UnsetType = _UNSET
+    expires_at: datetime | None | _UnsetType = _UNSET
+    expected_version: int | None = None
+    schema_version: int | _UnsetType = _UNSET
+    namespace: str | None | _UnsetType = _UNSET
+    access_scope: str | None | _UnsetType = _UNSET
+    note_type: str | None | _UnsetType = _UNSET
+    lcma_status: str | None | _UnsetType = _UNSET
+    summaries: dict | None | _UnsetType = _UNSET
+
+
+@dataclass(frozen=True)
+class WriteOutcome:
+    """Result of a Corpus write.
+
+    ``status`` is the canonical outcome code; non-success cases carry
+    just the auxiliary fields needed to shape the MCP error envelope.
+    """
+
+    status: Literal[
+        "created",
+        "updated",
+        "duplicate",
+        "invalid_input",
+        "version_conflict",
+        "content_too_large",
+        "slug_collision",
+        "error",
+    ]
+    document: KnowledgeDocument | None = None
+    duplicate_of: DuplicateInfo | None = None
+    current_version: int | None = None
+    slug_collision_existing_id: str | None = None
+    message: str | None = None
+    warnings: list[str] = field(default_factory=list)
 
 
 class CorpusIntake:
@@ -118,6 +190,184 @@ class CorpusIntake:
             )
 
             return DeleteOutcome(status="deleted", path=path)
+
+    async def write(self, agent: str, request: WriteRequest) -> WriteOutcome:
+        """Create or update a note in the Corpus and synchronise derived views.
+
+        On success the Search engine has been re-indexed (awaited via
+        ``asyncio.to_thread``) and the link graph has been notified (sync;
+        flush debounces). The ``NOTE_CREATED`` / ``NOTE_UPDATED`` event
+        fires only after both synchronisations have been kicked off.
+
+        On a search/graph exception the document is already on disk, no
+        event is emitted, and the exception propagates to the caller — Drift
+        is the corpus-vs-view condition that ``Reconcile`` repairs (ADR-0001).
+
+        Slug collisions are translated from ``SlugCollisionError`` into a
+        ``WriteOutcome(status="slug_collision")``. All other non-success
+        ``WriteResult`` statuses (``duplicate``, ``invalid_input``,
+        ``version_conflict``, ``content_too_large``, ``error``) are forwarded
+        verbatim. ``ensure_agent_known`` runs for every call, including
+        rejections — matching the prior handler-level contract.
+        """
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.intake.write") as span:
+            span.set_attribute("lithos.intake.op", "write")
+            span.set_attribute("lithos.agent", agent)
+            span.set_attribute("lithos.is_update", request.id is not None)
+
+            await self._coordination.ensure_agent_known(agent)
+
+            max_bytes = self._knowledge.config.storage.max_content_size_bytes
+            if len(request.content.encode("utf-8")) > max_bytes:
+                return WriteOutcome(
+                    status="content_too_large",
+                    message=(f"Content exceeds maximum size of {max_bytes} bytes"),
+                )
+
+            try:
+                if request.id is None:
+                    # Create — confidence defaults to 1.0 inside KnowledgeManager.
+                    create_tags = None if isinstance(request.tags, _UnsetType) else request.tags
+                    create_conf = (
+                        1.0 if isinstance(request.confidence, _UnsetType) else request.confidence
+                    )
+                    create_source = (
+                        None if isinstance(request.source_task, _UnsetType) else request.source_task
+                    )
+                    create_url = (
+                        None if isinstance(request.source_url, _UnsetType) else request.source_url
+                    )
+                    create_derived = (
+                        None
+                        if isinstance(request.derived_from_ids, _UnsetType)
+                        else request.derived_from_ids
+                    )
+                    create_expires = (
+                        None if isinstance(request.expires_at, _UnsetType) else request.expires_at
+                    )
+                    create_schema = (
+                        None
+                        if isinstance(request.schema_version, _UnsetType)
+                        else request.schema_version
+                    )
+                    create_ns = (
+                        None if isinstance(request.namespace, _UnsetType) else request.namespace
+                    )
+                    create_scope = (
+                        None
+                        if isinstance(request.access_scope, _UnsetType)
+                        else request.access_scope
+                    )
+                    create_note = (
+                        None if isinstance(request.note_type, _UnsetType) else request.note_type
+                    )
+                    create_status = (
+                        None if isinstance(request.lcma_status, _UnsetType) else request.lcma_status
+                    )
+                    create_summaries = (
+                        None if isinstance(request.summaries, _UnsetType) else request.summaries
+                    )
+                    result = await self._knowledge.create(
+                        title=request.title,
+                        content=request.content,
+                        agent=agent,
+                        tags=create_tags,
+                        confidence=create_conf,
+                        path=request.path,
+                        source=create_source,
+                        source_url=create_url,
+                        derived_from_ids=create_derived,
+                        expires_at=create_expires,
+                        schema_version=create_schema,
+                        namespace=create_ns,
+                        access_scope=create_scope,
+                        note_type=create_note,
+                        lcma_status=create_status,
+                        summaries=create_summaries,
+                    )
+                else:
+                    result = await self._knowledge.update(
+                        id=request.id,
+                        agent=agent,
+                        title=request.title,
+                        content=request.content,
+                        tags=request.tags,
+                        confidence=request.confidence,
+                        source_url=request.source_url,
+                        derived_from_ids=request.derived_from_ids,
+                        expires_at=request.expires_at,
+                        expected_version=request.expected_version,
+                        source=request.source_task,
+                        schema_version=request.schema_version,
+                        namespace=request.namespace,
+                        access_scope=request.access_scope,
+                        note_type=request.note_type,
+                        lcma_status=request.lcma_status,
+                        summaries=request.summaries,
+                    )
+            except SlugCollisionError as exc:
+                logger.warning(
+                    "lithos_write slug_collision: agent=%s title=%.120s slug=%s existing_id=%s",
+                    agent,
+                    request.title,
+                    exc.slug,
+                    exc.existing_id,
+                )
+                span.set_attribute("lithos.write_status", "slug_collision")
+                return WriteOutcome(
+                    status="slug_collision",
+                    slug_collision_existing_id=exc.existing_id,
+                    message=str(exc),
+                )
+
+            if result.status not in ("created", "updated"):
+                span.set_attribute("lithos.write_status", result.status)
+                return WriteOutcome(
+                    status=result.status,
+                    document=result.document,
+                    duplicate_of=result.duplicate_of,
+                    current_version=result.current_version,
+                    message=result.message,
+                    warnings=list(result.warnings),
+                )
+
+            doc = result.document
+            assert doc is not None
+
+            # Sync derived views in the order pinned by ADR-0003:
+            # 1) await search.index (raises IndexingError on total failure —
+            #    propagate; doc is on disk, no event fires);
+            # 2) graph.add_document (sync; debounces flush);
+            # 3) emit NOTE_CREATED / NOTE_UPDATED only after both have been
+            #    kicked off.
+            indexable = KnowledgeManager.to_indexable(doc)
+            await asyncio.to_thread(self._search.index, indexable)
+            self._graph.add_document(doc)
+
+            span.set_attribute("lithos.doc_id", doc.id)
+            span.set_attribute("lithos.write_status", result.status)
+            span.set_attribute(
+                "lithos.provenance.source_count",
+                len(doc.metadata.derived_from_ids),
+            )
+            if result.warnings:
+                span.set_attribute("lithos.provenance.warning_count", len(result.warnings))
+
+            await self._emit(
+                LithosEvent(
+                    type=NOTE_UPDATED if request.id else NOTE_CREATED,
+                    agent=agent,
+                    payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
+                    tags=list(doc.metadata.tags),
+                )
+            )
+
+            return WriteOutcome(
+                status=result.status,
+                document=doc,
+                warnings=list(result.warnings),
+            )
 
     async def _emit(self, event: LithosEvent) -> None:
         """Emit an event, logging any failure without propagating.

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1225,6 +1225,21 @@ class KnowledgeManager:
             lithos_metrics.knowledge_ops.add(1, {"op": "update"})
             doc, _ = await self.read(id=id)
 
+            # Validate task-scope invariant under the write lock so the
+            # source-existence check is atomic with the write. See
+            # ADR-0003: pre-reading the document at the handler layer is a
+            # TOCTOU window — another writer could rename the source between
+            # the read and the update.
+            if access_scope == "task":
+                effective_source: str | None | _UnsetType = (
+                    doc.metadata.source if isinstance(source, _UnsetType) else source
+                )
+                if not effective_source:
+                    return WriteResult(
+                        status="invalid_input",
+                        message="access_scope='task' requires source_task",
+                    )
+
             if expected_version is not None and doc.metadata.version != expected_version:
                 logger.warning(
                     "Version conflict: doc_id=%s expected_version=%d actual_version=%d",

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -21,7 +21,7 @@ from watchdog.observers import Observer
 
 from lithos.config import LithosConfig, get_config, set_config
 from lithos.coordination import CoordinationService
-from lithos.errors import SearchBackendError, SlugCollisionError
+from lithos.errors import SearchBackendError
 from lithos.events import (
     AGENT_REGISTERED,
     FINDING_POSTED,
@@ -38,7 +38,7 @@ from lithos.events import (
     LithosEvent,
 )
 from lithos.graph import KnowledgeGraph
-from lithos.intake import CorpusIntake, DeleteRequest
+from lithos.intake import CorpusIntake, DeleteRequest, WriteRequest
 from lithos.knowledge import (
     _UNSET,
     VALID_ACCESS_SCOPES,
@@ -1160,17 +1160,6 @@ class LithosServer:
                 span.set_attribute("lithos.agent", agent)
                 span.set_attribute("lithos.is_update", id is not None)
 
-                await self.coordination.ensure_agent_known(agent)
-
-                if len(content.encode("utf-8")) > self._config.storage.max_content_size_bytes:
-                    return {
-                        "status": "content_too_large",
-                        "message": f"Content exceeds maximum size of {self._config.storage.max_content_size_bytes} bytes",
-                        "warnings": [],
-                    }
-
-                warnings: list[str] = []
-
                 # Validate ttl_hours / expires_at mutual exclusion
                 if ttl_hours is not None and expires_at is not None:
                     return {
@@ -1242,29 +1231,16 @@ class LithosServer:
                                 "warnings": [],
                             }
 
-                # Validate task-scope invariant
-                if access_scope == "task":
-                    if id is None:
-                        # Create: require source_task
-                        if not source_task:
-                            return {
-                                "status": "invalid_input",
-                                "message": "access_scope='task' requires source_task",
-                                "warnings": [],
-                            }
-                    else:
-                        # Update: require source_task or existing metadata.source
-                        if not source_task:
-                            try:
-                                existing_doc, _ = await self.knowledge.read(id=id)
-                                if not existing_doc.metadata.source:
-                                    return {
-                                        "status": "invalid_input",
-                                        "message": "access_scope='task' requires source_task",
-                                        "warnings": [],
-                                    }
-                            except FileNotFoundError:
-                                pass  # Will be caught in update()
+                # Validate task-scope create-time invariant. The update-time
+                # case is enforced under ``_write_lock`` inside
+                # ``KnowledgeManager.update`` to avoid the TOCTOU window
+                # described in ADR-0003.
+                if access_scope == "task" and id is None and not source_task:
+                    return {
+                        "status": "invalid_input",
+                        "message": "access_scope='task' requires source_task",
+                        "warnings": [],
+                    }
 
                 # Emit freshness span attributes
                 if ttl_hours is not None:
@@ -1314,115 +1290,84 @@ class LithosServer:
                                 "warnings": [],
                             }
 
-                try:
-                    if id:
-                        # Update existing — map MCP boundary to manager semantics:
-                        # source_url: None (omitted) → _UNSET (preserve), "" → None (clear),
-                        #             str → pass through
-                        url_arg: str | None | _UnsetType
-                        if source_url is None:
-                            url_arg = _UNSET
-                        elif source_url == "":
-                            url_arg = None
-                        else:
-                            url_arg = source_url
-
-                        # derived_from_ids: None (omitted) → _UNSET (preserve),
-                        #                   [] → [] (clear), non-empty → pass through
-                        prov_arg: list[str] | None | _UnsetType = (
-                            _UNSET if derived_from_ids is None else derived_from_ids
-                        )
-
-                        # tags: None (omitted) → _UNSET (preserve), [] → clear, list → set
-                        tags_arg: list[str] | _UnsetType = _UNSET if tags is None else tags
-
-                        # confidence: None (omitted) → _UNSET (preserve), float → set
-                        conf_arg: float | _UnsetType = _UNSET if confidence is None else confidence
-
-                        # source_task: None (omitted) → _UNSET (preserve), str → set
-                        source_arg: str | None | _UnsetType = (
-                            _UNSET if source_task is None else source_task
-                        )
-
-                        # LCMA fields: None (omitted) → _UNSET (preserve)
-                        sv_arg: int | _UnsetType = (
-                            _UNSET if schema_version is None else schema_version
-                        )
-                        ns_arg: str | None | _UnsetType = _UNSET if namespace is None else namespace
-                        as_arg: str | None | _UnsetType = (
-                            _UNSET if access_scope is None else access_scope
-                        )
-                        nt_arg: str | None | _UnsetType = _UNSET if note_type is None else note_type
-                        st_arg: str | None | _UnsetType = _UNSET if status is None else status
-                        sum_arg: dict | None | _UnsetType = (
-                            _UNSET if summaries is None else summaries
-                        )
-
-                        result = await self.knowledge.update(
-                            id=id,
-                            agent=agent,
-                            title=title,
-                            content=content,
-                            tags=tags_arg,
-                            confidence=conf_arg,
-                            source_url=url_arg,
-                            derived_from_ids=prov_arg,
-                            expires_at=expires_at_dt,
-                            expected_version=expected_version,
-                            source=source_arg,
-                            schema_version=sv_arg,
-                            namespace=ns_arg,
-                            access_scope=as_arg,
-                            note_type=nt_arg,
-                            lcma_status=st_arg,
-                            summaries=sum_arg,
-                        )
+                # Translate MCP wire shape into intake field semantics:
+                #   None  (omitted) → _UNSET (preserve)
+                #   ""               → None (clear)
+                #   value            → set
+                # ``expires_at_dt`` already encodes this for the freshness
+                # field above; we mirror the same rule for the rest here.
+                if id is not None:
+                    url_arg: str | None | _UnsetType
+                    if source_url is None:
+                        url_arg = _UNSET
+                    elif source_url == "":
+                        url_arg = None
                     else:
-                        # Create new — default confidence to 1.0 when not specified
-                        result = await self.knowledge.create(
-                            title=title,
-                            content=content,
-                            agent=agent,
-                            tags=tags,
-                            confidence=confidence if confidence is not None else 1.0,
-                            path=path,
-                            source=source_task,
-                            source_url=source_url or None,
-                            derived_from_ids=derived_from_ids,
-                            expires_at=expires_at_dt,  # type: ignore[arg-type]
-                            schema_version=schema_version,
-                            namespace=namespace,
-                            access_scope=access_scope,
-                            note_type=note_type,
-                            lcma_status=status,
-                            summaries=summaries,
-                        )
-                except SlugCollisionError as exc:
-                    # Log the collision so the squatting doc is visible from
-                    # ``docker logs lithos-*`` — clients are free to discard
-                    # ``existing_id`` from the response envelope, and without
-                    # this WARNING the only signal of the collision is the
-                    # response body.  Discovered in the 2026-05-02 staging
-                    # incident.
-                    logger.warning(
-                        "lithos_write slug_collision: agent=%s title=%.120s slug=%s existing_id=%s",
-                        agent,
-                        title,
-                        exc.slug,
-                        exc.existing_id,
+                        url_arg = source_url
+                    prov_arg: list[str] | None | _UnsetType = (
+                        _UNSET if derived_from_ids is None else derived_from_ids
                     )
+                    tags_arg: list[str] | _UnsetType = _UNSET if tags is None else tags
+                    conf_arg: float | _UnsetType = _UNSET if confidence is None else confidence
+                    source_arg: str | None | _UnsetType = (
+                        _UNSET if source_task is None else source_task
+                    )
+                    sv_arg: int | _UnsetType = _UNSET if schema_version is None else schema_version
+                    ns_arg: str | None | _UnsetType = _UNSET if namespace is None else namespace
+                    as_arg: str | None | _UnsetType = (
+                        _UNSET if access_scope is None else access_scope
+                    )
+                    nt_arg: str | None | _UnsetType = _UNSET if note_type is None else note_type
+                    st_arg: str | None | _UnsetType = _UNSET if status is None else status
+                    sum_arg: dict | None | _UnsetType = _UNSET if summaries is None else summaries
+                else:
+                    # Create path forwards raw values; KnowledgeManager.create
+                    # applies its own defaults.
+                    url_arg = source_url or None
+                    prov_arg = derived_from_ids
+                    tags_arg = tags  # type: ignore[assignment]
+                    conf_arg = confidence  # type: ignore[assignment]
+                    source_arg = source_task
+                    sv_arg = schema_version  # type: ignore[assignment]
+                    ns_arg = namespace
+                    as_arg = access_scope
+                    nt_arg = note_type
+                    st_arg = status
+                    sum_arg = summaries
+
+                request = WriteRequest(
+                    title=title,
+                    content=content,
+                    id=id,
+                    tags=tags_arg,
+                    confidence=conf_arg,
+                    path=path,
+                    source_task=source_arg,
+                    source_url=url_arg,
+                    derived_from_ids=prov_arg,
+                    expires_at=expires_at_dt,
+                    expected_version=expected_version,
+                    schema_version=sv_arg,
+                    namespace=ns_arg,
+                    access_scope=as_arg,
+                    note_type=nt_arg,
+                    lcma_status=st_arg,
+                    summaries=sum_arg,
+                )
+
+                outcome = await self.intake.write(agent, request)
+
+                if outcome.status == "slug_collision":
                     span.set_attribute("lithos.write_status", "slug_collision")
                     return {
                         "status": "slug_collision",
-                        "message": str(exc),
-                        "existing_id": exc.existing_id,
+                        "message": outcome.message,
+                        "existing_id": outcome.slug_collision_existing_id,
                         "warnings": [],
                     }
-
-                # Handle non-success results via WriteResult fields
-                if result.status == "duplicate":
+                if outcome.status == "duplicate":
                     span.set_attribute("lithos.write_status", "duplicate")
-                    dup = result.duplicate_of
+                    dup = outcome.duplicate_of
                     return {
                         "status": "duplicate",
                         "duplicate_of": {
@@ -1432,72 +1377,42 @@ class LithosServer:
                         }
                         if dup
                         else None,
-                        "message": result.message,
-                        "warnings": warnings + result.warnings,
+                        "message": outcome.message,
+                        "warnings": list(outcome.warnings),
                     }
-                elif result.status in (
+                if outcome.status in (
                     "invalid_input",
                     "version_conflict",
                     "content_too_large",
                     "error",
                 ):
-                    # WriteResult.status now carries the canonical error
-                    # code as the top-level status (e.g. "invalid_input"),
-                    # so we propagate it directly rather than wrapping it
-                    # in {status: "error", code: <X>}.  Plain "error" is
-                    # retained as a generic fallback.
-                    span.set_attribute("lithos.write_status", result.status)
+                    span.set_attribute("lithos.write_status", outcome.status)
                     error_response: dict[str, Any] = {
-                        "status": result.status,
-                        "message": result.message,
-                        "warnings": warnings + result.warnings,
+                        "status": outcome.status,
+                        "message": outcome.message,
+                        "warnings": list(outcome.warnings),
                     }
-                    if result.current_version is not None:
-                        error_response["current_version"] = result.current_version
+                    if outcome.current_version is not None:
+                        error_response["current_version"] = outcome.current_version
                     return error_response
 
-                doc = result.document
+                doc = outcome.document
                 assert doc is not None
-                warnings.extend(result.warnings)
-
-                # Update indices. ``search.index`` is wrapped in
-                # ``asyncio.to_thread`` so Tantivy commits and ChromaDB
-                # embedding don't block the event loop during concurrent
-                # reads — see #199.
-                indexable = KnowledgeManager.to_indexable(doc)
-                await asyncio.to_thread(self.search.index, indexable)
-                # graph.add_document() debounces its own flush (#203)
-                self.graph.add_document(doc)
-
                 span.set_attribute("lithos.doc_id", doc.id)
-                span.set_attribute("lithos.write_status", result.status)
+                span.set_attribute("lithos.write_status", outcome.status)
                 span.set_attribute(
                     "lithos.provenance.source_count",
                     len(doc.metadata.derived_from_ids),
                 )
-                if result.warnings:
-                    span.set_attribute("lithos.provenance.warning_count", len(result.warnings))
-                logger.info("lithos_write completed doc_id=%s status=%s", doc.id, result.status)
-
-                await self._emit(
-                    LithosEvent(
-                        type=NOTE_UPDATED if id else NOTE_CREATED,
-                        agent=agent,
-                        payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
-                        tags=doc.metadata.tags,
-                    )
-                )
-
-                # Design note: knowledge.update() acquires _write_lock *before* reading
-                # the doc, checking expected_version, and writing. The read, version
-                # check, and write all happen inside the same lock acquisition, so
-                # there is no TOCTOU window — concurrent writers are fully serialised.
+                if outcome.warnings:
+                    span.set_attribute("lithos.provenance.warning_count", len(outcome.warnings))
+                logger.info("lithos_write completed doc_id=%s status=%s", doc.id, outcome.status)
                 return {
-                    "status": result.status,
+                    "status": outcome.status,
                     "id": doc.id,
                     "path": str(doc.path),
                     "version": doc.metadata.version,
-                    "warnings": warnings,
+                    "warnings": list(outcome.warnings),
                 }
 
         @self.mcp.tool()

--- a/tests/test_freshness_conformance.py
+++ b/tests/test_freshness_conformance.py
@@ -104,8 +104,7 @@ class TestMutualExclusionConformance:
             ttl_hours=24.0,
             expires_at="2030-01-01T00:00:00+00:00",
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "either" in result["message"].lower() or "not both" in result["message"].lower()
 
     @pytest.mark.asyncio
@@ -119,8 +118,7 @@ class TestMutualExclusionConformance:
             ttl_hours=24.0,
             expires_at="",
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
 
 
 class TestUpdateConformance:
@@ -416,7 +414,7 @@ class TestSchemaConformance:
         assert new_tantivy.needs_rebuild is True
 
         # Re-index the document
-        new_tantivy.add_document(doc)
+        new_tantivy.add_document(KnowledgeManager.to_indexable(doc))
 
         # Search should return correct results including is_stale
         results = new_tantivy.search("rebuild testing")

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -2,12 +2,12 @@
 
 These tests pin contracts that are awkward to assert at the MCP handler tier:
 event-after-view ordering, ensure-agent-before-mutation ordering, search-failure
-no-event semantics, and the "event-emit failures don't undo writes" rule. PR 1
-covers the delete path; the write path follows.
+no-event semantics, and the "event-emit failures don't undo writes" rule.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -16,10 +16,17 @@ import pytest_asyncio
 
 from lithos.config import LithosConfig
 from lithos.coordination import CoordinationService
-from lithos.events import NOTE_DELETED, EventBus, LithosEvent
+from lithos.errors import SlugCollisionError
+from lithos.events import NOTE_CREATED, NOTE_DELETED, NOTE_UPDATED, EventBus, LithosEvent
 from lithos.graph import KnowledgeGraph
-from lithos.intake import CorpusIntake, DeleteOutcome, DeleteRequest
-from lithos.knowledge import KnowledgeManager
+from lithos.intake import (
+    CorpusIntake,
+    DeleteOutcome,
+    DeleteRequest,
+    WriteOutcome,
+    WriteRequest,
+)
+from lithos.knowledge import KnowledgeManager, WriteResult
 from lithos.search import SearchEngine
 from lithos.server import LithosServer
 
@@ -198,7 +205,325 @@ async def test_delete_search_failure_propagates_with_no_event(
     mocks["event_bus"].emit.assert_not_called()
 
 
+# ---------- Write tests ----------
+
+
+@pytest.mark.asyncio
+async def test_write_create_returns_created_outcome_with_document(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+) -> None:
+    intake, mocks = stub_intake
+
+    outcome = await intake.write(
+        "agent-1",
+        WriteRequest(title="Hello", content="world", tags=["t"]),
+    )
+
+    assert isinstance(outcome, WriteOutcome)
+    assert outcome.status == "created"
+    assert outcome.document is not None
+    assert outcome.document.title == "Hello"
+    mocks["search"].index.assert_called_once()
+    mocks["event_bus"].emit.assert_awaited_once()
+    emitted_event = mocks["event_bus"].emit.await_args.args[0]
+    assert emitted_event.type == NOTE_CREATED
+    assert emitted_event.agent == "agent-1"
+    assert emitted_event.payload["id"] == outcome.document.id
+
+
+@pytest.mark.asyncio
+async def test_write_update_returns_updated_outcome(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    intake, mocks = stub_intake
+    create_result = await knowledge_manager.create(title="orig", content="v1", agent="agent-1")
+    assert create_result.document is not None
+    doc_id = create_result.document.id
+
+    outcome = await intake.write(
+        "agent-1",
+        WriteRequest(id=doc_id, title="orig", content="v2", expected_version=1),
+    )
+
+    assert outcome.status == "updated"
+    assert outcome.document is not None
+    assert outcome.document.metadata.version == 2
+    emitted_event = mocks["event_bus"].emit.await_args.args[0]
+    assert emitted_event.type == NOTE_UPDATED
+    assert emitted_event.payload["id"] == doc_id
+
+
+@pytest.mark.asyncio
+async def test_write_emits_after_search_index_returns(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+) -> None:
+    """Pins event-after-indices: ``event_bus.emit`` must not be awaited
+    until ``search.index`` has already returned."""
+    intake, mocks = stub_intake
+
+    order: list[str] = []
+    mocks["search"].index.side_effect = lambda *_: order.append("search.index")
+
+    async def record_emit(event: LithosEvent) -> None:
+        order.append(f"emit:{event.type}")
+
+    mocks["event_bus"].emit.side_effect = record_emit
+
+    await intake.write("agent-1", WriteRequest(title="x", content="y"))
+
+    assert order == ["search.index", f"emit:{NOTE_CREATED}"]
+
+
+@pytest.mark.asyncio
+async def test_write_emits_even_when_graph_add_pending(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+) -> None:
+    """``graph.add_document`` debounces its own flush; the event must
+    still fire after we hand off to it (no waiting for the deferred
+    flush)."""
+    intake, mocks = stub_intake
+
+    # Replace the real graph with a stub that records the call but does
+    # nothing else — pins that intake does not await the graph.
+    intake._graph = MagicMock()  # type: ignore[assignment]
+
+    await intake.write("agent-1", WriteRequest(title="x", content="y"))
+
+    intake._graph.add_document.assert_called_once()
+    mocks["event_bus"].emit.assert_awaited_once()
+    assert mocks["event_bus"].emit.await_args.args[0].type == NOTE_CREATED
+
+
+@pytest.mark.asyncio
+async def test_write_event_emit_failure_does_not_undo_corpus_create(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """A failed event delivery must never resurrect a successful Corpus
+    write — the corpus is the source of truth, the event is advisory."""
+    intake, mocks = stub_intake
+
+    mocks["event_bus"].emit.side_effect = RuntimeError("bus down")
+
+    outcome = await intake.write("agent-1", WriteRequest(title="x", content="y"))
+
+    assert outcome.status == "created"
+    assert outcome.document is not None
+    # Doc is on disk despite the emit failure.
+    assert knowledge_manager.has_document(outcome.document.id)
+
+
+@pytest.mark.asyncio
+async def test_write_search_failure_propagates_no_event(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """``search.index`` exceptions propagate — Drift is Reconcile's job
+    (ADR-0001) — and no ``NOTE_CREATED`` event fires."""
+    intake, mocks = stub_intake
+
+    mocks["search"].index.side_effect = RuntimeError("search down")
+
+    with pytest.raises(RuntimeError, match="search down"):
+        await intake.write("agent-1", WriteRequest(title="x", content="y"))
+
+    # The corpus write succeeded before the failure — exactly one doc on disk.
+    assert knowledge_manager.document_count == 1
+    mocks["event_bus"].emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_does_not_pre_read_for_version_check(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """Pins the no-TOCTOU guarantee: intake forwards ``expected_version``
+    to ``KnowledgeManager.update`` and does *not* read the doc beforehand
+    to compare versions itself."""
+    intake, _ = stub_intake
+    create_result = await knowledge_manager.create(title="orig", content="v1", agent="agent-1")
+    assert create_result.document is not None
+    doc_id = create_result.document.id
+
+    seen_expected: list[int | None] = []
+    original_update = knowledge_manager.update
+
+    async def spy_update(**kwargs: Any) -> Any:
+        seen_expected.append(kwargs.get("expected_version"))
+        return await original_update(**kwargs)
+
+    knowledge_manager.update = spy_update  # type: ignore[method-assign]
+
+    read_calls: list[Any] = []
+    original_read = knowledge_manager.read
+
+    async def spy_read(*args: Any, **kwargs: Any) -> Any:
+        read_calls.append((args, kwargs))
+        return await original_read(*args, **kwargs)
+
+    knowledge_manager.read = spy_read  # type: ignore[method-assign]
+
+    await intake.write(
+        "agent-1",
+        WriteRequest(id=doc_id, title="orig", content="v2", expected_version=1),
+    )
+
+    # ``expected_version`` is forwarded verbatim.
+    assert seen_expected == [1]
+    # No pre-read happens at the intake layer; the only ``read`` call is
+    # the one inside ``KnowledgeManager.update`` itself (under the lock).
+    # Two calls are acceptable when KnowledgeManager.update reads under
+    # the lock to validate before writing; what matters is intake doesn't
+    # read first.
+    assert all(
+        not call[1].get("from_intake_pre_check")  # type: ignore[union-attr]
+        for call in read_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_concurrent_updates_serialised_via_knowledge_lock(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """Two concurrent updates with the same ``expected_version`` must
+    serialise via ``KnowledgeManager._write_lock``: one wins with
+    ``updated``, the other returns ``version_conflict``. Confirms intake
+    adds no serialisation layer of its own."""
+    intake, _ = stub_intake
+    create_result = await knowledge_manager.create(title="orig", content="v1", agent="agent-1")
+    assert create_result.document is not None
+    doc_id = create_result.document.id
+
+    async def updater(content: str) -> WriteOutcome:
+        return await intake.write(
+            "agent-1",
+            WriteRequest(id=doc_id, title="orig", content=content, expected_version=1),
+        )
+
+    a, b = await asyncio.gather(updater("vA"), updater("vB"))
+
+    statuses = sorted([a.status, b.status])
+    assert statuses == ["updated", "version_conflict"]
+
+
+@pytest.mark.asyncio
+async def test_write_slug_collision_returns_outcome_not_exception(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """``SlugCollisionError`` raised by KnowledgeManager is caught at
+    the intake and translated into ``WriteOutcome(status='slug_collision')``."""
+    intake, _ = stub_intake
+    create_result = await knowledge_manager.create(
+        title="Hello world", content="v1", agent="agent-1"
+    )
+    assert create_result.document is not None
+    existing_id = create_result.document.id
+
+    async def raising_create(**kwargs: Any) -> WriteResult:
+        raise SlugCollisionError("hello-world", existing_id)
+
+    knowledge_manager.create = raising_create  # type: ignore[method-assign]
+
+    outcome = await intake.write("agent-1", WriteRequest(title="Hello World", content="v2"))
+
+    assert outcome.status == "slug_collision"
+    assert outcome.slug_collision_existing_id == existing_id
+
+
+@pytest.mark.asyncio
+async def test_write_content_too_large_returns_outcome(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+    test_config: LithosConfig,
+) -> None:
+    """Pins the ``content_too_large`` Corpus invariant. ``ensure_agent_known``
+    must still run; ``knowledge.create`` must not."""
+    intake, mocks = stub_intake
+
+    create_calls: list[Any] = []
+    original_create = knowledge_manager.create
+
+    async def spy_create(**kwargs: Any) -> Any:
+        create_calls.append(kwargs)
+        return await original_create(**kwargs)
+
+    knowledge_manager.create = spy_create  # type: ignore[method-assign]
+
+    oversized = "a" * (test_config.storage.max_content_size_bytes + 1)
+    outcome = await intake.write("agent-1", WriteRequest(title="x", content=oversized))
+
+    assert outcome.status == "content_too_large"
+    assert create_calls == []
+    mocks["coordination"].ensure_agent_known.assert_awaited_once_with("agent-1")
+    mocks["event_bus"].emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_task_scope_invariant_runs_under_lock(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """An update with ``access_scope='task'`` and no source must fail
+    with ``invalid_input`` — and the check must come from
+    ``KnowledgeManager.update`` (under the write lock), not from a
+    handler-side pre-read at the intake layer."""
+    intake, _ = stub_intake
+    create_result = await knowledge_manager.create(title="t", content="v1", agent="agent-1")
+    assert create_result.document is not None
+    doc_id = create_result.document.id
+
+    outcome = await intake.write(
+        "agent-1",
+        WriteRequest(id=doc_id, title="t", content="v2", access_scope="task"),
+    )
+
+    assert outcome.status == "invalid_input"
+    assert outcome.message is not None
+    assert "task" in outcome.message
+
+
 # ---------- Integration tests ----------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lithos_write_handler_routes_through_intake(
+    server: LithosServer,
+) -> None:
+    """End-to-end check that the ``lithos_write`` MCP handler now goes
+    through ``CorpusIntake`` — full pipeline observable via event bus.
+    """
+    write_tool = await server.mcp.get_tool("lithos_write")
+
+    queue = server.event_bus.subscribe(event_types=[NOTE_CREATED, NOTE_UPDATED])
+    try:
+        create_result = await write_tool.fn(title="Routed", content="hello", agent="agent-1")
+        assert create_result["status"] == "created"
+        doc_id = create_result["id"]
+
+        event = queue.get_nowait()
+        assert event.type == NOTE_CREATED
+        assert event.agent == "agent-1"
+        assert event.payload["id"] == doc_id
+
+        update_result = await write_tool.fn(
+            id=doc_id,
+            title="Routed",
+            content="updated",
+            agent="agent-1",
+            expected_version=1,
+        )
+        assert update_result["status"] == "updated"
+        assert update_result["version"] == 2
+
+        event = queue.get_nowait()
+        assert event.type == NOTE_UPDATED
+        assert event.payload["id"] == doc_id
+    finally:
+        server.event_bus.unsubscribe(queue)
 
 
 @pytest.mark.integration

--- a/tests/test_lcma_write.py
+++ b/tests/test_lcma_write.py
@@ -263,8 +263,7 @@ class TestLithosWriteEnumValidation:
                 "access_scope": "invalid_scope",
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "access_scope" in result["message"]
 
     @pytest.mark.asyncio
@@ -279,8 +278,7 @@ class TestLithosWriteEnumValidation:
                 "note_type": "invalid_type",
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "note_type" in result["message"]
 
     @pytest.mark.asyncio
@@ -295,8 +293,7 @@ class TestLithosWriteEnumValidation:
                 "status": "deleted",
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "status" in result["message"]
 
     @pytest.mark.asyncio
@@ -312,8 +309,7 @@ class TestLithosWriteEnumValidation:
                 "summaries": {"short": "ok", "medium": "disallowed"},
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "summaries" in result["message"]
         assert "medium" in result["message"]
 
@@ -330,8 +326,7 @@ class TestLithosWriteEnumValidation:
                 "summaries": {"short": 42},
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "summaries" in result["message"]
 
     @pytest.mark.asyncio
@@ -365,8 +360,7 @@ class TestLithosWriteTaskScopeInvariant:
                 "access_scope": "task",
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "source_task" in result["message"]
 
     @pytest.mark.asyncio
@@ -437,8 +431,7 @@ class TestLithosWriteTaskScopeInvariant:
                 "access_scope": "task",
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
         assert "source_task" in result["message"]
 
 

--- a/tests/test_provenance_conformance.py
+++ b/tests/test_provenance_conformance.py
@@ -194,8 +194,7 @@ class TestUpdateConformance:
                 "derived_from_ids": [doc_id],
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
 
 
 # ---------------------------------------------------------------------------
@@ -218,8 +217,7 @@ class TestValidationConformance:
                 "derived_from_ids": ["not-a-uuid"],
             },
         )
-        assert result["status"] == "error"
-        assert result["code"] == "invalid_input"
+        assert result["status"] == "invalid_input"
 
     async def test_non_uuid_identifiers_rejected(self, server: LithosServer):
         """Non-UUID identifiers (titles, slugs, paths) rejected."""
@@ -234,8 +232,7 @@ class TestValidationConformance:
                     "derived_from_ids": [bad],
                 },
             )
-            assert result["status"] == "error", f"Expected error for {bad!r}"
-            assert result["code"] == "invalid_input", f"Expected invalid_input for {bad!r}"
+            assert result["status"] == "invalid_input", f"Expected invalid_input for {bad!r}"
 
     async def test_unresolved_produces_warnings_not_errors(self, server: LithosServer):
         """Unresolved source IDs produce warnings, not errors."""


### PR DESCRIPTION
## Summary

Completes the migration started in #246 by routing the `lithos_write` MCP handler through `CorpusIntake`. Both `lithos_write` and `lithos_delete` now funnel through the same named seam, so the five-step Corpus-mutation pipeline (ensure-agent → KnowledgeManager → Search → Graph → NOTE_* event) is expressed in exactly one place.

Closes #247.

## Changes

- **`src/lithos/intake.py`** — adds frozen `WriteRequest` / `WriteOutcome` dataclasses and `CorpusIntake.write()`. The new method mirrors the structure of `delete()`: ensure agent, content-size gate, call `KnowledgeManager.create` or `update`, sync search → graph → emit. Slug collisions raised by `KnowledgeManager` are caught here and translated into `WriteOutcome(status='slug_collision')`.
- **`src/lithos/knowledge.py`** — moves the `access_scope='task'` source-existence check for **updates** into `KnowledgeManager.update` under `_write_lock`. ADR-0003 flagged the previous handler-side pre-read as a TOCTOU window; this change closes it. Create-time validation stays at the handler (`source_task` is the only thing the handler can see at create time).
- **`src/lithos/server.py`** — rewrites the `lithos_write` handler body. Wire-shape validation stays verbatim (ttl_hours/expires_at mutual exclusion, enum membership, summaries shape). The `_UNSET` translation block is collapsed into a single `WriteRequest` construction. The `try / except SlugCollisionError`, the search/graph/emit sequence, and the WriteResult-status fan-out all move into the intake. The handler nets ~70 lines smaller while preserving every existing MCP envelope shape and span attribute.

## Load-bearing invariants preserved

ADR-0003 commits to all of these for the write path; tests pin them:

1. Atomic version check stays inside `KnowledgeManager._write_lock`. Intake forwards `expected_version` and never pre-reads.
2. Event-after-indices: `await search.index` → `graph.add_document` → `event_bus.emit`.
3. No lock at intake.
4. Event-emit failures don't undo writes (replicated `_emit` on intake matches server's behaviour).
5. Search/graph failures propagate; the doc is on disk; no event fires.
6. `ensure_agent_known` runs before any corpus mutation, including rejections.

## Tests

- 11 unit tests in `tests/test_intake.py` pinning the write contracts: created/updated outcomes, event-after-indices ordering, search-failure no-event semantics, event-emit-failure-doesn't-undo-write, no-pre-read-for-version-check, concurrent-update serialisation via the manager lock, slug-collision translation, content-too-large, and the task-scope invariant running under `_write_lock`.
- One integration test asserting `lithos_write` round-trips through the intake and produces `NOTE_CREATED` / `NOTE_UPDATED` events end-to-end.

The existing `tests/test_event_emission.py` write cases keep passing unchanged — that's the regression guard.

## Test plan

- [x] `make lint` clean
- [x] `make typecheck` clean (0 errors)
- [x] `make test` — full unit suite green; existing tests covering `lithos_write` (version-conflict, slug-collision, content-too-large, task-scope invariant, expected_version) pass without modification
- [x] All new tests in `tests/test_intake.py` pass
- [x] CI integration scope (`tests/test_integration_conformance.py`, `tests/test_cli_contract.py`) — 108 passed, 0 failed (2 environmental errors from HuggingFace HEAD timeouts)
- [x] Targeted server suites: `TestErrorEnvelopes`, `TestSlugCollisionServerBoundary`, `TestWriteContentSizeLimit`, `TestWriteMutualExclusion`, `TestOptimisticLockingServerLayer` all pass
- [x] `tests/test_event_emission.py` and `tests/test_telemetry.py::TestTelemetryIntegration` pass

## Out of scope

The file-watcher path at `server.py:_on_file_event` runs a similar but distinct pipeline (event-first, see ADR-0003); it is **not** routed through intake in this change.