### PR TITLE
refactor(reconcile): KnowledgeGraph private plan/apply, dispatch via KM (#250)

### DIFF
--- a/src/lithos/graph.py
+++ b/src/lithos/graph.py
@@ -6,6 +6,7 @@ import logging
 import os
 import tempfile
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -13,7 +14,7 @@ from typing import Literal
 import networkx as nx
 
 from lithos.config import LithosConfig, get_config
-from lithos.knowledge import KnowledgeDocument
+from lithos.knowledge import KnowledgeDocument, parse_wiki_links
 from lithos.telemetry import StatusCode, get_tracer, traced
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,66 @@ class LinkInfo:
 
     outgoing: list[LinkedDocument]
     incoming: list[LinkedDocument]
+
+
+@dataclass(frozen=True)
+class GraphReconcileAction:
+    """A single action in a :class:`GraphReconcilePlan`.
+
+    ``target='graph_cache'`` with ``action='full_rebuild'`` means the cache
+    must be rebuilt from the corpus. ``target='wiki_link'`` with
+    ``action='stale_link'`` is report-only — the dangling target is surfaced
+    so the agent can fix or remove it, but the cache itself is fine.
+    """
+
+    target: Literal["graph_cache", "wiki_link"]
+    action: Literal["full_rebuild", "stale_link"]
+    reason: str
+    source_id: str | None = None
+    source_title: str | None = None
+    link_target: str | None = None
+    corpus_count: int | None = None
+    cached_count: int | None = None
+
+
+@dataclass(frozen=True)
+class GraphReconcileFailure:
+    """A graph rebuild that errored while applying a plan."""
+
+    detail: str
+
+
+@dataclass(frozen=True)
+class GraphReconcilePlan:
+    """The dry-run output of :meth:`KnowledgeGraph._plan_reconcile_to`.
+
+    Carries the corpus snapshot used to build the plan so applying it is
+    mechanical.
+    """
+
+    actions: tuple[GraphReconcileAction, ...]
+    docs: tuple[KnowledgeDocument, ...]
+    scanned: int
+
+    @property
+    def is_noop(self) -> bool:
+        """True when no drift was detected and no stale links exist."""
+        return not self.actions
+
+    @property
+    def needs_rebuild(self) -> bool:
+        """True when the plan includes a cache rebuild action."""
+        return any(a.action == "full_rebuild" for a in self.actions)
+
+
+@dataclass(frozen=True)
+class GraphReconcileResult:
+    """The outcome of applying a :class:`GraphReconcilePlan`."""
+
+    actions: tuple[GraphReconcileAction, ...]
+    repaired: int
+    failed: tuple[GraphReconcileFailure, ...]
+    scanned: int
 
 
 class KnowledgeGraph:
@@ -771,3 +832,123 @@ class KnowledgeGraph:
                     unresolved.append((node, link_text))
 
         return unresolved
+
+    def _plan_reconcile_to(self, docs: Iterable[KnowledgeDocument]) -> GraphReconcilePlan:
+        """Compute a :class:`GraphReconcilePlan` describing drift against *docs*.
+
+        Internal to :class:`~lithos.knowledge.KnowledgeManager` — agents call
+        ``KnowledgeManager.plan_reconcile``, which delegates here. Stores the
+        snapshot of *docs* on the plan so :meth:`_apply_reconcile` is mechanical.
+
+        Loads the on-disk cache as a side effect when present, so the same
+        instance can be passed to :meth:`_apply_reconcile`.
+        """
+        snapshot = tuple(docs)
+        actions: list[GraphReconcileAction] = []
+
+        cache_path = self.graph_cache_path
+        rebuild_needed = False
+
+        if not cache_path.exists():
+            actions.append(
+                GraphReconcileAction(
+                    target="graph_cache",
+                    action="full_rebuild",
+                    reason="cache_missing",
+                )
+            )
+            rebuild_needed = True
+        elif not self.load_cache():
+            actions.append(
+                GraphReconcileAction(
+                    target="graph_cache",
+                    action="full_rebuild",
+                    reason="cache_unreadable",
+                )
+            )
+            rebuild_needed = True
+        else:
+            corpus_ids = {doc.id for doc in snapshot}
+            cached_ids = self.get_doc_ids()
+            if cached_ids != corpus_ids:
+                actions.append(
+                    GraphReconcileAction(
+                        target="graph_cache",
+                        action="full_rebuild",
+                        reason="node_set_mismatch",
+                        corpus_count=len(corpus_ids),
+                        cached_count=len(cached_ids),
+                    )
+                )
+                rebuild_needed = True
+            else:
+                # Node set matches — check for edge/link-set drift.
+                # Compare raw (source_id, link_target_text) pairs so we don't
+                # need to re-resolve links through the lookup tables.
+                corpus_links: set[tuple[str, str]] = set()
+                for doc in snapshot:
+                    for link in parse_wiki_links(doc.content):
+                        corpus_links.add((doc.id, link.target))
+
+                cached_links: set[tuple[str, str]] = set()
+                for source, _target, data in self.graph.edges(data=True):
+                    link_text = data.get("link_text", "")
+                    if link_text:
+                        cached_links.add((source, link_text))
+
+                if corpus_links != cached_links:
+                    actions.append(
+                        GraphReconcileAction(
+                            target="graph_cache",
+                            action="full_rebuild",
+                            reason="edge_set_mismatch",
+                        )
+                    )
+                    rebuild_needed = True
+
+        if not rebuild_needed:
+            # Cache is consistent — scan for stale wiki-links (report-only).
+            for source_id, source_title, link_target in self.get_broken_links():
+                actions.append(
+                    GraphReconcileAction(
+                        target="wiki_link",
+                        action="stale_link",
+                        reason="target_slug_not_found",
+                        source_id=source_id,
+                        source_title=source_title,
+                        link_target=link_target,
+                    )
+                )
+
+        return GraphReconcilePlan(
+            actions=tuple(actions),
+            docs=snapshot,
+            scanned=len(snapshot),
+        )
+
+    def _apply_reconcile(self, plan: GraphReconcilePlan) -> GraphReconcileResult:
+        """Execute *plan* against the graph cache.
+
+        Idempotent — applying twice produces the same cache state. Stale-link
+        actions are report-only and require no work to apply.
+        """
+        repaired = 0
+        failures: list[GraphReconcileFailure] = []
+
+        if plan.needs_rebuild:
+            try:
+                self.clear()
+                for doc in plan.docs:
+                    self.add_document(doc)
+                self.save_cache()
+                repaired = 1
+            except Exception as exc:
+                logger.error("Failed to rebuild graph cache: %s", exc)
+                failures.append(GraphReconcileFailure(detail=str(exc)))
+
+        return GraphReconcileResult(
+            actions=plan.actions,
+            repaired=repaired,
+            failed=tuple(failures),
+            scanned=plan.scanned,
+        )

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -21,6 +21,11 @@ from lithos.errors import SlugCollisionError
 from lithos.telemetry import lithos_metrics, timed_write, traced
 
 if TYPE_CHECKING:
+    from lithos.graph import (
+        GraphReconcilePlan,
+        GraphReconcileResult,
+        KnowledgeGraph,
+    )
     from lithos.search import (
         IndexableDocument,
         SearchEngine,
@@ -625,18 +630,22 @@ _UNSET = _UnsetType()
 class ReconcilePlan:
     """Aggregate reconcile plan owned by :class:`KnowledgeManager`.
 
-    Carries one slice per derived view. Today only the search slice exists;
-    ``graph=`` and ``provenance=`` fields land in later ADR-0001 phases.
+    Carries one slice per derived view. ``search`` and ``graph`` are populated
+    when the corresponding engine is passed to
+    :meth:`KnowledgeManager.plan_reconcile`. The ``provenance`` slice lands in
+    a later ADR-0001 phase.
     """
 
-    search: "SearchReconcilePlan"
+    search: "SearchReconcilePlan | None" = None
+    graph: "GraphReconcilePlan | None" = None
 
 
 @dataclass(frozen=True)
 class ReconcileResult:
     """Outcome of applying a :class:`ReconcilePlan`."""
 
-    search: "SearchReconcileResult"
+    search: "SearchReconcileResult | None" = None
+    graph: "GraphReconcileResult | None" = None
 
 
 class KnowledgeManager:
@@ -677,19 +686,45 @@ class KnowledgeManager:
         docs, _ = await self.list_all(limit=total)
         return docs
 
-    async def plan_reconcile(self, search: "SearchEngine") -> ReconcilePlan:
+    async def plan_reconcile(
+        self,
+        search: "SearchEngine | None" = None,
+        graph: "KnowledgeGraph | None" = None,
+    ) -> ReconcilePlan:
         """Plan a reconcile of every derived view against the corpus.
 
-        Today only the search slice is populated. The ``graph`` and
-        ``provenance`` fields land in later ADR-0001 phases.
+        Slices are populated for the engines that are passed in. The
+        ``provenance`` slice lands in a later ADR-0001 phase.
         """
         corpus = await self._scan_corpus()
-        indexables = [self.to_indexable(d) for d in corpus]
-        return ReconcilePlan(search=search.plan_reconcile_to(indexables))
+        search_plan: SearchReconcilePlan | None = None
+        graph_plan: GraphReconcilePlan | None = None
+        if search is not None:
+            indexables = [self.to_indexable(d) for d in corpus]
+            search_plan = search.plan_reconcile_to(indexables)
+        if graph is not None:
+            graph_plan = graph._plan_reconcile_to(corpus)
+        return ReconcilePlan(search=search_plan, graph=graph_plan)
 
-    async def apply_reconcile(self, plan: ReconcilePlan, search: "SearchEngine") -> ReconcileResult:
-        """Apply *plan* — bringing each derived view back into agreement."""
-        return ReconcileResult(search=search.apply_reconcile(plan.search))
+    async def apply_reconcile(
+        self,
+        plan: ReconcilePlan,
+        search: "SearchEngine | None" = None,
+        graph: "KnowledgeGraph | None" = None,
+    ) -> ReconcileResult:
+        """Apply *plan* — bringing each derived view back into agreement.
+
+        Each slice is applied via the corresponding engine when both the slice
+        and engine are present; missing pairs are skipped silently so callers
+        can reconcile a single view without constructing the others.
+        """
+        search_result: SearchReconcileResult | None = None
+        graph_result: GraphReconcileResult | None = None
+        if plan.search is not None and search is not None:
+            search_result = search.apply_reconcile(plan.search)
+        if plan.graph is not None and graph is not None:
+            graph_result = graph._apply_reconcile(plan.graph)
+        return ReconcileResult(search=search_result, graph=graph_result)
 
     def __init__(self, config: LithosConfig):
         """Initialize knowledge manager.

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -19,8 +19,8 @@ import logging
 from typing import Any, Literal
 
 from lithos.config import LithosConfig, get_config
-from lithos.graph import KnowledgeGraph
-from lithos.knowledge import KnowledgeDocument, KnowledgeManager, parse_wiki_links
+from lithos.graph import GraphReconcileAction, KnowledgeGraph
+from lithos.knowledge import KnowledgeManager
 from lithos.search import SearchEngine
 from lithos.telemetry import get_tracer, lithos_metrics
 
@@ -62,17 +62,6 @@ def _make_result(
         "actions": actions or [],
         "failures": failures or [],
     }
-
-
-async def _scan_corpus(config: LithosConfig) -> list[KnowledgeDocument]:
-    """Backwards-compatibility shim around :meth:`KnowledgeManager._scan_corpus`.
-
-    The corpus scan itself moved onto :class:`KnowledgeManager` in #226 because
-    the corpus is its source of truth. This shim still feeds the
-    ``_reconcile_graph`` and ``_reconcile_provenance_projection`` paths; both
-    fold onto KM in later ADR-0001 phases, at which point this shim is deleted.
-    """
-    return await KnowledgeManager(config=config)._scan_corpus()
 
 
 def _aggregate_status(statuses: list[ReconcileStatus]) -> ReconcileStatus:
@@ -127,12 +116,14 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
             failures=[{"code": "internal_error", "detail": str(exc)}],
         )
 
+    assert plan.search is not None  # search engine was passed → slice is populated
+    search_plan = plan.search
     actions = [
-        {"backend": a.backend, "action": a.action, "reason": a.reason} for a in plan.search.actions
+        {"backend": a.backend, "action": a.action, "reason": a.reason} for a in search_plan.actions
     ]
-    scanned = plan.search.scanned
+    scanned = search_plan.scanned
 
-    if plan.search.is_noop:
+    if search_plan.is_noop:
         return _make_result("indices", dry_run, status="noop", scanned=scanned)
 
     if dry_run:
@@ -149,10 +140,12 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
         apply_span.set_attribute("lithos.reconcile.scope", "indices")
         result = await knowledge.apply_reconcile(plan, search)
 
-    repaired = result.search.repaired
+    assert result.search is not None
+    search_result = result.search
+    repaired = search_result.repaired
     failures = [
         {"code": "index_rebuild_failed", "backend": f.backend, "detail": f.detail}
-        for f in result.search.failed
+        for f in search_result.failed
     ]
     n_failed = len(failures)
 
@@ -192,121 +185,82 @@ async def _reconcile_indices(config: LithosConfig, dry_run: bool) -> dict[str, A
     )
 
 
-async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any]:
-    """Reconcile the wiki-link graph cache against the markdown corpus.
+def _action_to_dict(action: GraphReconcileAction) -> dict[str, Any]:
+    """Translate a structured graph action into the legacy dict shape."""
+    payload: dict[str, Any] = {
+        "target": action.target,
+        "action": action.action,
+        "reason": action.reason,
+    }
+    if action.source_id is not None:
+        payload["source_id"] = action.source_id
+    if action.source_title is not None:
+        payload["source_title"] = action.source_title
+    if action.link_target is not None:
+        payload["link_target"] = action.link_target
+    if action.corpus_count is not None:
+        payload["corpus_count"] = action.corpus_count
+    if action.cached_count is not None:
+        payload["cached_count"] = action.cached_count
+    return payload
 
-    When the cache is already consistent (no node/edge drift), a second pass
-    scans for stale wiki-links (targets that don't resolve to any document)
-    and reports them as ``stale_link`` actions.  Stale-link detection is
-    skipped when the cache itself needs a rebuild; the caller must reconcile
-    again after repair to surface stale links.
+
+async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any]:
+    """Reconcile the wiki-link graph cache via :class:`KnowledgeManager`.
+
+    KM owns the corpus scan and dispatches the graph slice; this function is
+    a thin adapter that translates the structured
+    :class:`~lithos.knowledge.ReconcilePlan` /
+    :class:`~lithos.knowledge.ReconcileResult` back into the legacy dict shape
+    the public :func:`reconcile` aggregator returns.
+
+    When the cache is already consistent (no node/edge drift), the planner
+    surfaces stale wiki-links as report-only ``stale_link`` actions. Stale-link
+    detection is skipped when the cache itself needs a rebuild; the caller
+    must reconcile again after repair to surface stale links.
     """
     tracer = get_tracer()
-    actions: list[dict[str, Any]] = []
-    failures: list[dict[str, Any]] = []
-
-    with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
-        scan_span.set_attribute("lithos.reconcile.scope", "graph")
-        try:
-            corpus_docs = await _scan_corpus(config)
-        except Exception as exc:
-            logger.error("Failed to scan corpus for graph reconcile: %s", exc)
-            return _make_result(
-                "graph",
-                dry_run,
-                status="failed",
-                failed=1,
-                failures=[{"code": "internal_error", "detail": str(exc)}],
-            )
 
     logger.info(
-        "reconcile graph started: dry_run=%s corpus_count=%d",
+        "reconcile graph started: dry_run=%s",
         dry_run,
-        len(corpus_docs),
-        extra={"scope": "graph", "dry_run": dry_run, "corpus_count": len(corpus_docs)},
+        extra={"scope": "graph", "dry_run": dry_run},
     )
+
+    knowledge = KnowledgeManager(config=config)
     graph = KnowledgeGraph(config)
-    with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
-        diff_span.set_attribute("lithos.reconcile.scope", "graph")
-        corpus_ids = {doc.id for doc in corpus_docs}
-        cache_path = graph.graph_cache_path
+    try:
+        with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
+            scan_span.set_attribute("lithos.reconcile.scope", "graph")
+            with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
+                diff_span.set_attribute("lithos.reconcile.scope", "graph")
+                plan = await knowledge.plan_reconcile(graph=graph)
+    except Exception as exc:
+        logger.error("Failed to plan graph reconcile: %s", exc)
+        return _make_result(
+            "graph",
+            dry_run,
+            status="failed",
+            failed=1,
+            failures=[{"code": "internal_error", "detail": str(exc)}],
+        )
 
-        if not cache_path.exists():
-            actions.append(
-                {"target": "graph_cache", "action": "full_rebuild", "reason": "cache_missing"}
-            )
-        else:
-            loaded = graph.load_cache()
-            if not loaded:
-                actions.append(
-                    {
-                        "target": "graph_cache",
-                        "action": "full_rebuild",
-                        "reason": "cache_unreadable",
-                    }
-                )
-            else:
-                cached_ids = graph.get_doc_ids()
-                if cached_ids != corpus_ids:
-                    actions.append(
-                        {
-                            "target": "graph_cache",
-                            "action": "full_rebuild",
-                            "reason": "node_set_mismatch",
-                            "corpus_count": len(corpus_ids),
-                            "cached_count": len(cached_ids),
-                        }
-                    )
-                else:
-                    # Node set matches — check for edge/link-set drift.
-                    # Compare raw (source_id, link_target_text) pairs so we
-                    # don't need to re-resolve links through the lookup tables.
-                    corpus_links: set[tuple[str, str]] = set()
-                    for doc in corpus_docs:
-                        for link in parse_wiki_links(doc.content):
-                            corpus_links.add((doc.id, link.target))
+    assert plan.graph is not None  # graph engine was passed → slice is populated
+    graph_plan = plan.graph
+    actions = [_action_to_dict(a) for a in graph_plan.actions]
+    scanned = graph_plan.scanned
 
-                    cached_links: set[tuple[str, str]] = set()
-                    for source, _target, data in graph.graph.edges(data=True):
-                        link_text = data.get("link_text", "")
-                        if link_text:
-                            cached_links.add((source, link_text))
+    if graph_plan.is_noop:
+        return _make_result("graph", dry_run, status="noop", scanned=scanned)
 
-                    if corpus_links != cached_links:
-                        actions.append(
-                            {
-                                "target": "graph_cache",
-                                "action": "full_rebuild",
-                                "reason": "edge_set_mismatch",
-                            }
-                        )
-
-    if not actions:
-        # Cache is consistent — scan for stale wiki-links (report-only, do NOT modify note content)
-        broken = graph.get_broken_links()
-        stale_actions: list[dict[str, Any]] = []
-        for source_id, source_title, link_target in broken:
-            stale_actions.append(
-                {
-                    "target": "wiki_link",
-                    "action": "stale_link",
-                    "source_id": source_id,
-                    "source_title": source_title,
-                    "link_target": link_target,
-                    "reason": "target_slug_not_found",
-                }
-            )
-
-        if not stale_actions:
-            return _make_result("graph", dry_run, status="noop", scanned=len(corpus_docs))
-
-        # Stale links detected — report them (no writes in either dry_run or real run)
+    if not graph_plan.needs_rebuild:
+        # Stale links only — report them (no writes in either dry_run or real run).
         return _make_result(
             "graph",
             dry_run,
             status="ok",
-            scanned=len(corpus_docs),
-            actions=stale_actions,
+            scanned=scanned,
+            actions=actions,
         )
 
     if dry_run:
@@ -314,27 +268,20 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
             "graph",
             dry_run,
             status="ok",
-            scanned=len(corpus_docs),
+            scanned=scanned,
             repaired=len(actions),
             actions=actions,
         )
 
-    # Apply repairs: full rebuild (always prefer full rebuild for graph)
-    repaired = 0
     with tracer.start_as_current_span("lithos.reconcile.apply") as apply_span:
         apply_span.set_attribute("lithos.reconcile.scope", "graph")
         apply_span.set_attribute("lithos.reconcile.backend", "graph")
-        try:
-            fresh_graph = KnowledgeGraph(config)
-            fresh_graph.clear()
-            for doc in corpus_docs:
-                fresh_graph.add_document(doc)
-            fresh_graph.save_cache()
-            repaired = 1
-        except Exception as exc:
-            logger.error("Failed to rebuild graph cache: %s", exc)
-            failures.append({"code": "graph_rebuild_failed", "detail": str(exc)})
+        result = await knowledge.apply_reconcile(plan, graph=graph)
 
+    assert result.graph is not None
+    graph_result = result.graph
+    repaired = graph_result.repaired
+    failures = [{"code": "graph_rebuild_failed", "detail": f.detail} for f in graph_result.failed]
     n_failed = len(failures)
     status: ReconcileStatus = "failed" if n_failed > 0 else "ok"
 
@@ -342,14 +289,14 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
     logger.info(
         "reconcile graph complete: status=%s scanned=%d repaired=%d failed=%d dry_run=%s",
         status,
-        len(corpus_docs),
+        scanned,
         repaired,
         n_failed,
         dry_run,
         extra={
             "scope": "graph",
             "status": status,
-            "scanned": len(corpus_docs),
+            "scanned": scanned,
             "repaired": repaired,
             "failed": n_failed,
             "dry_run": dry_run,
@@ -359,7 +306,7 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
         "graph",
         dry_run,
         status=status,
-        scanned=len(corpus_docs),
+        scanned=scanned,
         repaired=repaired,
         failed=n_failed,
         actions=actions,

--- a/tests/test_graph_reconcile.py
+++ b/tests/test_graph_reconcile.py
@@ -1,0 +1,273 @@
+"""Tests for KnowledgeGraph._plan_reconcile_to / _apply_reconcile (#250).
+
+ADR-0001 step 2: the wiki-link graph exposes a private plan/apply pair that
+KnowledgeManager dispatches through. These tests cover the round-trip plus
+KnowledgeManager.apply_reconcile integration; the broader behavioural
+coverage (cache_missing/unreadable, node/edge drift, stale links, crash
+safety) lives in test_reconcile.py and is unaffected by the migration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.graph import (
+    GraphReconcileAction,
+    GraphReconcilePlan,
+    GraphReconcileResult,
+    KnowledgeGraph,
+)
+from lithos.knowledge import KnowledgeManager
+
+
+async def _create_doc(knowledge: KnowledgeManager, title: str, content: str) -> str:
+    result = await knowledge.create(title=title, content=content, agent="test")
+    assert result.status == "created"
+    assert result.document is not None
+    return result.document.id
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraph._plan_reconcile_to
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_reports_cache_missing_when_no_cache_exists(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Empty filesystem → plan asks for a full rebuild with reason=cache_missing."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+    graph = KnowledgeGraph(test_config)
+    assert not graph.graph_cache_path.exists()
+
+    corpus = await knowledge_manager._scan_corpus()
+    plan = graph._plan_reconcile_to(corpus)
+
+    assert isinstance(plan, GraphReconcilePlan)
+    assert plan.scanned == 1
+    assert plan.needs_rebuild
+    assert any(a.reason == "cache_missing" for a in plan.actions)
+
+
+@pytest.mark.asyncio
+async def test_plan_is_noop_when_cache_matches_corpus(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Build a cache then re-plan — no drift → is_noop."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+    await _create_doc(knowledge_manager, "Beta", "Body beta links to [[alpha]].")
+
+    graph = KnowledgeGraph(test_config)
+    corpus = await knowledge_manager._scan_corpus()
+
+    # First pass builds and saves the cache.
+    first = graph._plan_reconcile_to(corpus)
+    assert first.needs_rebuild
+    graph._apply_reconcile(first)
+
+    # Second pass on a fresh KG instance reads the cache and reports noop.
+    fresh_graph = KnowledgeGraph(test_config)
+    second = fresh_graph._plan_reconcile_to(corpus)
+    assert second.is_noop
+    assert not second.needs_rebuild
+    assert second.actions == ()
+
+
+@pytest.mark.asyncio
+async def test_plan_reports_stale_links_when_cache_is_consistent(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Consistent cache + dangling [[...]] target → stale_link action surfaces."""
+    doc_id = await _create_doc(knowledge_manager, "Source", "Points to [[NoSuchTarget]].")
+
+    graph = KnowledgeGraph(test_config)
+    corpus = await knowledge_manager._scan_corpus()
+    graph._apply_reconcile(graph._plan_reconcile_to(corpus))
+
+    # Replan from a fresh instance: cache loads, no rebuild, stale link reported.
+    fresh_graph = KnowledgeGraph(test_config)
+    plan = fresh_graph._plan_reconcile_to(corpus)
+    assert not plan.needs_rebuild
+    stale = [a for a in plan.actions if a.action == "stale_link"]
+    assert len(stale) == 1
+    assert stale[0].source_id == doc_id
+    assert stale[0].link_target == "NoSuchTarget"
+    assert stale[0].reason == "target_slug_not_found"
+
+
+@pytest.mark.asyncio
+async def test_plan_reports_node_set_mismatch_after_doc_added(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Adding a doc after the cache was built → node_set_mismatch on next plan."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+
+    graph = KnowledgeGraph(test_config)
+    corpus_v1 = await knowledge_manager._scan_corpus()
+    graph._apply_reconcile(graph._plan_reconcile_to(corpus_v1))
+
+    # Add a second doc — corpus moves but the cache does not.
+    await _create_doc(knowledge_manager, "Beta", "Body beta.")
+    corpus_v2 = await knowledge_manager._scan_corpus()
+
+    fresh_graph = KnowledgeGraph(test_config)
+    plan = fresh_graph._plan_reconcile_to(corpus_v2)
+    assert plan.needs_rebuild
+    rebuilds = [a for a in plan.actions if a.action == "full_rebuild"]
+    assert any(a.reason == "node_set_mismatch" for a in rebuilds)
+    nsm = next(a for a in rebuilds if a.reason == "node_set_mismatch")
+    assert nsm.corpus_count == 2
+    assert nsm.cached_count == 1
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeGraph._apply_reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_round_trip_writes_cache_and_is_idempotent(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """plan → apply round trip: cache file is created and a re-plan is noop."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha [[beta]].")
+    await _create_doc(knowledge_manager, "Beta", "Body beta.")
+
+    graph = KnowledgeGraph(test_config)
+    corpus = await knowledge_manager._scan_corpus()
+
+    plan = graph._plan_reconcile_to(corpus)
+    result = graph._apply_reconcile(plan)
+
+    assert isinstance(result, GraphReconcileResult)
+    assert result.repaired == 1
+    assert result.failed == ()
+    assert graph.graph_cache_path.exists()
+
+    # Re-planning from a fresh KG must see no drift.
+    fresh = KnowledgeGraph(test_config)
+    assert fresh._plan_reconcile_to(corpus).is_noop
+
+
+@pytest.mark.asyncio
+async def test_apply_is_noop_when_plan_only_has_stale_links(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Stale-link actions are report-only — apply does no work, repaired=0."""
+    await _create_doc(knowledge_manager, "Source", "Links to [[NoSuchTarget]].")
+
+    graph = KnowledgeGraph(test_config)
+    corpus = await knowledge_manager._scan_corpus()
+    graph._apply_reconcile(graph._plan_reconcile_to(corpus))
+
+    fresh_graph = KnowledgeGraph(test_config)
+    plan = fresh_graph._plan_reconcile_to(corpus)
+    assert all(a.action == "stale_link" for a in plan.actions)
+
+    result = fresh_graph._apply_reconcile(plan)
+    assert result.repaired == 0
+    assert result.failed == ()
+    # Actions are echoed back unchanged for the caller's report.
+    assert result.actions == plan.actions
+
+
+@pytest.mark.asyncio
+async def test_apply_records_failure_when_save_cache_raises(
+    test_config: LithosConfig,
+    knowledge_manager: KnowledgeManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """save_cache exception is captured in result.failed without raising."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+
+    graph = KnowledgeGraph(test_config)
+    corpus = await knowledge_manager._scan_corpus()
+    plan = graph._plan_reconcile_to(corpus)
+
+    def boom(self: KnowledgeGraph) -> None:
+        raise RuntimeError("simulated cache write failure")
+
+    monkeypatch.setattr(KnowledgeGraph, "save_cache", boom)
+
+    result = graph._apply_reconcile(plan)
+    assert result.repaired == 0
+    assert len(result.failed) == 1
+    assert "simulated cache write failure" in result.failed[0].detail
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeManager dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_km_plan_reconcile_populates_graph_slice(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """KM.plan_reconcile(graph=...) puts a GraphReconcilePlan on the result."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+    graph = KnowledgeGraph(test_config)
+
+    plan = await knowledge_manager.plan_reconcile(graph=graph)
+
+    assert plan.search is None
+    assert plan.graph is not None
+    assert isinstance(plan.graph, GraphReconcilePlan)
+    assert plan.graph.scanned == 1
+    assert plan.graph.needs_rebuild
+
+
+@pytest.mark.asyncio
+async def test_km_apply_reconcile_dispatches_graph(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """KM.apply_reconcile(graph=...) rebuilds the graph and returns its result."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+    await _create_doc(knowledge_manager, "Beta", "Links to [[alpha]].")
+    graph = KnowledgeGraph(test_config)
+
+    plan = await knowledge_manager.plan_reconcile(graph=graph)
+    result = await knowledge_manager.apply_reconcile(plan, graph=graph)
+
+    assert result.search is None
+    assert result.graph is not None
+    assert result.graph.repaired == 1
+    assert result.graph.failed == ()
+    assert graph.graph_cache_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_km_skips_graph_when_engine_not_passed(
+    test_config: LithosConfig, knowledge_manager: KnowledgeManager
+) -> None:
+    """Without a graph engine the slice is left None — no implicit construction."""
+    await _create_doc(knowledge_manager, "Alpha", "Body alpha.")
+
+    plan = await knowledge_manager.plan_reconcile()
+
+    assert plan.search is None
+    assert plan.graph is None
+
+    result = await knowledge_manager.apply_reconcile(plan)
+    assert result.search is None
+    assert result.graph is None
+
+
+def test_graph_reconcile_action_carries_optional_metadata() -> None:
+    """Direct dataclass test — defaults match the dict-shape contract."""
+    bare = GraphReconcileAction(target="graph_cache", action="full_rebuild", reason="cache_missing")
+    assert bare.source_id is None
+    assert bare.corpus_count is None
+
+    enriched = GraphReconcileAction(
+        target="wiki_link",
+        action="stale_link",
+        reason="target_slug_not_found",
+        source_id="abc",
+        source_title="Source",
+        link_target="missing",
+    )
+    assert enriched.source_id == "abc"
+    assert enriched.link_target == "missing"


### PR DESCRIPTION
Closes #250.

## Summary

- Adds `KnowledgeGraph._plan_reconcile_to(docs) → GraphReconcilePlan` and `_apply_reconcile(plan) → GraphReconcileResult`, plus the supporting `GraphReconcileAction` / `GraphReconcileFailure` dataclasses. Leading underscore marks them as package-private — only `KnowledgeManager` should call them.
- Extends `KnowledgeManager.ReconcilePlan` / `ReconcileResult` with a `graph` slice. Both `search` and `graph` are now optional, so callers can reconcile a single view without constructing the other engine.
- `KnowledgeManager.plan_reconcile` / `apply_reconcile` accept `search=` and `graph=` independently and dispatch to the matching slices.
- `reconcile.py`'s graph branch becomes a thin adapter: it scans the corpus through `KnowledgeManager`, asks the manager to plan, and translates the structured plan/result back into the legacy dict shape the public `reconcile()` aggregator returns. The inline `fresh_graph.clear()` + per-doc rebuild loop is gone, along with the `_scan_corpus` shim that fed it.
- Per-action shape (target, action, reason, optional source/link/count fields) and stale-link semantics (report-only, never modifies note content) are preserved end-to-end.

## ADR-0001 progress

After this lands, `reconcile.py`'s indices and graph paths share one shape. Only the provenance projection step remains before the module can be deleted.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] `make test` — 1102 passed
- [x] `make test-integration` — same pre-existing flaky errors as `main` (telemetry/fixture isolation in test_smoke / test_telemetry / test_server). Each failing test passes when run in isolation; the diff vs `main` shows no regression introduced by this change.
- [x] New `tests/test_graph_reconcile.py` covers plan/apply round-trip, stale-link reporting, node-set drift, save_cache failure, and `KnowledgeManager.apply_reconcile` integration (11 tests).
- [x] Existing `tests/test_reconcile.py` graph cases still pass — they now exercise the new dispatch path end-to-end.