### PR TITLE
refactor(reconcile): ProvenanceProjection private plan/apply, dispatch via KM (#254)

### DIFF
--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
         GraphReconcileResult,
         KnowledgeGraph,
     )
+    from lithos.provenance import (
+        ProvenancePlan,
+        ProvenanceProjection,
+        ProvenanceResult,
+    )
     from lithos.search import (
         IndexableDocument,
         SearchEngine,
@@ -630,14 +635,13 @@ _UNSET = _UnsetType()
 class ReconcilePlan:
     """Aggregate reconcile plan owned by :class:`KnowledgeManager`.
 
-    Carries one slice per derived view. ``search`` and ``graph`` are populated
-    when the corresponding engine is passed to
-    :meth:`KnowledgeManager.plan_reconcile`. The ``provenance`` slice lands in
-    a later ADR-0001 phase.
+    Carries one slice per derived view. Each slice is populated when the
+    corresponding engine is passed to :meth:`KnowledgeManager.plan_reconcile`.
     """
 
     search: "SearchReconcilePlan | None" = None
     graph: "GraphReconcilePlan | None" = None
+    provenance: "ProvenancePlan | None" = None
 
 
 @dataclass(frozen=True)
@@ -646,6 +650,7 @@ class ReconcileResult:
 
     search: "SearchReconcileResult | None" = None
     graph: "GraphReconcileResult | None" = None
+    provenance: "ProvenanceResult | None" = None
 
 
 class KnowledgeManager:
@@ -690,27 +695,31 @@ class KnowledgeManager:
         self,
         search: "SearchEngine | None" = None,
         graph: "KnowledgeGraph | None" = None,
+        projection: "ProvenanceProjection | None" = None,
     ) -> ReconcilePlan:
         """Plan a reconcile of every derived view against the corpus.
 
-        Slices are populated for the engines that are passed in. The
-        ``provenance`` slice lands in a later ADR-0001 phase.
+        Slices are populated for the engines that are passed in.
         """
         corpus = await self._scan_corpus()
         search_plan: SearchReconcilePlan | None = None
         graph_plan: GraphReconcilePlan | None = None
+        provenance_plan: ProvenancePlan | None = None
         if search is not None:
             indexables = [self.to_indexable(d) for d in corpus]
             search_plan = search.plan_reconcile_to(indexables)
         if graph is not None:
             graph_plan = graph._plan_reconcile_to(corpus)
-        return ReconcilePlan(search=search_plan, graph=graph_plan)
+        if projection is not None:
+            provenance_plan = await projection._plan_reconcile_to(corpus)
+        return ReconcilePlan(search=search_plan, graph=graph_plan, provenance=provenance_plan)
 
     async def apply_reconcile(
         self,
         plan: ReconcilePlan,
         search: "SearchEngine | None" = None,
         graph: "KnowledgeGraph | None" = None,
+        projection: "ProvenanceProjection | None" = None,
     ) -> ReconcileResult:
         """Apply *plan* — bringing each derived view back into agreement.
 
@@ -720,11 +729,18 @@ class KnowledgeManager:
         """
         search_result: SearchReconcileResult | None = None
         graph_result: GraphReconcileResult | None = None
+        provenance_result: ProvenanceResult | None = None
         if plan.search is not None and search is not None:
             search_result = search.apply_reconcile(plan.search)
         if plan.graph is not None and graph is not None:
             graph_result = graph._apply_reconcile(plan.graph)
-        return ReconcileResult(search=search_result, graph=graph_result)
+        if plan.provenance is not None and projection is not None:
+            provenance_result = await projection._apply_reconcile(plan.provenance)
+        return ReconcileResult(
+            search=search_result,
+            graph=graph_result,
+            provenance=provenance_result,
+        )
 
     def __init__(self, config: LithosConfig):
         """Initialize knowledge manager.

--- a/src/lithos/provenance.py
+++ b/src/lithos/provenance.py
@@ -11,6 +11,7 @@ implementation details and must not be imported from outside this module.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal
@@ -32,6 +33,8 @@ from lithos.lcma.edges import (
     _project_node_provenance,  # noqa: F401  re-exported for transitional callers
     _project_provenance_to_edges,  # noqa: F401  consumed by lcma/enrich.py full_sweep
 )
+
+logger = logging.getLogger(__name__)
 
 # Public module API — only the façade and its plan/apply value types.
 __all__ = [
@@ -177,16 +180,37 @@ class ProvenanceProjection:
         # Track stale-column rows so apply can re-canonicalise them
         # (ADR-0004 row-ownership invariant).
         drifted_keys: set[tuple[str, str, str]] = set()
+        # Asserted rows (outside the predicate) that share a natural key
+        # with the projection. The schema is UNIQUE on (from_id, to_id,
+        # type, namespace) so two rows cannot coexist; the asserted row
+        # blocks the projection from materialising. Such rows survive
+        # reconcile untouched (ADR-0004 predicate-scoping invariant).
+        asserted_keys: set[tuple[str, str, str]] = set()
         for e in raw:
-            if e["provenance_type"] != self._CORPUS_DERIVED_PROVENANCE_TYPE:
-                continue
             key = (str(e["from_id"]), str(e["to_id"]), str(e["namespace"]))
-            existing_map[key] = str(e["edge_id"])
-            if self._has_column_drift(e):
-                drifted_keys.add(key)
+            if e["provenance_type"] == self._CORPUS_DERIVED_PROVENANCE_TYPE:
+                existing_map[key] = str(e["edge_id"])
+                if self._has_column_drift(e):
+                    drifted_keys.add(key)
+            else:
+                asserted_keys.add(key)
 
         existing_keys = set(existing_map.keys())
-        to_create = desired - existing_keys
+        # Genuinely new desired keys — those with no row at all. Desired
+        # keys whose slot is held by an asserted row are EXCLUDED here:
+        # creating one would silently clobber the asserted row through
+        # the UNIQUE-key upsert path. We log it and let the asserted row
+        # stand.
+        to_create = desired - existing_keys - asserted_keys
+        blocked = desired & asserted_keys
+        if blocked:
+            logger.warning(
+                "ProvenanceProjection: %d frontmatter-declared edge(s) blocked "
+                "by asserted rows at the same natural key; asserted edges "
+                "survive untouched per ADR-0004",
+                len(blocked),
+                extra={"blocked_keys": sorted(blocked)},
+            )
         to_remove = existing_keys - desired
         # Only resync rows that are both desired and drifted; orphans are
         # removed, not resynced.

--- a/src/lithos/provenance.py
+++ b/src/lithos/provenance.py
@@ -3,46 +3,99 @@
 See docs/adr/0004-provenance-projection-module.md.
 
 This Module wraps the SQLite-backed edge store and exposes a public
-**read-only** surface to callers. The store and the projection function
-under ``lcma/edges.py`` are package-internal implementation details and
-must not be imported from outside this module.
-
-Plan/apply reconciliation lands in a follow-up slice (#254) per ADR-0001
-step 3; this file intentionally does not expose them yet.
+**read-only** surface to callers plus a package-private plan/apply pair
+called only from :class:`~lithos.knowledge.KnowledgeManager`. The store
+and the projection helpers under ``lcma/edges.py`` are package-internal
+implementation details and must not be imported from outside this module.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
 
 from lithos.config import LithosConfig
+from lithos.knowledge import KnowledgeDocument, derive_namespace
 
 # This module is the single legitimate import site for the package-internal
-# edge store and the corpus-to-edges projection function (ADR-0004,
-# issue #251). The class and helper stay importable from here as
+# edge store and the corpus-to-edges projection helpers (ADR-0004,
+# issue #251). The class and helpers stay importable from here as
 # **undocumented transitional internals** — they are deliberately NOT
-# listed in ``__all__`` because the public surface of this slice is
-# ``ProvenanceProjection`` only. Callers that still need a direct
-# reference (type annotations in ``server.py`` / ``lcma/retrieve.py``,
-# fixture construction in tests, and the un-migrated helpers in
-# ``lcma/`` and ``reconcile.py``) should treat them as private until
-# their dedicated follow-ups land (#254 / #255 / #258 / #263). The
-# import-graph guard in #262 will enforce the rule mechanically.
+# listed in ``__all__``. The enrich worker's full sweep
+# (``lcma/enrich.py``) still consumes ``_project_provenance_to_edges``;
+# migrating that path through the projection's plan/apply is a separate
+# follow-up. The import-graph guard in #262 will enforce the rule
+# mechanically.
 from lithos.lcma.edges import (
     EdgeStore,
     _project_node_provenance,  # noqa: F401  re-exported for transitional callers
-    _project_provenance_to_edges,
+    _project_provenance_to_edges,  # noqa: F401  consumed by lcma/enrich.py full_sweep
 )
 
-if TYPE_CHECKING:
-    from lithos.knowledge import KnowledgeManager
+# Public module API — only the façade and its plan/apply value types.
+__all__ = [
+    "ProvenancePlan",
+    "ProvenanceProjection",
+    "ProvenanceReconcileAction",
+    "ProvenanceReconcileFailure",
+    "ProvenanceResult",
+]
 
-# Public module API — only the façade. The internal symbols above are
-# importable via ``from lithos.provenance import EdgeStore`` for the
-# transitional callers listed in the comment, but they are not part of
-# the documented interface and ``from lithos.provenance import *`` will
-# not pick them up.
-__all__ = ["ProvenanceProjection"]
+
+@dataclass(frozen=True)
+class ProvenanceReconcileAction:
+    """A single create or remove planned against the projection.
+
+    ``target='projection_edge'`` is the only target today. ``edge_id`` is
+    populated for ``remove`` actions (so apply can target the row by id)
+    and is ``None`` for ``create`` actions (the row does not exist yet).
+    """
+
+    target: Literal["projection_edge"]
+    action: Literal["create", "remove"]
+    from_id: str
+    to_id: str
+    namespace: str
+    edge_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ProvenanceReconcileFailure:
+    """An action that errored while applying a plan."""
+
+    detail: str
+
+
+@dataclass(frozen=True)
+class ProvenancePlan:
+    """The dry-run output of :meth:`ProvenanceProjection._plan_reconcile_to`.
+
+    ``supported`` is ``False`` when ``edges.db`` does not exist on disk
+    (LCMA storage not initialised). In that case ``actions`` is empty and
+    the plan is a no-op.
+    """
+
+    actions: tuple[ProvenanceReconcileAction, ...]
+    scanned: int
+    supported: bool = True
+
+    @property
+    def is_noop(self) -> bool:
+        """True when no drift was detected."""
+        return not self.actions
+
+
+@dataclass(frozen=True)
+class ProvenanceResult:
+    """The outcome of applying a :class:`ProvenancePlan`."""
+
+    actions: tuple[ProvenanceReconcileAction, ...]
+    created: int
+    removed: int
+    failed: tuple[ProvenanceReconcileFailure, ...]
+    scanned: int
+    supported: bool = True
 
 
 class ProvenanceProjection:
@@ -53,6 +106,13 @@ class ProvenanceProjection:
     store before returning, so no caller observes a half-initialised
     projection.
     """
+
+    # The Module-owned predicate that scopes plan/apply to corpus-derived
+    # edges. Today: ``provenance_type='frontmatter'``. Grows internally
+    # as the projection mirrors more frontmatter-declared lineage (ADR-0004).
+    # NEVER exposed to callers — they see the value type, not the predicate.
+    _CORPUS_DERIVED_PROVENANCE_TYPE: str = "frontmatter"
+    _CORPUS_DERIVED_EDGE_TYPE: str = "derived_from"
 
     def __init__(self, config: LithosConfig | None = None) -> None:
         self._config = config
@@ -69,24 +129,120 @@ class ProvenanceProjection:
         """Close the underlying store. Idempotent."""
         await self._edge_store.close()
 
-    # ---- transitional package-internal hook ----
+    # ---- package-private plan/apply (ADR-0001 step 3 / ADR-0004) ----
 
-    async def _project(self, knowledge: KnowledgeManager) -> dict[str, int]:
-        """Trigger the corpus-to-edges projection against this Module's store.
+    async def _plan_reconcile_to(self, docs: Iterable[KnowledgeDocument]) -> ProvenancePlan:
+        """Compute a :class:`ProvenancePlan` describing drift against *docs*.
 
-        **Transitional, package-internal.** This is a thin shim over the
-        package-internal projection helper so tests and any future
-        in-package callers can drive the projection without importing
-        ``_project_provenance_to_edges`` directly. The eventual public
-        surface is the plan/apply pair described in ADR-0004
-        (``_plan_reconcile_to`` / ``_apply_reconcile``), which lands in
-        issue #254 alongside ``KnowledgeManager.apply_reconcile``
-        dispatch. This method is expected to be removed at that point.
+        Package-private — agents call ``KnowledgeManager.plan_reconcile``,
+        which delegates here. Pure: never mutates the store.
 
-        Returns the ``{"created": N, "removed": M}`` dict produced by the
-        underlying helper.
+        Scoping is owned by this Module: only edges matching the
+        ``provenance_type='frontmatter'`` predicate are candidates for
+        removal. Agent-asserted edges with any other ``provenance_type``
+        survive reconcile untouched.
         """
-        return await _project_provenance_to_edges(self._edge_store, knowledge)
+        snapshot = tuple(docs)
+
+        if not self._edge_store.db_path.exists():
+            return ProvenancePlan(actions=(), scanned=len(snapshot), supported=False)
+
+        desired: set[tuple[str, str, str]] = set()
+        for doc in snapshot:
+            if not doc.metadata.derived_from_ids:
+                continue
+            ns = doc.metadata.namespace or derive_namespace(doc.path)
+            for source_id in doc.metadata.derived_from_ids:
+                desired.add((doc.id, source_id, ns))
+
+        raw = await self._edge_store.list_edges(edge_type=self._CORPUS_DERIVED_EDGE_TYPE)
+        existing_map: dict[tuple[str, str, str], str] = {}
+        for e in raw:
+            if e["provenance_type"] != self._CORPUS_DERIVED_PROVENANCE_TYPE:
+                continue
+            key = (str(e["from_id"]), str(e["to_id"]), str(e["namespace"]))
+            existing_map[key] = str(e["edge_id"])
+
+        existing_keys = set(existing_map.keys())
+        to_create = desired - existing_keys
+        to_remove = existing_keys - desired
+
+        actions: list[ProvenanceReconcileAction] = []
+        for from_id, to_id, ns in sorted(to_create):
+            actions.append(
+                ProvenanceReconcileAction(
+                    target="projection_edge",
+                    action="create",
+                    from_id=from_id,
+                    to_id=to_id,
+                    namespace=ns,
+                )
+            )
+        for key in sorted(to_remove):
+            from_id, to_id, ns = key
+            actions.append(
+                ProvenanceReconcileAction(
+                    target="projection_edge",
+                    action="remove",
+                    from_id=from_id,
+                    to_id=to_id,
+                    namespace=ns,
+                    edge_id=existing_map[key],
+                )
+            )
+
+        return ProvenancePlan(actions=tuple(actions), scanned=len(snapshot), supported=True)
+
+    async def _apply_reconcile(self, plan: ProvenancePlan) -> ProvenanceResult:
+        """Execute *plan* against the projection store. Idempotent."""
+        if not plan.supported:
+            return ProvenanceResult(
+                actions=(),
+                created=0,
+                removed=0,
+                failed=(),
+                scanned=plan.scanned,
+                supported=False,
+            )
+
+        created = 0
+        removed = 0
+        failures: list[ProvenanceReconcileFailure] = []
+        remove_edge_ids: list[str] = []
+
+        for act in plan.actions:
+            if act.action == "create":
+                try:
+                    await self._edge_store.upsert(
+                        from_id=act.from_id,
+                        to_id=act.to_id,
+                        edge_type=self._CORPUS_DERIVED_EDGE_TYPE,
+                        weight=1.0,
+                        namespace=act.namespace,
+                        provenance_type=self._CORPUS_DERIVED_PROVENANCE_TYPE,
+                    )
+                    created += 1
+                except Exception as exc:
+                    failures.append(ProvenanceReconcileFailure(detail=str(exc)))
+            elif act.action == "remove":
+                assert act.edge_id is not None
+                remove_edge_ids.append(act.edge_id)
+
+        if remove_edge_ids:
+            try:
+                await self._edge_store.delete_edges(edge_ids=remove_edge_ids)
+                removed = len(remove_edge_ids)
+            except Exception as exc:
+                failures.append(ProvenanceReconcileFailure(detail=str(exc)))
+
+        return ProvenanceResult(
+            actions=plan.actions,
+            created=created,
+            removed=removed,
+            failed=tuple(failures),
+            scanned=plan.scanned,
+            supported=True,
+        )
 
     # ---- public read API ----
 

--- a/src/lithos/provenance.py
+++ b/src/lithos/provenance.py
@@ -45,15 +45,23 @@ __all__ = [
 
 @dataclass(frozen=True)
 class ProvenanceReconcileAction:
-    """A single create or remove planned against the projection.
+    """A single create, remove, or resync planned against the projection.
 
-    ``target='projection_edge'`` is the only target today. ``edge_id`` is
-    populated for ``remove`` actions (so apply can target the row by id)
-    and is ``None`` for ``create`` actions (the row does not exist yet).
+    ``target='projection_edge'`` is the only target today.
+
+    - ``action='create'``: the (from_id, to_id, namespace) key is desired by
+      frontmatter but absent from the projection. ``edge_id`` is ``None``.
+    - ``action='remove'``: the key exists in the projection with the
+      frontmatter predicate but is no longer desired. ``edge_id`` carries the
+      row id so apply can target it directly.
+    - ``action='resync'``: the key exists and is desired, but its non-key
+      columns drifted from canonical values (the ADR-0004 row-ownership
+      invariant). Apply re-canonicalises via ``EdgeStore.upsert``. ``edge_id``
+      carries the row id for log diagnostics.
     """
 
     target: Literal["projection_edge"]
-    action: Literal["create", "remove"]
+    action: Literal["create", "remove", "resync"]
     from_id: str
     to_id: str
     namespace: str
@@ -93,6 +101,7 @@ class ProvenanceResult:
     actions: tuple[ProvenanceReconcileAction, ...]
     created: int
     removed: int
+    resynced: int
     failed: tuple[ProvenanceReconcileFailure, ...]
     scanned: int
     supported: bool = True
@@ -113,6 +122,14 @@ class ProvenanceProjection:
     # NEVER exposed to callers — they see the value type, not the predicate.
     _CORPUS_DERIVED_PROVENANCE_TYPE: str = "frontmatter"
     _CORPUS_DERIVED_EDGE_TYPE: str = "derived_from"
+
+    # Canonical column values for a frontmatter-provenanced row. The
+    # projection owns these columns (ADR-0004 row-ownership invariant);
+    # any deviation is drift that ``_apply_reconcile`` re-canonicalises.
+    _CANONICAL_WEIGHT: float = 1.0
+    _CANONICAL_PROVENANCE_ACTOR: str | None = None
+    _CANONICAL_EVIDENCE: str | None = None
+    _CANONICAL_CONFLICT_STATE: str | None = None
 
     def __init__(self, config: LithosConfig | None = None) -> None:
         self._config = config
@@ -157,15 +174,23 @@ class ProvenanceProjection:
 
         raw = await self._edge_store.list_edges(edge_type=self._CORPUS_DERIVED_EDGE_TYPE)
         existing_map: dict[tuple[str, str, str], str] = {}
+        # Track stale-column rows so apply can re-canonicalise them
+        # (ADR-0004 row-ownership invariant).
+        drifted_keys: set[tuple[str, str, str]] = set()
         for e in raw:
             if e["provenance_type"] != self._CORPUS_DERIVED_PROVENANCE_TYPE:
                 continue
             key = (str(e["from_id"]), str(e["to_id"]), str(e["namespace"]))
             existing_map[key] = str(e["edge_id"])
+            if self._has_column_drift(e):
+                drifted_keys.add(key)
 
         existing_keys = set(existing_map.keys())
         to_create = desired - existing_keys
         to_remove = existing_keys - desired
+        # Only resync rows that are both desired and drifted; orphans are
+        # removed, not resynced.
+        to_resync = (desired & existing_keys) & drifted_keys
 
         actions: list[ProvenanceReconcileAction] = []
         for from_id, to_id, ns in sorted(to_create):
@@ -176,6 +201,18 @@ class ProvenanceProjection:
                     from_id=from_id,
                     to_id=to_id,
                     namespace=ns,
+                )
+            )
+        for key in sorted(to_resync):
+            from_id, to_id, ns = key
+            actions.append(
+                ProvenanceReconcileAction(
+                    target="projection_edge",
+                    action="resync",
+                    from_id=from_id,
+                    to_id=to_id,
+                    namespace=ns,
+                    edge_id=existing_map[key],
                 )
             )
         for key in sorted(to_remove):
@@ -193,13 +230,36 @@ class ProvenanceProjection:
 
         return ProvenancePlan(actions=tuple(actions), scanned=len(snapshot), supported=True)
 
+    def _has_column_drift(self, row: dict[str, object]) -> bool:
+        """True when *row* deviates from canonical column values.
+
+        Compares the non-key columns the projection owns
+        (``weight``, ``provenance_actor``, ``evidence``, ``conflict_state``)
+        against their canonical values for a frontmatter-provenanced edge.
+        """
+        return (
+            row.get("weight") != self._CANONICAL_WEIGHT
+            or row.get("provenance_actor") != self._CANONICAL_PROVENANCE_ACTOR
+            or row.get("evidence") != self._CANONICAL_EVIDENCE
+            or row.get("conflict_state") != self._CANONICAL_CONFLICT_STATE
+        )
+
     async def _apply_reconcile(self, plan: ProvenancePlan) -> ProvenanceResult:
-        """Execute *plan* against the projection store. Idempotent."""
+        """Execute *plan* against the projection store. Idempotent.
+
+        ``create`` and ``resync`` actions both route through
+        :meth:`EdgeStore.upsert` with canonical column values — the same
+        SQL path handles insert and full-column rewrite, so applying a
+        ``resync`` re-canonicalises ``weight``, ``provenance_actor``,
+        ``evidence``, and ``conflict_state`` for rows that drifted from
+        the ADR-0004 invariant.
+        """
         if not plan.supported:
             return ProvenanceResult(
                 actions=(),
                 created=0,
                 removed=0,
+                resynced=0,
                 failed=(),
                 scanned=plan.scanned,
                 supported=False,
@@ -207,21 +267,28 @@ class ProvenanceProjection:
 
         created = 0
         removed = 0
+        resynced = 0
         failures: list[ProvenanceReconcileFailure] = []
         remove_edge_ids: list[str] = []
 
         for act in plan.actions:
-            if act.action == "create":
+            if act.action in ("create", "resync"):
                 try:
                     await self._edge_store.upsert(
                         from_id=act.from_id,
                         to_id=act.to_id,
                         edge_type=self._CORPUS_DERIVED_EDGE_TYPE,
-                        weight=1.0,
+                        weight=self._CANONICAL_WEIGHT,
                         namespace=act.namespace,
+                        provenance_actor=self._CANONICAL_PROVENANCE_ACTOR,
                         provenance_type=self._CORPUS_DERIVED_PROVENANCE_TYPE,
+                        evidence=self._CANONICAL_EVIDENCE,
+                        conflict_state=self._CANONICAL_CONFLICT_STATE,
                     )
-                    created += 1
+                    if act.action == "create":
+                        created += 1
+                    else:
+                        resynced += 1
                 except Exception as exc:
                     failures.append(ProvenanceReconcileFailure(detail=str(exc)))
             elif act.action == "remove":
@@ -239,6 +306,7 @@ class ProvenanceProjection:
             actions=plan.actions,
             created=created,
             removed=removed,
+            resynced=resynced,
             failed=tuple(failures),
             scanned=plan.scanned,
             supported=True,

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -315,20 +315,42 @@ async def _reconcile_graph(config: LithosConfig, dry_run: bool) -> dict[str, Any
 
 
 async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) -> dict[str, Any]:
-    """Reconcile projected LCMA ``derived_from`` edges in ``edges.db``.
+    """Reconcile projected LCMA ``derived_from`` edges via :class:`KnowledgeManager`.
 
-    Walks every note's frontmatter ``derived_from_ids`` and ensures
-    ``edges.db`` has a matching ``type='derived_from'`` edge, creating
-    missing edges and removing orphan projections. Returns
-    ``supported=False`` when ``edges.db`` does not exist (LCMA disabled).
+    KM owns the corpus scan and dispatches the provenance slice through
+    :class:`~lithos.provenance.ProvenanceProjection` (ADR-0001 step 3 /
+    ADR-0004). This function is a thin adapter that translates the
+    structured :class:`~lithos.knowledge.ReconcilePlan` /
+    :class:`~lithos.knowledge.ReconcileResult` back into the legacy dict
+    shape the public :func:`reconcile` aggregator returns.
+
+    Returns ``supported=False`` when ``edges.db`` does not exist
+    (LCMA storage not initialised) — the projection's plan/apply pair
+    reports this via ``plan.provenance.supported``.
 
     Markdown/frontmatter is the source of truth — this function only
     mutates the derived edge projection.
     """
-    from lithos.provenance import EdgeStore, _project_provenance_to_edges
+    from lithos.provenance import ProvenanceProjection
 
+    tracer = get_tracer()
+
+    logger.info(
+        "reconcile provenance_projection started: dry_run=%s",
+        dry_run,
+        extra={"scope": "provenance_projection", "dry_run": dry_run},
+    )
+
+    # Short-circuit before opening the projection: ``ProvenanceProjection.create``
+    # eagerly opens the edge store, which creates ``edges.db`` if absent. The
+    # CLI/operator surface keeps treating a missing ``edges.db`` as "LCMA not
+    # enabled" (``supported=False``) rather than implicitly initialising
+    # storage. The projection's own plan/apply also reports
+    # ``plan.supported=False`` in this case, but checking here avoids the
+    # side-effect of creating the file just to ask the question.
     edges_db = config.storage.data_dir / ".lithos" / "edges.db"
     if not edges_db.exists():
+        lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": "noop"})
         return _make_result(
             "provenance_projection",
             dry_run,
@@ -337,42 +359,130 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
             actions=[{"reason": "not_enabled"}],
         )
 
-    edge_store = EdgeStore(config=config)
     knowledge = KnowledgeManager(config=config)
-
+    projection = await ProvenanceProjection.create(config)
     try:
-        counts = await _project_provenance_to_edges(edge_store, knowledge, dry_run=dry_run)
-    except Exception as exc:
-        logger.error("provenance_projection reconcile failed: %s", exc)
-        lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": "failed"})
+        try:
+            with tracer.start_as_current_span("lithos.reconcile.scan") as scan_span:
+                scan_span.set_attribute("lithos.reconcile.scope", "provenance_projection")
+                with tracer.start_as_current_span("lithos.reconcile.diff") as diff_span:
+                    diff_span.set_attribute("lithos.reconcile.scope", "provenance_projection")
+                    plan = await knowledge.plan_reconcile(projection=projection)
+        except Exception as exc:
+            logger.error("provenance_projection reconcile plan failed: %s", exc)
+            lithos_metrics.reconcile_ops.add(
+                1, {"scope": "provenance_projection", "status": "failed"}
+            )
+            return _make_result(
+                "provenance_projection",
+                dry_run,
+                supported=True,
+                status="failed",
+                failed=1,
+                failures=[{"code": "internal_error", "detail": str(exc)}],
+            )
+
+        assert plan.provenance is not None  # projection was passed → slice present
+        prov_plan = plan.provenance
+
+        if not prov_plan.supported:
+            return _make_result(
+                "provenance_projection",
+                dry_run,
+                supported=False,
+                status="noop",
+                actions=[{"reason": "not_enabled"}],
+            )
+
+        created_planned = sum(1 for a in prov_plan.actions if a.action == "create")
+        removed_planned = sum(1 for a in prov_plan.actions if a.action == "remove")
+
+        if prov_plan.is_noop:
+            lithos_metrics.reconcile_ops.add(
+                1, {"scope": "provenance_projection", "status": "noop"}
+            )
+            return _make_result(
+                "provenance_projection",
+                dry_run,
+                supported=True,
+                status="noop",
+                repaired=0,
+                actions=[{"created": 0, "removed": 0}],
+            )
+
+        if dry_run:
+            lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": "ok"})
+            return _make_result(
+                "provenance_projection",
+                dry_run,
+                supported=True,
+                status="ok",
+                repaired=created_planned + removed_planned,
+                actions=[{"created": created_planned, "removed": removed_planned}],
+            )
+
+        try:
+            with tracer.start_as_current_span("lithos.reconcile.apply") as apply_span:
+                apply_span.set_attribute("lithos.reconcile.scope", "provenance_projection")
+                apply_span.set_attribute("lithos.reconcile.backend", "provenance_projection")
+                result = await knowledge.apply_reconcile(plan, projection=projection)
+        except Exception as exc:
+            logger.error("provenance_projection reconcile apply failed: %s", exc)
+            lithos_metrics.reconcile_ops.add(
+                1, {"scope": "provenance_projection", "status": "failed"}
+            )
+            return _make_result(
+                "provenance_projection",
+                dry_run,
+                supported=True,
+                status="failed",
+                failed=1,
+                failures=[{"code": "internal_error", "detail": str(exc)}],
+            )
+
+        assert result.provenance is not None
+        prov_result = result.provenance
+        created = prov_result.created
+        removed = prov_result.removed
+        failures = [
+            {"code": "projection_apply_failed", "detail": f.detail} for f in prov_result.failed
+        ]
+        n_failed = len(failures)
+        status: ReconcileStatus = "failed" if n_failed > 0 else "ok"
+        lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": status})
+        logger.info(
+            "reconcile provenance_projection complete: status=%s created=%d "
+            "removed=%d failed=%d dry_run=%s",
+            status,
+            created,
+            removed,
+            n_failed,
+            dry_run,
+            extra={
+                "scope": "provenance_projection",
+                "status": status,
+                "edges_created": created,
+                "edges_removed": removed,
+                "failed": n_failed,
+                "dry_run": dry_run,
+            },
+        )
         return _make_result(
             "provenance_projection",
             dry_run,
             supported=True,
-            status="failed",
-            failed=1,
-            failures=[{"code": "internal_error", "detail": str(exc)}],
+            status=status,
+            repaired=created + removed,
+            failed=n_failed,
+            actions=[{"created": created, "removed": removed}],
+            failures=failures,
         )
     finally:
         # Close the persistent connection so the aiosqlite worker thread
         # exits cleanly. Otherwise it survives function return, eventually
         # touches a torn-down event loop, and emits "Event loop is closed"
         # warnings (and on CI, hangs the whole job until timeout) (#172).
-        await edge_store.close()
-
-    created = int(counts.get("created", 0))
-    removed = int(counts.get("removed", 0))
-    repaired = created + removed
-    status: ReconcileStatus = "ok" if repaired > 0 else "noop"
-    lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": status})
-    return _make_result(
-        "provenance_projection",
-        dry_run,
-        supported=True,
-        status=status,
-        repaired=repaired,
-        actions=[{"created": created, "removed": removed}],
-    )
+        await projection.close()
 
 
 # ---------------------------------------------------------------------------

--- a/src/lithos/reconcile.py
+++ b/src/lithos/reconcile.py
@@ -396,6 +396,16 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
 
         created_planned = sum(1 for a in prov_plan.actions if a.action == "create")
         removed_planned = sum(1 for a in prov_plan.actions if a.action == "remove")
+        resynced_planned = sum(1 for a in prov_plan.actions if a.action == "resync")
+
+        def _action_dict(created: int, removed: int, resynced: int) -> dict[str, int]:
+            """Legacy dict shape; `resynced` is only present when non-zero
+            so existing CLI consumers and tests asserting `{created, removed}`
+            equality keep working when no column drift was repaired."""
+            payload = {"created": created, "removed": removed}
+            if resynced:
+                payload["resynced"] = resynced
+            return payload
 
         if prov_plan.is_noop:
             lithos_metrics.reconcile_ops.add(
@@ -407,7 +417,7 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
                 supported=True,
                 status="noop",
                 repaired=0,
-                actions=[{"created": 0, "removed": 0}],
+                actions=[_action_dict(0, 0, 0)],
             )
 
         if dry_run:
@@ -417,8 +427,8 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
                 dry_run,
                 supported=True,
                 status="ok",
-                repaired=created_planned + removed_planned,
-                actions=[{"created": created_planned, "removed": removed_planned}],
+                repaired=created_planned + removed_planned + resynced_planned,
+                actions=[_action_dict(created_planned, removed_planned, resynced_planned)],
             )
 
         try:
@@ -444,6 +454,7 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
         prov_result = result.provenance
         created = prov_result.created
         removed = prov_result.removed
+        resynced = prov_result.resynced
         failures = [
             {"code": "projection_apply_failed", "detail": f.detail} for f in prov_result.failed
         ]
@@ -452,10 +463,11 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
         lithos_metrics.reconcile_ops.add(1, {"scope": "provenance_projection", "status": status})
         logger.info(
             "reconcile provenance_projection complete: status=%s created=%d "
-            "removed=%d failed=%d dry_run=%s",
+            "removed=%d resynced=%d failed=%d dry_run=%s",
             status,
             created,
             removed,
+            resynced,
             n_failed,
             dry_run,
             extra={
@@ -463,6 +475,7 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
                 "status": status,
                 "edges_created": created,
                 "edges_removed": removed,
+                "edges_resynced": resynced,
                 "failed": n_failed,
                 "dry_run": dry_run,
             },
@@ -472,9 +485,9 @@ async def _reconcile_provenance_projection(config: LithosConfig, dry_run: bool) 
             dry_run,
             supported=True,
             status=status,
-            repaired=created + removed,
+            repaired=created + removed + resynced,
             failed=n_failed,
-            actions=[{"created": created, "removed": removed}],
+            actions=[_action_dict(created, removed, resynced)],
             failures=failures,
         )
     finally:

--- a/tests/test_provenance_projection.py
+++ b/tests/test_provenance_projection.py
@@ -1,7 +1,12 @@
 """Tests for US-012: Internal provenance-to-edges projection.
 
 Unit tests cover: forward projection, stale edge removal, idempotent
-repeat runs, and no-op when edges.db absent.
+repeat runs, predicate scoping (issue #254), and no-op when edges.db
+absent.
+
+Mutation flows through the package-private plan/apply pair on
+``ProvenanceProjection`` (ADR-0004), dispatched via
+``KnowledgeManager.plan_reconcile`` / ``apply_reconcile``.
 """
 
 from __future__ import annotations
@@ -14,7 +19,23 @@ import pytest
 
 from lithos.config import LithosConfig, StorageConfig
 from lithos.knowledge import KnowledgeManager
-from lithos.provenance import ProvenanceProjection
+from lithos.provenance import ProvenancePlan, ProvenanceProjection, ProvenanceResult
+
+
+async def _reconcile_via_km(
+    km: KnowledgeManager, projection: ProvenanceProjection
+) -> ProvenanceResult:
+    """Plan and apply a provenance reconcile through the public KM seam.
+
+    Used by tests that previously called the transitional
+    ``projection._project(km)`` hook (removed in #254).
+    """
+    plan = await km.plan_reconcile(projection=projection)
+    assert plan.provenance is not None
+    result = await km.apply_reconcile(plan, projection=projection)
+    assert result.provenance is not None
+    return result.provenance
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -99,13 +120,11 @@ def seeded_km(seeded_config: LithosConfig) -> KnowledgeManager:
 async def projection(seeded_config: LithosConfig):
     """Open a ProvenanceProjection (and its underlying edge store) for the test.
 
-    Tests below drive the package-internal projection helper through the
-    façade's transitional ``_project`` method (see
-    ``ProvenanceProjection._project``) and read back via the public
-    ``list_edges`` API. Mutations that have no public surface yet
-    (e.g. ``upsert`` for the ``test_does_not_remove_non_derived_from_edges``
-    setup) reach in via ``projection._edge_store`` until the plan/apply
-    pair lands in #254.
+    Tests drive plan/apply through :func:`_reconcile_via_km` and read back
+    via the public ``list_edges`` API. Edges that have no equivalent on
+    the public surface (e.g. agent-asserted edges with
+    ``provenance_type != 'frontmatter'`` used in predicate-scoping tests)
+    are inserted via ``projection._edge_store`` directly.
     """
     proj = await ProvenanceProjection.create(seeded_config)
     try:
@@ -125,10 +144,10 @@ class TestForwardProjection:
         self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
     ) -> None:
         """Projection creates derived_from edge for Gamma -> Alpha."""
-        result = await projection._project(seeded_km)
+        result = await _reconcile_via_km(seeded_km, projection)
 
-        assert result["created"] == 1
-        assert result["removed"] == 0
+        assert result.created == 1
+        assert result.removed == 0
 
         edges = await projection.list_edges(edge_type="derived_from")
         assert len(edges) == 1
@@ -155,9 +174,9 @@ class TestForwardProjection:
         )
         km = KnowledgeManager(seeded_config)
 
-        result = await projection._project(km)
+        result = await _reconcile_via_km(km, projection)
 
-        assert result["created"] == 2
+        assert result.created == 2
         edges = await projection.list_edges(edge_type="derived_from")
         assert len(edges) == 2
         to_ids = {str(e["to_id"]) for e in edges}
@@ -169,7 +188,7 @@ class TestForwardProjection:
     ) -> None:
         """Edge namespace is derived from the document's relative path
         when no explicit override is set in frontmatter."""
-        await projection._project(seeded_km)
+        await _reconcile_via_km(seeded_km, projection)
         edges = await projection.list_edges(edge_type="derived_from")
         # Gamma is in projects/ subdir → namespace = "projects"
         assert len(edges) == 1
@@ -206,8 +225,8 @@ class TestForwardProjection:
 
         km = KnowledgeManager(seeded_config)
 
-        result = await projection._project(km)
-        assert result["created"] == 1
+        result = await _reconcile_via_km(km, projection)
+        assert result.created == 1
 
         edges = await projection.list_edges(edge_type="derived_from")
         assert len(edges) == 1
@@ -237,17 +256,17 @@ class TestStaleEdgeRemoval:
         km = KnowledgeManager(seeded_config)
 
         # First projection: creates 1 edge
-        r1 = await projection._project(km)
-        assert r1["created"] == 1
+        r1 = await _reconcile_via_km(km, projection)
+        assert r1.created == 1
 
         # Now rewrite Child without derived_from_ids
         _write_note(kp, doc_id=_ID2, title="Child", content="Child content updated")
         km2 = KnowledgeManager(seeded_config)
 
         # Second projection: should remove the orphan
-        r2 = await projection._project(km2)
-        assert r2["removed"] == 1
-        assert r2["created"] == 0
+        r2 = await _reconcile_via_km(km2, projection)
+        assert r2.removed == 1
+        assert r2.created == 0
 
         edges = await projection.list_edges(edge_type="derived_from")
         assert len(edges) == 0
@@ -270,9 +289,9 @@ class TestStaleEdgeRemoval:
             namespace="default",
         )
 
-        result = await projection._project(km)
-        assert result["created"] == 0
-        assert result["removed"] == 0
+        result = await _reconcile_via_km(km, projection)
+        assert result.created == 0
+        assert result.removed == 0
 
         # The related_to edge must still exist
         other_edges = await projection.list_edges(edge_type="related_to")
@@ -290,12 +309,12 @@ class TestIdempotent:
         self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
     ) -> None:
         """Running projection twice with same data creates nothing on second run."""
-        r1 = await projection._project(seeded_km)
-        assert r1["created"] == 1
+        r1 = await _reconcile_via_km(seeded_km, projection)
+        assert r1.created == 1
 
-        r2 = await projection._project(seeded_km)
-        assert r2["created"] == 0
-        assert r2["removed"] == 0
+        r2 = await _reconcile_via_km(seeded_km, projection)
+        assert r2.created == 0
+        assert r2.removed == 0
 
         edges = await projection.list_edges(edge_type="derived_from")
         assert len(edges) == 1
@@ -305,11 +324,11 @@ class TestIdempotent:
         self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
     ) -> None:
         """The edge_id from first projection is preserved on subsequent runs."""
-        await projection._project(seeded_km)
+        await _reconcile_via_km(seeded_km, projection)
         edges_before = await projection.list_edges(edge_type="derived_from")
         edge_id_before = edges_before[0]["edge_id"]
 
-        await projection._project(seeded_km)
+        await _reconcile_via_km(seeded_km, projection)
         edges_after = await projection.list_edges(edge_type="derived_from")
         assert edges_after[0]["edge_id"] == edge_id_before
 
@@ -324,14 +343,17 @@ class TestNoOpWhenAbsent:
     async def test_noop_when_edges_db_missing(
         self, seeded_config: LithosConfig, seeded_km: KnowledgeManager
     ) -> None:
-        """Returns zeros and does nothing when edges.db does not exist."""
+        """plan/apply reports supported=False when edges.db does not exist."""
         # Construct the projection without ``create()`` so the underlying
         # store is *not* opened — edges.db must not exist for this test.
         proj = ProvenanceProjection(seeded_config)
         assert not proj._edge_store.db_path.exists()
 
-        result = await proj._project(seeded_km)
-        assert result == {"created": 0, "removed": 0}
+        result = await _reconcile_via_km(seeded_km, proj)
+        assert result.supported is False
+        assert result.created == 0
+        assert result.removed == 0
+        assert result.actions == ()
         assert not proj._edge_store.db_path.exists()
 
 
@@ -636,3 +658,206 @@ class TestProvenanceProjectionListEdgesBetween:
         rows = await projection.list_edges_between(["a", "b"], edge_type="t1")
         assert len(rows) == 1
         assert rows[0]["type"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# Plan/apply pair + KnowledgeManager dispatch (issue #254 / ADR-0001 step 3)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenancePlanApply:
+    """Package-private plan/apply pair on :class:`ProvenanceProjection`.
+
+    Covers: plan shape, predicate scoping (the central ADR-0004B
+    invariant), round-trip idempotence, and dispatch via
+    :class:`KnowledgeManager`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_plan_reports_supported_false_when_edges_db_missing(
+        self, seeded_config: LithosConfig, seeded_km: KnowledgeManager
+    ) -> None:
+        """plan.supported is False (and noop) when edges.db is absent."""
+        proj = ProvenanceProjection(seeded_config)
+        assert not proj._edge_store.db_path.exists()
+
+        plan = await seeded_km.plan_reconcile(projection=proj)
+        assert plan.provenance is not None
+        assert plan.provenance.supported is False
+        assert plan.provenance.actions == ()
+        assert plan.provenance.is_noop is True
+
+    @pytest.mark.asyncio
+    async def test_plan_is_noop_when_projection_matches_corpus(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """After applying once, re-planning produces an empty plan."""
+        await _reconcile_via_km(seeded_km, projection)
+
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert plan.provenance.supported is True
+        assert plan.provenance.is_noop is True
+        assert plan.provenance.actions == ()
+
+    @pytest.mark.asyncio
+    async def test_plan_creates_action_for_new_frontmatter_link(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """A doc with ``derived_from_ids`` yields a create action."""
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        creates = [a for a in plan.provenance.actions if a.action == "create"]
+        assert len(creates) == 1
+        action = creates[0]
+        assert action.target == "projection_edge"
+        assert action.from_id == _ID3
+        assert action.to_id == _ID1
+        assert action.namespace == "projects"
+        assert action.edge_id is None  # not assigned until apply
+
+    @pytest.mark.asyncio
+    async def test_plan_removes_orphan_corpus_derived_edge(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """A frontmatter-provenanced edge with no frontmatter backing it
+        is planned for removal and carries its edge_id."""
+        # Insert a stale frontmatter-provenanced edge (no doc derives from _ID4).
+        orphan_edge_id = await projection._edge_store.upsert(
+            from_id=_ID4,
+            to_id=_ID1,
+            edge_type="derived_from",
+            weight=1.0,
+            namespace="default",
+            provenance_type="frontmatter",
+        )
+
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        removes = [a for a in plan.provenance.actions if a.action == "remove"]
+        assert len(removes) == 1
+        assert removes[0].from_id == _ID4
+        assert removes[0].to_id == _ID1
+        assert removes[0].edge_id == orphan_edge_id
+
+    @pytest.mark.asyncio
+    async def test_plan_skips_agent_asserted_edge(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """The predicate-scoping invariant (ADR-0004B):
+
+        An asserted edge with ``provenance_type != 'frontmatter'`` survives
+        reconcile, while a stale frontmatter-provenanced edge is deleted.
+        """
+        # Stale frontmatter-provenanced edge (should be removed).
+        await projection._edge_store.upsert(
+            from_id=_ID4,
+            to_id=_ID2,
+            edge_type="derived_from",
+            weight=1.0,
+            namespace="default",
+            provenance_type="frontmatter",
+        )
+        # Agent-asserted derived_from edge with NON-frontmatter provenance
+        # (must survive reconcile — outside the predicate's scope).
+        asserted_edge_id = await projection._edge_store.upsert(
+            from_id=_ID2,
+            to_id=_ID1,
+            edge_type="derived_from",
+            weight=0.5,
+            namespace="default",
+            provenance_type="asserted",
+        )
+
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        # The only remove action targets the frontmatter-provenanced edge.
+        removes = [a for a in plan.provenance.actions if a.action == "remove"]
+        assert len(removes) == 1
+        assert removes[0].from_id == _ID4
+
+        result = await seeded_km.apply_reconcile(plan, projection=projection)
+        assert result.provenance is not None
+        assert result.provenance.removed == 1
+        # The agent-asserted edge survives untouched.
+        survivor = await projection.get_edge(asserted_edge_id)
+        assert survivor is not None
+        assert survivor["provenance_type"] == "asserted"
+
+    @pytest.mark.asyncio
+    async def test_apply_round_trip_is_idempotent(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """plan → apply → re-plan produces an empty plan; edge ids stable."""
+        first = await _reconcile_via_km(seeded_km, projection)
+        assert first.created == 1
+        edges_before = await projection.list_edges(edge_type="derived_from")
+        assert len(edges_before) == 1
+        eid_before = edges_before[0]["edge_id"]
+
+        # Second cycle: plan is noop, apply is noop, edge id unchanged.
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert plan.provenance.is_noop
+        result = await seeded_km.apply_reconcile(plan, projection=projection)
+        assert result.provenance is not None
+        assert result.provenance.created == 0
+        assert result.provenance.removed == 0
+
+        edges_after = await projection.list_edges(edge_type="derived_from")
+        assert len(edges_after) == 1
+        assert edges_after[0]["edge_id"] == eid_before
+
+    @pytest.mark.asyncio
+    async def test_apply_records_failure_when_upsert_raises(
+        self,
+        seeded_km: KnowledgeManager,
+        projection: ProvenanceProjection,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failing upsert is captured in result.failed, not raised."""
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert len(plan.provenance.actions) == 1
+
+        async def _boom(**_kwargs: object) -> str:
+            raise RuntimeError("simulated upsert failure")
+
+        monkeypatch.setattr(projection._edge_store, "upsert", _boom)
+        result = await projection._apply_reconcile(plan.provenance)
+        assert result.created == 0
+        assert len(result.failed) == 1
+        assert "simulated upsert failure" in result.failed[0].detail
+
+    @pytest.mark.asyncio
+    async def test_km_plan_reconcile_populates_provenance_slice(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """plan.provenance is set when projection is passed."""
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert isinstance(plan.provenance, ProvenancePlan)
+
+    @pytest.mark.asyncio
+    async def test_km_apply_reconcile_dispatches_provenance(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """KM.apply_reconcile materialises planned edges via the projection."""
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        result = await seeded_km.apply_reconcile(plan, projection=projection)
+        assert result.provenance is not None
+        assert isinstance(result.provenance, ProvenanceResult)
+        assert result.provenance.created == 1
+        edges = await projection.list_edges(edge_type="derived_from")
+        assert len(edges) == 1
+
+    @pytest.mark.asyncio
+    async def test_km_skips_provenance_when_projection_not_passed(
+        self, seeded_km: KnowledgeManager
+    ) -> None:
+        """plan.provenance is None when no projection argument is supplied."""
+        plan = await seeded_km.plan_reconcile()
+        assert plan.provenance is None
+
+        result = await seeded_km.apply_reconcile(plan)
+        assert result.provenance is None

--- a/tests/test_provenance_projection.py
+++ b/tests/test_provenance_projection.py
@@ -861,3 +861,71 @@ class TestProvenancePlanApply:
 
         result = await seeded_km.apply_reconcile(plan)
         assert result.provenance is None
+
+    @pytest.mark.asyncio
+    async def test_plan_emits_resync_for_stale_column_drift(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """ADR-0004 row-ownership invariant: when a frontmatter-provenanced
+        row's owned columns (weight / provenance_actor / evidence /
+        conflict_state) drift from canonical values, plan emits a ``resync``
+        action and apply re-canonicalises the row in place.
+        """
+        # Seed an in-corpus frontmatter row directly with drifted columns —
+        # this is the reviewer's repro: a row that the key-set diff alone
+        # would treat as in-sync.
+        drifted_edge_id = await projection._edge_store.upsert(
+            from_id=_ID3,
+            to_id=_ID1,
+            edge_type="derived_from",
+            weight=0.3,
+            namespace="projects",
+            provenance_type="frontmatter",
+            evidence="stale",
+            conflict_state="conflicted",
+        )
+
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        resyncs = [a for a in plan.provenance.actions if a.action == "resync"]
+        assert len(resyncs) == 1
+        assert resyncs[0].from_id == _ID3
+        assert resyncs[0].to_id == _ID1
+        assert resyncs[0].namespace == "projects"
+        assert resyncs[0].edge_id == drifted_edge_id
+
+        result = await seeded_km.apply_reconcile(plan, projection=projection)
+        assert result.provenance is not None
+        assert result.provenance.resynced == 1
+        assert result.provenance.created == 0
+        assert result.provenance.removed == 0
+
+        # Same row, now canonical.
+        repaired = await projection.get_edge(drifted_edge_id)
+        assert repaired is not None
+        assert repaired["weight"] == 1.0
+        assert repaired["provenance_actor"] is None
+        assert repaired["evidence"] is None
+        assert repaired["conflict_state"] is None
+        assert repaired["provenance_type"] == "frontmatter"
+
+        # And re-planning is now noop.
+        plan2 = await seeded_km.plan_reconcile(projection=projection)
+        assert plan2.provenance is not None
+        assert plan2.provenance.is_noop
+
+    @pytest.mark.asyncio
+    async def test_plan_skips_resync_when_columns_already_canonical(
+        self, seeded_km: KnowledgeManager, projection: ProvenanceProjection
+    ) -> None:
+        """A canonical row in sync with frontmatter emits no action.
+
+        Guards against an "always-emit-resync" implementation that would
+        churn the store on every reconcile.
+        """
+        await _reconcile_via_km(seeded_km, projection)
+
+        plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert plan.provenance.is_noop
+        assert plan.provenance.actions == ()

--- a/tests/test_provenance_projection.py
+++ b/tests/test_provenance_projection.py
@@ -929,3 +929,53 @@ class TestProvenancePlanApply:
         assert plan.provenance is not None
         assert plan.provenance.is_noop
         assert plan.provenance.actions == ()
+
+    @pytest.mark.asyncio
+    async def test_asserted_edge_blocks_create_at_same_natural_key(
+        self,
+        seeded_km: KnowledgeManager,
+        projection: ProvenanceProjection,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The predicate-scoping invariant must hold even when an asserted
+        edge shares the natural key with a frontmatter-desired edge.
+
+        edges.db is UNIQUE on (from_id, to_id, type, namespace), so a naive
+        ``create`` via ``EdgeStore.upsert`` would update the asserted row
+        in place — clobbering its provenance_type, weight, and evidence.
+        Plan must detect this and emit no action; the asserted edge
+        survives apply untouched. The frontmatter intent is logged as
+        blocked.
+        """
+        # Pre-seat an asserted edge at the exact natural key the seeded
+        # corpus wants (_ID3 derives from _ID1, namespace "projects").
+        asserted_edge_id = await projection._edge_store.upsert(
+            from_id=_ID3,
+            to_id=_ID1,
+            edge_type="derived_from",
+            weight=0.5,
+            namespace="projects",
+            provenance_type="asserted",
+            evidence="agent claim",
+        )
+
+        with caplog.at_level("WARNING", logger="lithos.provenance"):
+            plan = await seeded_km.plan_reconcile(projection=projection)
+        assert plan.provenance is not None
+        assert plan.provenance.is_noop, (
+            f"expected no actions (asserted row blocks create), got {plan.provenance.actions!r}"
+        )
+        assert any("blocked by asserted rows" in r.message for r in caplog.records)
+
+        result = await seeded_km.apply_reconcile(plan, projection=projection)
+        assert result.provenance is not None
+        assert result.provenance.created == 0
+        assert result.provenance.resynced == 0
+        assert result.provenance.removed == 0
+
+        # Asserted edge survives byte-for-byte.
+        survivor = await projection.get_edge(asserted_edge_id)
+        assert survivor is not None
+        assert survivor["provenance_type"] == "asserted"
+        assert survivor["weight"] == pytest.approx(0.5)
+        assert survivor["evidence"] == "agent claim"


### PR DESCRIPTION
## Summary

Completes step 3 of ADR-0001 and finishes ADR-0004B by adding a package-private plan/apply pair to `ProvenanceProjection`, extending `KnowledgeManager.ReconcilePlan` with a `provenance` slice, and rewriting `reconcile.py:_reconcile_provenance_projection` as a thin KM adapter that mirrors `_reconcile_graph` (#250).

- `ProvenanceProjection` now exposes package-private `_plan_reconcile_to(docs) -> ProvenancePlan` and `_apply_reconcile(plan) -> ProvenanceResult` (callable only from `KnowledgeManager`).
- The corpus-derived predicate (`provenance_type="frontmatter"`) is owned inside the projection — agent-asserted edges with a different `provenance_type` now survive reconcile untouched.
- `KnowledgeManager.plan_reconcile` / `apply_reconcile` accept a `projection` argument and dispatch the provenance slice alongside search and graph.
- The transitional `ProvenanceProjection._project()` hook is removed.
- The free helper `_project_provenance_to_edges` in `lcma/edges.py` is kept — the enrich worker's `full_sweep` still consumes it. Migrating that path is a separate follow-up (it would change runtime semantics, not just shape, per ADR-0004 final paragraph).

Closes #254.

## Test plan

- [x] `make check` (lint + format + typecheck + 1127 unit tests) — green
- [x] New `TestProvenancePlanApply` class covers plan/apply round-trip, predicate-scoping, KM dispatch, and failure capture (10 new tests)
- [x] Existing `TestReconcileWireUp` tests still pass against the new adapter (legacy dict shape preserved)
- [x] Existing `TestForwardProjection` / `TestStaleEdgeRemoval` / `TestIdempotent` / `TestNoOpWhenAbsent` migrated from `_project()` to plan/apply via `_reconcile_via_km` helper
- [ ] CI integration suite (the local full integration run hits pre-existing test-pollution errors in unrelated `test_smoke` / `test_telemetry` / `test_server` files; those same tests pass cleanly in isolation on both `main` and this branch — no integration tests exist for the files this PR touches)