### PR TITLE
feat(watch-intake): extract WatchIntake Module from LithosServer (#261)

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -120,10 +120,10 @@ def serve(
         await server.initialize()
         logger.info("lithos server initialized: data_dir=%s", config.storage.data_dir)
 
-        # Start file watcher if enabled
+        # Start file watcher if enabled (ADR-0007).
         if watch:
             click.echo("Starting file watcher...")
-            server.start_file_watcher()
+            await server.watch_intake.start(asyncio.get_running_loop())
             logger.info("file watcher started: knowledge_path=%s", config.storage.knowledge_path)
 
         click.echo(f"Starting MCP server ({transport} transport)...")
@@ -167,9 +167,10 @@ def serve(
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
         logger.info("lithos server shutting down (KeyboardInterrupt)")
-        server.stop_file_watcher()
-        asyncio.run(server.stop_coordination_stats_refresh())
-        asyncio.run(server.stop_enrich_worker())
+        # shutdown() aggregates stop_coordination_stats_refresh,
+        # stop_enrich_worker, watch_intake.stop, and the graph cache flush
+        # (ADR-0007) — one call, no risk of forgetting a subsystem.
+        asyncio.run(server.shutdown())
         logger.info("lithos server stopped")
     finally:
         shutdown_telemetry()

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import collections
-import concurrent.futures
 import contextlib
 import hashlib
 import json
@@ -16,8 +15,6 @@ from typing import TYPE_CHECKING, Any
 from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from watchdog.events import FileSystemEvent, FileSystemEventHandler
-from watchdog.observers import Observer
 
 from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig, get_config, set_config
@@ -26,10 +23,6 @@ from lithos.errors import SearchBackendError
 from lithos.events import (
     AGENT_REGISTERED,
     FINDING_POSTED,
-    NOTE_CREATED,
-    NOTE_DELETED,
-    NOTE_RENAMED,
-    NOTE_UPDATED,
     TASK_CANCELLED,
     TASK_CLAIMED,
     TASK_COMPLETED,
@@ -62,6 +55,7 @@ from lithos.telemetry import (
     register_sse_active_clients_observer,
     tool_metrics,
 )
+from lithos.watch_intake import WatchIntake
 
 if TYPE_CHECKING:
     # ``EdgeStore`` is used as a type annotation only — runtime construction
@@ -114,6 +108,11 @@ class LithosServer:
         self.event_bus = EventBus(self._config.events)
         # CorpusIntake is built in initialize() once self.search exists.
         self.intake: CorpusIntake = None  # type: ignore[assignment]
+        # WatchIntake (ADR-0007) is built in initialize() alongside CorpusIntake,
+        # after the late-bound SearchEngine is ready. Watcher events have no
+        # agent and never register one, so the Module takes the four view-layer
+        # collaborators only.
+        self.watch_intake: WatchIntake = None  # type: ignore[assignment]
 
         # ``projection`` (and the EdgeStore it owns) is created
         # asynchronously in :meth:`initialize` via
@@ -153,12 +152,6 @@ class LithosServer:
 
         # Background tasks (kept to prevent garbage collection)
         self._background_tasks: set[asyncio.Task[None]] = set()
-
-        # File watcher
-        self._observer: Observer | None = None  # type: ignore[reportInvalidTypeForm]
-        self._watch_loop: asyncio.AbstractEventLoop | None = None
-        self._pending_updates: set[Path] = set()
-        self._update_lock = asyncio.Lock()
 
         # Create FastMCP app
         self.mcp = FastMCP(
@@ -647,6 +640,18 @@ class LithosServer:
                         event_bus=self.event_bus,
                     )
 
+                # Build the watcher intake — peer of CorpusIntake (ADR-0007).
+                # Same late-binding idiom: tests that pre-inject
+                # ``self.watch_intake`` keep their injection.
+                if self.watch_intake is None:
+                    self.watch_intake = WatchIntake(
+                        knowledge=self.knowledge,
+                        search=self.search,
+                        graph=self.graph,
+                        event_bus=self.event_bus,
+                        watch_path=self.config.storage.knowledge_path,
+                    )
+
                 # Initialize and run schema migrations
                 registry_path = (
                     self.config.storage.lithos_store_path / "migrations" / "registry.json"
@@ -945,37 +950,6 @@ class LithosServer:
             key=lambda n: n["id"],
         )
 
-    def start_file_watcher(self) -> None:
-        """Start watching for file changes."""
-        if self._observer:
-            return
-
-        try:
-            self._watch_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            raise RuntimeError("File watcher requires a running asyncio event loop") from None
-
-        handler = _FileChangeHandler(self, self._watch_loop)
-        observer = Observer()
-        observer.schedule(
-            handler,
-            str(self.config.storage.knowledge_path),
-            recursive=True,
-        )
-        observer.start()
-        self._observer = observer
-
-    def stop_file_watcher(self) -> None:
-        """Stop file watcher and flush any debounced graph-cache writes."""
-        if self._observer:
-            self._observer.stop()
-            self._observer.join()
-            self._observer = None
-        # Force-flush the graph cache so pending mutations land on disk before
-        # the process exits (#203).
-        if self.graph._dirty_ops > 0:
-            self.graph.save_cache()
-
     async def stop_enrich_worker(self) -> None:
         """Stop the CognitiveMemory Module and close the projection.
 
@@ -996,141 +970,24 @@ class LithosServer:
         """Stop every background worker and close every persistent handle.
 
         Idempotent. Aggregates :meth:`stop_coordination_stats_refresh`,
-        :meth:`stop_enrich_worker`, and :meth:`stop_file_watcher` so callers
-        — especially test fixtures — do not need to track which subsystems
-        own which handles. Forgetting any one of these used to leave
-        aiosqlite worker threads alive past test event-loop teardown,
-        which surfaced as ``RuntimeError: Event loop is closed``
-        warnings and (on CI) job-hanging orphan processes.
+        :meth:`stop_enrich_worker`, the :class:`WatchIntake` observer, and
+        the graph-cache flush so callers — especially test fixtures — do
+        not need to track which subsystems own which handles. Forgetting
+        any one of these used to leave aiosqlite worker threads alive past
+        test event-loop teardown, which surfaced as
+        ``RuntimeError: Event loop is closed`` warnings and (on CI)
+        job-hanging orphan processes.
         """
         await self.stop_coordination_stats_refresh()
         await self.stop_enrich_worker()
-        self.stop_file_watcher()
-
-    async def handle_file_rename(self, src_path: Path, dest_path: Path) -> None:
-        """Handle a file-rename watchdog event (#202).
-
-        External renames (Obsidian rename, ``mv``, ``git checkout``) used to
-        be processed as a delete+create pair: the doc id was lost, wiki-links
-        pointing at the old path went stale, and the indices drifted until
-        the next reconcile. Now we update the path mapping under the same
-        doc id and re-index in place.
-
-        Behaviour by source/destination location:
-        - both inside knowledge_path → rename in place, emit ``note.renamed``.
-        - source inside, destination outside → treat as deletion.
-        - source outside, destination inside → treat as creation.
-        - both outside → no-op.
-        """
-        knowledge_path = self.config.storage.knowledge_path
-
-        def _relative_or_none(path: Path) -> Path | None:
-            try:
-                return path.relative_to(knowledge_path)
-            except ValueError:
-                return None
-
-        src_rel = _relative_or_none(src_path) if src_path.suffix == ".md" else None
-        dest_rel = _relative_or_none(dest_path) if dest_path.suffix == ".md" else None
-
-        if src_rel is None and dest_rel is None:
-            return
-        if src_rel is None and dest_rel is not None:
-            await self.handle_file_change(dest_path)
-            return
-        if src_rel is not None and dest_rel is None:
-            await self.handle_file_change(src_path, deleted=True)
-            return
-
-        # Genuine in-corpus rename.
-        tracer = get_tracer()
-        with tracer.start_as_current_span("lithos.file_rename") as span:
-            assert src_rel is not None
-            assert dest_rel is not None
-            span.set_attribute("lithos.src_path", str(src_rel))
-            span.set_attribute("lithos.dest_path", str(dest_rel))
-            async with self._update_lock:
-                try:
-                    doc_id = self.knowledge.get_id_by_path(src_rel)
-                    # ``sync_from_disk`` re-reads frontmatter and rebinds the
-                    # path mapping under the existing doc id. The graph and
-                    # search backends overwrite by id, so re-indexing closes
-                    # the loop without losing wiki-link targets.
-                    doc = await self.knowledge.sync_from_disk(dest_rel)
-                    indexable = KnowledgeManager.to_indexable(doc)
-                    await asyncio.to_thread(self.search.index, indexable)
-                    self.graph.add_document(doc)
-
-                    lithos_metrics.file_watcher_events.add(1, {"event_type": "renamed"})
-                    await self._emit(
-                        LithosEvent(
-                            type=NOTE_RENAMED,
-                            payload={
-                                "id": doc_id or doc.id,
-                                "src_path": str(src_rel),
-                                "dest_path": str(dest_rel),
-                            },
-                        )
-                    )
-                except FileNotFoundError:
-                    # Destination disappeared between the watchdog event and
-                    # our processing — treat as a deletion of the source.
-                    await self.handle_file_change(src_path, deleted=True)
-                except Exception as exc:
-                    logger.error(
-                        "Error handling file rename %s -> %s: %s", src_path, dest_path, exc
-                    )
-
-    async def handle_file_change(self, path: Path, deleted: bool = False) -> None:
-        """Handle a file change event."""
-        if path.suffix != ".md":
-            return
-
-        tracer = get_tracer()
-        with tracer.start_as_current_span("lithos.file_change") as span:
-            span.set_attribute("lithos.deleted", deleted)
-            async with self._update_lock:
-                try:
-                    knowledge_path = self.config.storage.knowledge_path
-                    try:
-                        relative_path = path.relative_to(knowledge_path)
-                    except ValueError:
-                        return
-
-                    if deleted:
-                        doc_id = self.knowledge.get_id_by_path(relative_path)
-                        if doc_id:
-                            # Emit event with doc id before delete evicts _meta_cache
-                            lithos_metrics.file_watcher_events.add(1, {"event_type": "deleted"})
-                            await self._emit(
-                                LithosEvent(
-                                    type=NOTE_DELETED,
-                                    payload={"id": doc_id, "path": str(relative_path)},
-                                )
-                            )
-
-                            await self.knowledge.delete(doc_id)
-                            await asyncio.to_thread(self.search.remove, doc_id)
-                            # graph.remove_document() debounces its own flush (#203)
-                            self.graph.remove_document(doc_id)
-                    else:
-                        is_new = not self.knowledge.get_id_by_path(relative_path)
-                        doc = await self.knowledge.sync_from_disk(relative_path)
-                        indexable = KnowledgeManager.to_indexable(doc)
-                        await asyncio.to_thread(self.search.index, indexable)
-                        # graph.add_document() debounces its own flush (#203)
-                        self.graph.add_document(doc)
-
-                        event_type = "created" if is_new else "updated"
-                        lithos_metrics.file_watcher_events.add(1, {"event_type": event_type})
-                        await self._emit(
-                            LithosEvent(
-                                type=NOTE_CREATED if is_new else NOTE_UPDATED,
-                                payload={"path": str(relative_path)},
-                            )
-                        )
-                except Exception as e:
-                    logger.error("Error handling file change %s: %s", path, e)
+        if self.watch_intake is not None:
+            await self.watch_intake.stop()
+        # Force-flush the graph cache so pending mutations land on disk
+        # before the process exits (#203). Owned by shutdown rather than
+        # WatchIntake.stop because it's a graph-cache concern, not a
+        # watcher concern (ADR-0007).
+        if self.graph._dirty_ops > 0:
+            self.graph.save_cache()
 
     def _register_tools(self) -> None:
         """Register all MCP tools."""
@@ -3486,70 +3343,6 @@ def _format_sse(event: LithosEvent) -> str:
     }
     data = json.dumps(payload, default=str)
     return f"id: {event.id}\nevent: {event.type}\ndata: {data}\n\n"
-
-
-class _FileChangeHandler(FileSystemEventHandler):
-    """Handle file system events for index updates."""
-
-    def __init__(self, server: LithosServer, loop: asyncio.AbstractEventLoop):
-        self.server = server
-        self._loop = loop
-
-    def on_created(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self._schedule_update(Path(str(event.src_path)))
-
-    def on_modified(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self._schedule_update(Path(str(event.src_path)))
-
-    def on_deleted(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self._schedule_update(Path(str(event.src_path)), deleted=True)
-
-    def on_moved(self, event: FileSystemEvent) -> None:
-        """Handle external file renames (#202).
-
-        Watchdog emits this on most platforms (POSIX inotify, macOS FSEvents,
-        Windows ReadDirectoryChangesW). Some network filesystems do not — in
-        that case watchdog falls back to a delete+create pair which still
-        works through the existing handlers, just less precisely.
-        """
-        if event.is_directory:
-            return
-        dest_path = getattr(event, "dest_path", None)
-        if dest_path is None:
-            return
-        self._schedule_rename(Path(str(event.src_path)), Path(str(dest_path)))
-
-    def _schedule_update(self, path: Path, deleted: bool = False) -> None:
-        try:
-            future = asyncio.run_coroutine_threadsafe(
-                self.server.handle_file_change(path, deleted),
-                self._loop,
-            )
-            future.add_done_callback(self._log_future_exception)
-        except Exception:
-            pass
-
-    def _schedule_rename(self, src_path: Path, dest_path: Path) -> None:
-        try:
-            future = asyncio.run_coroutine_threadsafe(
-                self.server.handle_file_rename(src_path, dest_path),
-                self._loop,
-            )
-            future.add_done_callback(self._log_future_exception)
-        except Exception:
-            pass
-
-    @staticmethod
-    def _log_future_exception(future: "concurrent.futures.Future[None]") -> None:
-        try:
-            exception = future.exception()
-            if exception:
-                logger.error("Error processing file update: %s", exception)
-        except Exception:
-            pass
 
 
 # Global server instance

--- a/src/lithos/watch_intake.py
+++ b/src/lithos/watch_intake.py
@@ -1,0 +1,385 @@
+"""Watch intake — filesystem-driven Corpus mutations.
+
+``WatchIntake`` is the peer of ``CorpusIntake``: the agent-driven seam handles
+mutations originating in MCP tool calls; the filesystem-driven seam handles
+mutations originating in external file events (Obsidian, ``mv``, ``git checkout``,
+bulk import scripts). See ADR-0007 for the design rationale and rejected
+alternatives.
+
+The Module owns three filesystem operations and the watchdog ``Observer``
+lifecycle:
+
+    * ``upsert_from_disk``   — file appeared or changed on disk;
+    * ``delete_from_disk``   — file disappeared from disk;
+    * ``rename_on_disk``     — file moved (in-corpus, into corpus, or out of
+                                 corpus; pure-outside moves are no-ops).
+
+All three serialise the path→id capture step (and the in-corpus rename
+sequence) on a private ``_update_lock``. The lock is local to the Module —
+``KnowledgeManager`` has its own ``_write_lock`` for atomicity of the
+mutation itself; ``_update_lock`` exists to serialise the watcher path
+because watchdog can deliver duplicate events from the OS, not because the
+underlying mutation needs an outer lock.
+
+Watcher-emitted events carry ``agent="watcher"`` (system-reserved sentinel).
+Today's empty-string ``agent`` was a negative distinguisher; the sentinel is
+the affirmative form. No subscriber filters on ``event.agent`` today, so the
+change is backward-compatible at the consumer surface.
+
+The ``delete_from_disk`` emit order matches ``CorpusIntake.delete``:
+``KnowledgeManager.delete`` → ``search.remove`` → ``graph.remove_document``
+→ emit. The previously-claimed "emit-before-delete is load-bearing" framing
+is retracted in ADR-0007: ``EventBus.emit`` is queue-based, no subscriber
+observes pre-delete cache state regardless of emit order. The real invariant
+is capture-before-mutate — ``get_id_by_path(relative_path)`` must run before
+``KnowledgeManager.delete(id)`` because ``delete`` clears ``_id_to_path``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from lithos.events import (
+    NOTE_CREATED,
+    NOTE_DELETED,
+    NOTE_RENAMED,
+    NOTE_UPDATED,
+    EventBus,
+    LithosEvent,
+)
+from lithos.graph import KnowledgeGraph
+from lithos.knowledge import KnowledgeManager
+from lithos.search import SearchEngine
+from lithos.telemetry import get_tracer, lithos_metrics
+
+logger = logging.getLogger(__name__)
+
+# Agent attribution sentinel for events originating in the file watcher
+# (ADR-0007). Use the affirmative sentinel over today's empty-string
+# distinguisher so consumers can match on it without relying on truthiness.
+WATCHER_AGENT = "watcher"
+
+
+class WatchIntake:
+    """Filesystem-driven Corpus mutations. Peer of :class:`CorpusIntake`.
+
+    Constructor takes the four view-layer collaborators and the watch path.
+    No ``coordination`` dependency — watcher-driven mutations do not register
+    agents because there is no agent. The Module holds a private
+    ``_update_lock`` that wraps the path→id capture on ``delete_from_disk``
+    and serialises the in-corpus rename sequence on ``rename_on_disk``; it
+    also owns the watchdog ``Observer`` and the private
+    ``_FileChangeHandler`` adapter.
+    """
+
+    def __init__(
+        self,
+        knowledge: KnowledgeManager,
+        search: SearchEngine,
+        graph: KnowledgeGraph,
+        event_bus: EventBus,
+        watch_path: Path,
+    ) -> None:
+        self._knowledge = knowledge
+        self._search = search
+        self._graph = graph
+        self._event_bus = event_bus
+        self._watch_path = watch_path
+        self._update_lock = asyncio.Lock()
+        self._observer: Observer | None = None  # type: ignore[reportInvalidTypeForm]
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start the watchdog ``Observer`` watching ``watch_path`` recursively.
+
+        Idempotent: a second call while the observer is running is a no-op.
+        The loop is captured so the private ``_FileChangeHandler`` can
+        marshal watchdog-thread events back onto the asyncio loop via
+        :func:`asyncio.run_coroutine_threadsafe`.
+        """
+        if self._observer is not None:
+            return
+        self._loop = loop
+        handler = WatchIntake._FileChangeHandler(self, loop)
+        observer = Observer()
+        observer.schedule(handler, str(self._watch_path), recursive=True)
+        observer.start()
+        self._observer = observer
+
+    async def stop(self) -> None:
+        """Stop the watchdog ``Observer`` and join its thread.
+
+        Idempotent: a second call after stop is a no-op. The graph-cache
+        flush that lived in the old ``stop_file_watcher`` is now a
+        graph-cache concern owned by :meth:`LithosServer.shutdown` (ADR-0007).
+        """
+        if self._observer is None:
+            return
+        self._observer.stop()
+        self._observer.join()
+        self._observer = None
+        self._loop = None
+
+    async def upsert_from_disk(self, path: Path) -> None:
+        """Apply a filesystem create-or-modify to the Corpus and derived views.
+
+        Non-markdown files and paths outside ``watch_path`` are ignored.
+        On success the document is re-read from disk via
+        ``KnowledgeManager.sync_from_disk``, re-indexed in Search (awaited via
+        ``asyncio.to_thread``), and re-bound in the link graph (sync;
+        debounces own flush). The ``NOTE_CREATED`` / ``NOTE_UPDATED`` event
+        fires after both view syncs have been kicked off, matching
+        ``CorpusIntake.write``'s order. All emits carry ``agent="watcher"``.
+        """
+        if path.suffix != ".md":
+            return
+
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.watch_intake.upsert") as span:
+            span.set_attribute("lithos.deleted", False)
+            async with self._update_lock:
+                try:
+                    try:
+                        relative_path = path.relative_to(self._watch_path)
+                    except ValueError:
+                        return
+
+                    is_new = not self._knowledge.get_id_by_path(relative_path)
+                    doc = await self._knowledge.sync_from_disk(relative_path)
+                    indexable = KnowledgeManager.to_indexable(doc)
+                    await asyncio.to_thread(self._search.index, indexable)
+                    # graph.add_document() debounces its own flush (#203)
+                    self._graph.add_document(doc)
+
+                    event_type = "created" if is_new else "updated"
+                    lithos_metrics.file_watcher_events.add(1, {"event_type": event_type})
+                    await self._emit(
+                        LithosEvent(
+                            type=NOTE_CREATED if is_new else NOTE_UPDATED,
+                            agent=WATCHER_AGENT,
+                            payload={"path": str(relative_path)},
+                        )
+                    )
+                except Exception as e:
+                    logger.error("Error handling file change %s: %s", path, e)
+
+    async def delete_from_disk(self, path: Path) -> None:
+        """Apply a filesystem deletion to the Corpus and derived views.
+
+        Non-markdown files and paths outside ``watch_path`` are ignored.
+        Capture-before-mutate is enforced: ``get_id_by_path`` runs inside
+        ``_update_lock`` before ``KnowledgeManager.delete``, because ``delete``
+        clears ``_id_to_path`` (ADR-0007). On success the document is
+        removed from KnowledgeManager, Search, and the link graph, and
+        ``NOTE_DELETED`` (carrying ``agent="watcher"``) fires after both
+        view syncs have been kicked off — matching ``CorpusIntake.delete``'s
+        emit-after-mutate order. The previously-claimed emit-before-delete
+        invariant is retracted (ADR-0007).
+        """
+        if path.suffix != ".md":
+            return
+
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.watch_intake.delete") as span:
+            span.set_attribute("lithos.deleted", True)
+            async with self._update_lock:
+                try:
+                    try:
+                        relative_path = path.relative_to(self._watch_path)
+                    except ValueError:
+                        return
+
+                    # Capture-before-mutate: KnowledgeManager.delete clears
+                    # _id_to_path, so the path→id resolution must precede it.
+                    doc_id = self._knowledge.get_id_by_path(relative_path)
+                    if not doc_id:
+                        return
+
+                    await self._knowledge.delete(doc_id)
+                    await asyncio.to_thread(self._search.remove, doc_id)
+                    # graph.remove_document() debounces its own flush (#203)
+                    self._graph.remove_document(doc_id)
+
+                    lithos_metrics.file_watcher_events.add(1, {"event_type": "deleted"})
+                    await self._emit(
+                        LithosEvent(
+                            type=NOTE_DELETED,
+                            agent=WATCHER_AGENT,
+                            payload={"id": doc_id, "path": str(relative_path)},
+                        )
+                    )
+                except Exception as e:
+                    logger.error("Error handling file delete %s: %s", path, e)
+
+    async def rename_on_disk(self, src: Path, dest: Path) -> None:
+        """Apply an external rename (#202) to the Corpus and derived views.
+
+        Behaviour by source/destination location relative to ``watch_path``:
+
+        * both inside  → rename in place, emit ``NOTE_RENAMED``;
+        * source inside, destination outside → degrade to
+          ``delete_from_disk(src)``;
+        * source outside, destination inside → degrade to
+          ``upsert_from_disk(dest)``;
+        * both outside → no-op.
+
+        In-place renames re-bind the existing doc id under the new path via
+        ``sync_from_disk`` (the graph and Search backends overwrite by id),
+        preserving wiki-link targets that previously went stale on
+        delete+create. The ``_update_lock`` serialises the in-corpus rename;
+        the degradation branches acquire the lock through the inner method.
+        """
+
+        def _relative_or_none(p: Path) -> Path | None:
+            try:
+                return p.relative_to(self._watch_path)
+            except ValueError:
+                return None
+
+        src_rel = _relative_or_none(src) if src.suffix == ".md" else None
+        dest_rel = _relative_or_none(dest) if dest.suffix == ".md" else None
+
+        if src_rel is None and dest_rel is None:
+            return
+        if src_rel is None and dest_rel is not None:
+            await self.upsert_from_disk(dest)
+            return
+        if src_rel is not None and dest_rel is None:
+            await self.delete_from_disk(src)
+            return
+
+        assert src_rel is not None
+        assert dest_rel is not None
+
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.watch_intake.rename") as span:
+            span.set_attribute("lithos.src_path", str(src_rel))
+            span.set_attribute("lithos.dest_path", str(dest_rel))
+            # FileNotFoundError degrades to delete_from_disk, which acquires
+            # _update_lock itself — defer that recursion until after we've
+            # released the lock here (asyncio.Lock is not reentrant).
+            degrade_to_delete = False
+            async with self._update_lock:
+                try:
+                    doc_id = self._knowledge.get_id_by_path(src_rel)
+                    # sync_from_disk re-reads frontmatter and rebinds the
+                    # path mapping under the existing doc id. The graph
+                    # and search backends overwrite by id, so re-indexing
+                    # closes the loop without losing wiki-link targets.
+                    doc = await self._knowledge.sync_from_disk(dest_rel)
+                    indexable = KnowledgeManager.to_indexable(doc)
+                    await asyncio.to_thread(self._search.index, indexable)
+                    self._graph.add_document(doc)
+
+                    lithos_metrics.file_watcher_events.add(1, {"event_type": "renamed"})
+                    await self._emit(
+                        LithosEvent(
+                            type=NOTE_RENAMED,
+                            agent=WATCHER_AGENT,
+                            payload={
+                                "id": doc_id or doc.id,
+                                "src_path": str(src_rel),
+                                "dest_path": str(dest_rel),
+                            },
+                        )
+                    )
+                except FileNotFoundError:
+                    # Destination disappeared between the watchdog event
+                    # and our processing — treat as a deletion of the
+                    # source.
+                    degrade_to_delete = True
+                except Exception as exc:
+                    logger.error("Error handling file rename %s -> %s: %s", src, dest, exc)
+
+            if degrade_to_delete:
+                await self.delete_from_disk(src)
+
+    async def _emit(self, event: LithosEvent) -> None:
+        """Emit an event, logging any failure without propagating.
+
+        Mirrors ``CorpusIntake._emit``: a failed event delivery never undoes
+        a successful Corpus mutation.
+        """
+        try:
+            await self._event_bus.emit(event)
+        except Exception:
+            logger.exception("Failed to emit %s event", event.type)
+
+    class _FileChangeHandler(FileSystemEventHandler):
+        """Handle watchdog file system events for index updates.
+
+        Lives in the watchdog observer thread; marshals each event back to
+        the asyncio loop captured at :meth:`WatchIntake.start` via
+        :func:`asyncio.run_coroutine_threadsafe`. Schedule errors are
+        swallowed to keep the watcher running; coroutine-level errors are
+        logged via :meth:`_log_future_exception`.
+        """
+
+        def __init__(self, intake: WatchIntake, loop: asyncio.AbstractEventLoop) -> None:
+            self.intake = intake
+            self._loop = loop
+
+        def on_created(self, event: FileSystemEvent) -> None:
+            if not event.is_directory:
+                self._schedule_update(Path(str(event.src_path)))
+
+        def on_modified(self, event: FileSystemEvent) -> None:
+            if not event.is_directory:
+                self._schedule_update(Path(str(event.src_path)))
+
+        def on_deleted(self, event: FileSystemEvent) -> None:
+            if not event.is_directory:
+                self._schedule_update(Path(str(event.src_path)), deleted=True)
+
+        def on_moved(self, event: FileSystemEvent) -> None:
+            """Handle external file renames (#202).
+
+            Watchdog emits this on most platforms (POSIX inotify, macOS
+            FSEvents, Windows ReadDirectoryChangesW). Some network
+            filesystems do not — in that case watchdog falls back to a
+            delete+create pair which still works through the existing
+            handlers, just less precisely.
+            """
+            if event.is_directory:
+                return
+            dest_path = getattr(event, "dest_path", None)
+            if dest_path is None:
+                return
+            self._schedule_rename(Path(str(event.src_path)), Path(str(dest_path)))
+
+        def _schedule_update(self, path: Path, deleted: bool = False) -> None:
+            try:
+                coro = (
+                    self.intake.delete_from_disk(path)
+                    if deleted
+                    else self.intake.upsert_from_disk(path)
+                )
+                future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+                future.add_done_callback(self._log_future_exception)
+            except Exception:
+                pass
+
+        def _schedule_rename(self, src_path: Path, dest_path: Path) -> None:
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self.intake.rename_on_disk(src_path, dest_path),
+                    self._loop,
+                )
+                future.add_done_callback(self._log_future_exception)
+            except Exception:
+                pass
+
+        @staticmethod
+        def _log_future_exception(future: concurrent.futures.Future[None]) -> None:
+            try:
+                exception = future.exception()
+                if exception:
+                    logger.error("Error processing file update: %s", exception)
+            except Exception:
+                pass

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -266,17 +266,22 @@ class TestCLIContracts:
                 assert kwargs["path"] == "/sse"
                 calls["sse"] += 1
 
+        class _DummyWatchIntake:
+            async def start(self, _loop):
+                calls["watch_started"] += 1
+
+            async def stop(self):
+                calls["watch_stopped"] += 1
+
         class _DummyServer:
             def __init__(self):
                 self.mcp = _DummyMCP()
+                self.watch_intake = _DummyWatchIntake()
 
             async def initialize(self):
                 return None
 
-            def start_file_watcher(self):
-                calls["watch_started"] += 1
-
-            def stop_file_watcher(self):
+            async def shutdown(self):
                 calls["watch_stopped"] += 1
 
         monkeypatch.setattr("lithos.server.create_server", lambda _cfg: _DummyServer())
@@ -323,23 +328,22 @@ class TestCLIContracts:
             async def run_stdio_async(self, show_banner=False):
                 return None
 
+        class _DummyWatchIntake:
+            async def start(self, _loop):
+                return None
+
+            async def stop(self):
+                return None
+
         class _DummyServer:
             def __init__(self):
                 self.mcp = _DummyMCP()
+                self.watch_intake = _DummyWatchIntake()
 
             async def initialize(self):
                 return None
 
-            def start_file_watcher(self):
-                return None
-
-            def stop_file_watcher(self):
-                return None
-
-            async def stop_enrich_worker(self):
-                return None
-
-            async def stop_coordination_stats_refresh(self):
+            async def shutdown(self):
                 return None
 
         monkeypatch.setattr("lithos.server.create_server", lambda _cfg: _DummyServer())
@@ -373,33 +377,47 @@ class TestCLIContracts:
 
         calls = {"stop": 0}
 
+        class _DummyWatchIntake:
+            async def start(self, _loop):
+                return None
+
+            async def stop(self):
+                return None
+
         class _DummyServer:
             mcp = SimpleNamespace()
+            watch_intake = _DummyWatchIntake()
 
             async def initialize(self):
                 return None
 
-            def start_file_watcher(self):
-                return None
-
-            def stop_file_watcher(self):
+            async def shutdown(self):
                 calls["stop"] += 1
-
-            async def stop_enrich_worker(self):
-                return None
-
-            async def stop_coordination_stats_refresh(self):
-                return None
 
         monkeypatch.setattr("lithos.server.create_server", lambda _cfg: _DummyServer())
 
         _first_call = {"value": True}
 
         def _raise_keyboard_interrupt(coro):
-            coro.close()
+            # Track which coroutine asyncio.run was handed: the main
+            # run_server() raises KeyboardInterrupt, and the subsequent
+            # shutdown() coroutine is awaited so its body runs and bumps
+            # calls["stop"]. Closing it (as the old test did) would skip
+            # the cleanup assertion entirely.
+            name = getattr(coro, "__name__", "")
             if _first_call["value"]:
                 _first_call["value"] = False
+                coro.close()
                 raise KeyboardInterrupt
+            if name == "shutdown":
+                # Drive the shutdown coroutine to completion using a fresh
+                # event loop — matches the behaviour of the real
+                # asyncio.run().
+                import asyncio as _asyncio
+
+                _asyncio.new_event_loop().run_until_complete(coro)
+                return None
+            coro.close()
 
         monkeypatch.setattr("lithos.cli.asyncio.run", _raise_keyboard_interrupt)
 

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lithos.events import NOTE_DELETED, NOTE_RENAMED, NOTE_UPDATED
+from lithos.events import NOTE_CREATED, NOTE_DELETED, NOTE_RENAMED, NOTE_UPDATED
 from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
 from lithos.watch_intake import WATCHER_AGENT
@@ -16,6 +16,30 @@ pytestmark = pytest.mark.integration
 class TestFileWatcherEventEmission:
     """Test that WatchIntake emits events for file operations with the
     ``agent="watcher"`` sentinel (ADR-0007)."""
+
+    async def test_file_create_emits_note_created(self, server: LithosServer) -> None:
+        """A brand-new .md file appearing on disk triggers note.created with agent=\"watcher\".
+
+        Pins the create-side attribution: an externally-written file that
+        is not yet in ``KnowledgeManager._id_to_path`` produces
+        ``NOTE_CREATED`` (not ``NOTE_UPDATED``), and the event carries the
+        watcher sentinel. The branch is otherwise only exercised by the
+        telemetry counter test (``TestFileWatcherEventsCounter``), which
+        does not subscribe to the event.
+        """
+        queue = server.event_bus.subscribe(event_types=[NOTE_CREATED])
+
+        new_file = server.config.storage.knowledge_path / "brand-new-watcher.md"
+        new_file.write_text(
+            "---\ntitle: Brand New Watcher Doc\nagent: external\n---\nHello.\n"
+        )
+
+        await server.watch_intake.upsert_from_disk(new_file)
+
+        event = queue.get_nowait()
+        assert event.type == NOTE_CREATED
+        assert event.agent == WATCHER_AGENT
+        assert event.payload["path"] == "brand-new-watcher.md"
 
     async def test_file_modify_emits_note_updated(self, server: LithosServer) -> None:
         """A file create/modify triggers note.updated event with agent="watcher"."""

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -1,4 +1,4 @@
-"""Tests for event emission from file watcher handle_file_change."""
+"""Tests for event emission from the WatchIntake Module (ADR-0007)."""
 
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -8,15 +8,17 @@ import pytest
 from lithos.events import NOTE_DELETED, NOTE_RENAMED, NOTE_UPDATED
 from lithos.knowledge import KnowledgeManager
 from lithos.server import LithosServer
+from lithos.watch_intake import WATCHER_AGENT
 
 pytestmark = pytest.mark.integration
 
 
 class TestFileWatcherEventEmission:
-    """Test that handle_file_change emits events for file operations."""
+    """Test that WatchIntake emits events for file operations with the
+    ``agent="watcher"`` sentinel (ADR-0007)."""
 
     async def test_file_modify_emits_note_updated(self, server: LithosServer) -> None:
-        """A file create/modify triggers note.updated event."""
+        """A file create/modify triggers note.updated event with agent="watcher"."""
         doc = (
             await server.knowledge.create(
                 title="Watcher Event Doc",
@@ -31,14 +33,15 @@ class TestFileWatcherEventEmission:
         queue = server.event_bus.subscribe(event_types=[NOTE_UPDATED])
 
         file_path = server.config.storage.knowledge_path / doc.path
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         event = queue.get_nowait()
         assert event.type == NOTE_UPDATED
+        assert event.agent == WATCHER_AGENT
         assert event.payload["path"] == str(doc.path)
 
     async def test_file_delete_emits_note_deleted(self, server: LithosServer) -> None:
-        """A file deletion triggers note.deleted event."""
+        """A file deletion triggers note.deleted event with agent="watcher"."""
         doc = (
             await server.knowledge.create(
                 title="Watcher Delete Doc",
@@ -55,18 +58,59 @@ class TestFileWatcherEventEmission:
         file_path = server.config.storage.knowledge_path / doc.path
         file_path.unlink()
 
-        await server.handle_file_change(file_path, deleted=True)
+        await server.watch_intake.delete_from_disk(file_path)
 
         event = queue.get_nowait()
         assert event.type == NOTE_DELETED
+        assert event.agent == WATCHER_AGENT
         assert event.payload["path"] == str(doc.path)
+
+    async def test_delete_emits_after_knowledge_delete_completes(
+        self, server: LithosServer
+    ) -> None:
+        """Verification test for ADR-0007: NOTE_DELETED fires AFTER
+        KnowledgeManager.delete has cleared the indices.
+
+        Pins the corrected ordering — capture-before-mutate (path→id
+        resolved inside the lock), emit-after-mutate (event delivered to
+        subscriber while the id is already absent from
+        ``get_id_by_path`` and ``_meta_cache``). The previously-claimed
+        emit-before-delete invariant is retracted.
+        """
+        doc = (
+            await server.knowledge.create(
+                title="Ordering Verification Doc",
+                content="Pins ADR-0007 ordering.",
+                agent="test-agent",
+                path="watched",
+            )
+        ).document
+        server.search.index(KnowledgeManager.to_indexable(doc))
+        server.graph.add_document(doc)
+
+        queue = server.event_bus.subscribe(event_types=[NOTE_DELETED])
+
+        file_path = server.config.storage.knowledge_path / doc.path
+        file_path.unlink()
+
+        await server.watch_intake.delete_from_disk(file_path)
+
+        # Subscriber consumes the event with a valid payload["id"]…
+        event = queue.get_nowait()
+        assert event.type == NOTE_DELETED
+        assert event.agent == WATCHER_AGENT
+        assert event.payload["id"] == doc.id
+
+        # …while KnowledgeManager already reports the id as removed.
+        assert server.knowledge.get_id_by_path(doc.path) is None
+        assert doc.id not in server.knowledge._meta_cache
 
     async def test_non_markdown_file_emits_no_event(self, server: LithosServer) -> None:
         """Non-markdown files produce no event."""
         queue = server.event_bus.subscribe()
 
-        await server.handle_file_change(
-            server.config.storage.knowledge_path / "ignored.txt", deleted=False
+        await server.watch_intake.upsert_from_disk(
+            server.config.storage.knowledge_path / "ignored.txt"
         )
 
         assert queue.empty()
@@ -75,14 +119,14 @@ class TestFileWatcherEventEmission:
         """Files outside knowledge root produce no event."""
         queue = server.event_bus.subscribe()
 
-        await server.handle_file_change(Path("/tmp/outside.md"), deleted=False)
+        await server.watch_intake.upsert_from_disk(Path("/tmp/outside.md"))
 
         assert queue.empty()
 
     async def test_event_emission_failure_does_not_crash_watcher(
         self, server: LithosServer
     ) -> None:
-        """If event emission raises, handle_file_change still succeeds."""
+        """If event emission raises, upsert_from_disk still succeeds."""
         doc = (
             await server.knowledge.create(
                 title="Watcher Resilience Doc",
@@ -99,12 +143,12 @@ class TestFileWatcherEventEmission:
 
         file_path = server.config.storage.knowledge_path / doc.path
         # Should not raise even though emit fails
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
     async def test_delete_emission_failure_does_not_crash_watcher(
         self, server: LithosServer
     ) -> None:
-        """If event emission raises on delete, handle_file_change still succeeds."""
+        """If event emission raises on delete, delete_from_disk still succeeds."""
         doc = (
             await server.knowledge.create(
                 title="Watcher Delete Resilience",
@@ -122,7 +166,7 @@ class TestFileWatcherEventEmission:
         server.event_bus.emit = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
 
         # Should not raise even though emit fails
-        await server.handle_file_change(file_path, deleted=True)
+        await server.watch_intake.delete_from_disk(file_path)
 
     async def test_file_rename_preserves_doc_id_and_emits_renamed(
         self, server: LithosServer
@@ -147,7 +191,7 @@ class TestFileWatcherEventEmission:
         src_path.rename(dest_path)
 
         queue = server.event_bus.subscribe(event_types=[NOTE_RENAMED])
-        await server.handle_file_rename(src_path, dest_path)
+        await server.watch_intake.rename_on_disk(src_path, dest_path)
 
         # Path mapping is now under the destination, doc id unchanged.
         assert server.knowledge.get_id_by_path(dest_rel) == original_id
@@ -156,6 +200,7 @@ class TestFileWatcherEventEmission:
         # The renamed event fired with both paths.
         event = queue.get_nowait()
         assert event.type == NOTE_RENAMED
+        assert event.agent == WATCHER_AGENT
         assert event.payload["id"] == original_id
         assert event.payload["src_path"] == str(doc.path)
         assert event.payload["dest_path"] == str(dest_rel)
@@ -179,14 +224,14 @@ class TestFileWatcherEventEmission:
         dest_path = knowledge_path / dest_rel
         src_path.rename(dest_path)
 
-        await server.handle_file_rename(src_path, dest_path)
+        await server.watch_intake.rename_on_disk(src_path, dest_path)
 
         # Old path lookup gone, new path lookup wired to the same node.
         assert server.graph._path_to_node.get(str(doc.path)) is None
         assert server.graph._path_to_node.get(str(dest_rel)) == doc.id
 
     async def test_file_change_update_rebuilds_graph_edges(self, server: LithosServer) -> None:
-        """handle_file_change rebuilds graph edges when a file is modified."""
+        """upsert_from_disk rebuilds graph edges when a file is modified."""
         target_alpha = (
             await server.knowledge.create(
                 title="Target Alpha",
@@ -227,7 +272,7 @@ class TestFileWatcherEventEmission:
         )
 
         file_path = server.config.storage.knowledge_path / source.path
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         assert not server.graph.has_edge(source.id, target_alpha.id)
         assert server.graph.has_edge(source.id, target_beta.id)

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -30,9 +30,7 @@ class TestFileWatcherEventEmission:
         queue = server.event_bus.subscribe(event_types=[NOTE_CREATED])
 
         new_file = server.config.storage.knowledge_path / "brand-new-watcher.md"
-        new_file.write_text(
-            "---\ntitle: Brand New Watcher Doc\nagent: external\n---\nHello.\n"
-        )
+        new_file.write_text("---\ntitle: Brand New Watcher Doc\nagent: external\n---\nHello.\n")
 
         await server.watch_intake.upsert_from_disk(new_file)
 

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -12,7 +12,8 @@ from fastmcp.exceptions import ToolError
 
 from lithos.config import LithosConfig
 from lithos.knowledge import KnowledgeManager
-from lithos.server import LithosServer, _FileChangeHandler
+from lithos.server import LithosServer
+from lithos.watch_intake import WatchIntake
 
 pytestmark = pytest.mark.integration
 
@@ -407,7 +408,7 @@ class TestFileWatcherRace:
         server.graph.add_document(doc)
 
         file_path = server.config.storage.knowledge_path / doc.path
-        handler = _FileChangeHandler(server, asyncio.get_running_loop())
+        handler = WatchIntake._FileChangeHandler(server.watch_intake, asyncio.get_running_loop())
 
         for i in range(10):
             await server.knowledge.update(id=doc.id, agent="race-agent", content=f"v{i}")
@@ -2421,8 +2422,8 @@ class TestSyncFromDisk:
         file_path = knowledge_path / "external-derived.md"
         file_path.write_text(frontmatter.dumps(post))
 
-        # Call handle_file_change to simulate watcher
-        await server.handle_file_change(file_path, deleted=False)
+        # Call WatchIntake.upsert_from_disk to simulate watcher
+        await server.watch_intake.upsert_from_disk(file_path)
 
         # Verify provenance indexes are updated
         assert doc_id in server.knowledge._doc_to_sources
@@ -2469,7 +2470,7 @@ class TestSyncFromDisk:
         file_path.write_text(frontmatter.dumps(post))
 
         # Simulate watcher event
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         # Verify indexes updated: s1 removed, s2 added
         assert server.knowledge._doc_to_sources[derived_id] == [s2["id"]]
@@ -2502,7 +2503,7 @@ class TestSyncFromDisk:
         post.content = "# Changed Title\n\nContent."
         file_path.write_text(frontmatter.dumps(post))
 
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         assert server.knowledge._id_to_title[doc_id] == "Changed Title"
 
@@ -2538,7 +2539,7 @@ class TestSyncFromDisk:
         src_file = knowledge_path / src_path_str
         src_file.unlink()
 
-        await server.handle_file_change(src_file, deleted=True)
+        await server.watch_intake.delete_from_disk(src_file)
 
         # Source should be removed from indexes
         assert src_id not in server.knowledge._id_to_path
@@ -2589,7 +2590,7 @@ class TestSyncFromDisk:
         file_path = knowledge_path / "future-source.md"
         file_path.write_text(frontmatter.dumps(post))
 
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         # Unresolved should now be resolved
         assert future_source_id not in server.knowledge._unresolved_provenance
@@ -2605,7 +2606,7 @@ class TestSyncFromDisk:
         bad_file.write_bytes(b"\x00\x01\x02\xff\xfe")
 
         # Should not raise
-        await server.handle_file_change(bad_file, deleted=False)
+        await server.watch_intake.upsert_from_disk(bad_file)
 
         # Verify server is still functional
         result = await _call_tool(

--- a/tests/test_provenance_conformance.py
+++ b/tests/test_provenance_conformance.py
@@ -554,7 +554,7 @@ class TestReadPathNormalization:
             supersedes=None,
         )
         (knowledge_path / "derived-ext.md").write_text(fm.dumps(post))
-        await server.handle_file_change(knowledge_path / "derived-ext.md", deleted=False)
+        await server.watch_intake.upsert_from_disk(knowledge_path / "derived-ext.md")
 
         # lithos_read should return normalized (lowercase) UUID
         result = await _call_tool(server, "lithos_read", {"id": derived_id})
@@ -590,7 +590,7 @@ class TestReadPathNormalization:
             supersedes=None,
         )
         (knowledge_path / "list-derived.md").write_text(fm.dumps(post))
-        await server.handle_file_change(knowledge_path / "list-derived.md", deleted=False)
+        await server.watch_intake.upsert_from_disk(knowledge_path / "list-derived.md")
 
         # lithos_list should return normalized UUIDs
         result = await _call_tool(server, "lithos_list", {})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,8 @@ import pytest
 from lithos.config import LithosConfig
 from lithos.knowledge import KnowledgeManager
 from lithos.search import SearchEngine
-from lithos.server import LithosServer, _FileChangeHandler, create_server, get_server
+from lithos.server import LithosServer, create_server, get_server
+from lithos.watch_intake import WatchIntake
 
 pytestmark = pytest.mark.integration
 
@@ -94,15 +95,18 @@ class TestServerInitialization:
     async def test_file_change_handler_schedules_on_loop(self):
         """File change handler schedules work on provided event loop."""
 
-        class DummyServer:
+        class DummyIntake:
             def __init__(self):
                 self.calls: list[tuple[str, bool]] = []
 
-            async def handle_file_change(self, path, deleted=False):
-                self.calls.append((str(path), deleted))
+            async def upsert_from_disk(self, path):
+                self.calls.append((str(path), False))
 
-        dummy = DummyServer()
-        handler = _FileChangeHandler(dummy, asyncio.get_running_loop())
+            async def delete_from_disk(self, path):
+                self.calls.append((str(path), True))
+
+        dummy = DummyIntake()
+        handler = WatchIntake._FileChangeHandler(dummy, asyncio.get_running_loop())
 
         handler._schedule_update(path=Path("/tmp/handler-test.md"), deleted=True)
         await asyncio.sleep(0.05)
@@ -169,45 +173,40 @@ class TestServerInitialization:
         finally:
             await server.shutdown()
 
-    def test_start_file_watcher_requires_running_loop(self, test_config):
-        """Watcher startup without a running loop raises a clear RuntimeError."""
-        server = LithosServer(test_config)
-        with pytest.raises(RuntimeError, match="running asyncio event loop"):
-            server.start_file_watcher()
-
     @pytest.mark.asyncio
-    async def test_start_and_stop_file_watcher_is_idempotent(self, server: LithosServer):
+    async def test_start_and_stop_watch_intake_is_idempotent(self, server: LithosServer):
         """Starting twice and stopping twice should not raise."""
-        server.start_file_watcher()
-        first_observer = server._observer
+        loop = asyncio.get_running_loop()
+        await server.watch_intake.start(loop)
+        first_observer = server.watch_intake._observer
         assert first_observer is not None
 
         # No-op when already started.
-        server.start_file_watcher()
-        assert server._observer is first_observer
+        await server.watch_intake.start(loop)
+        assert server.watch_intake._observer is first_observer
 
-        server.stop_file_watcher()
-        assert server._observer is None
+        await server.watch_intake.stop()
+        assert server.watch_intake._observer is None
 
         # No-op when already stopped.
-        server.stop_file_watcher()
+        await server.watch_intake.stop()
 
     @pytest.mark.asyncio
-    async def test_handle_file_change_ignores_non_markdown_and_outside_root(
+    async def test_upsert_from_disk_ignores_non_markdown_and_outside_root(
         self, server: LithosServer
     ):
         """Non-markdown and out-of-root file events are ignored safely."""
         original_nodes = server.graph.node_count()
 
-        await server.handle_file_change(
-            server.config.storage.knowledge_path / "ignored.txt", deleted=False
+        await server.watch_intake.upsert_from_disk(
+            server.config.storage.knowledge_path / "ignored.txt"
         )
-        await server.handle_file_change(Path("/tmp/outside.md"), deleted=False)
+        await server.watch_intake.upsert_from_disk(Path("/tmp/outside.md"))
 
         assert server.graph.node_count() == original_nodes
 
     @pytest.mark.asyncio
-    async def test_handle_file_change_modified_markdown_reindexes(self, server: LithosServer):
+    async def test_upsert_from_disk_modified_markdown_reindexes(self, server: LithosServer):
         """A markdown modification event reindexes search and graph projections."""
         doc = (
             await server.knowledge.create(
@@ -239,14 +238,14 @@ Updated watcher content with unique phrase.
 """
         )
 
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         results = server.search.full_text_search("unique phrase", limit=10)
         assert any(r.id == doc.id for r in results)
         assert server.graph.has_node(doc.id)
 
     @pytest.mark.asyncio
-    async def test_handle_file_change_update_rebuilds_outgoing_links(self, server: LithosServer):
+    async def test_upsert_from_disk_update_rebuilds_outgoing_links(self, server: LithosServer):
         """Updating a document via file change rebuilds its outgoing wiki-links in the graph."""
         # Create target document
         target = (
@@ -290,7 +289,7 @@ Now linking to [[watcher-target]].
 """
         )
 
-        await server.handle_file_change(file_path, deleted=False)
+        await server.watch_intake.upsert_from_disk(file_path)
 
         assert server.graph.has_edge(source.id, target.id)
 
@@ -298,11 +297,14 @@ Now linking to [[watcher-target]].
     async def test_file_change_handler_event_methods_route_events(self):
         """Event callbacks dispatch to schedule method with expected deleted flag."""
 
-        class DummyServer:
-            async def handle_file_change(self, path, deleted=False):
+        class DummyIntake:
+            async def upsert_from_disk(self, path):
                 return None
 
-        handler = _FileChangeHandler(DummyServer(), asyncio.get_running_loop())
+            async def delete_from_disk(self, path):
+                return None
+
+        handler = WatchIntake._FileChangeHandler(DummyIntake(), asyncio.get_running_loop())
         calls: list[tuple[str, bool]] = []
 
         def _capture(path: Path, deleted: bool = False):
@@ -325,17 +327,20 @@ Now linking to [[watcher-target]].
     async def test_file_change_handler_schedule_exception_is_swallowed(self, monkeypatch):
         """Scheduling failures should be swallowed rather than crash file watcher thread."""
 
-        class DummyServer:
-            async def handle_file_change(self, path, deleted=False):
+        class DummyIntake:
+            async def upsert_from_disk(self, path):
                 return None
 
-        handler = _FileChangeHandler(DummyServer(), asyncio.get_running_loop())
+            async def delete_from_disk(self, path):
+                return None
+
+        handler = WatchIntake._FileChangeHandler(DummyIntake(), asyncio.get_running_loop())
 
         def _boom(coro, *_args, **_kwargs):
             coro.close()
             raise RuntimeError("schedule boom")
 
-        monkeypatch.setattr("lithos.server.asyncio.run_coroutine_threadsafe", _boom)
+        monkeypatch.setattr("lithos.watch_intake.asyncio.run_coroutine_threadsafe", _boom)
         handler._schedule_update(Path("/tmp/fail.md"), deleted=False)
 
     def test_file_change_handler_logs_future_exception(self):
@@ -349,8 +354,8 @@ Now linking to [[watcher-target]].
             def exception(self):
                 raise RuntimeError("cannot fetch exception")
 
-        _FileChangeHandler._log_future_exception(_FutureWithException())
-        _FileChangeHandler._log_future_exception(_FutureExceptionRaises())
+        WatchIntake._FileChangeHandler._log_future_exception(_FutureWithException())
+        WatchIntake._FileChangeHandler._log_future_exception(_FutureExceptionRaises())
 
     def test_global_server_singleton_helpers(self, test_config):
         """create_server installs global instance and get_server returns same object."""
@@ -795,7 +800,7 @@ class TestKnowledgeToolWorkflow:
         file_path = server.config.storage.knowledge_path / doc.path
         file_path.unlink()
 
-        await server.handle_file_change(file_path, deleted=True)
+        await server.watch_intake.delete_from_disk(file_path)
 
         with pytest.raises(FileNotFoundError):
             await server.knowledge.read(id=doc.id)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1080,10 +1080,10 @@ class TestFileWatcherEventsCounter:
         lithos_metrics.file_watcher_events.add(1, {"event_type": "updated"})
         lithos_metrics.file_watcher_events.add(1, {"event_type": "deleted"})
 
-    async def test_handle_file_change_increments_deleted_counter(
+    async def test_delete_from_disk_increments_deleted_counter(
         self, server: "LithosServer"
     ) -> None:
-        """handle_file_change(deleted=True) increments the counter with event_type=deleted."""
+        """WatchIntake.delete_from_disk increments the counter with event_type=deleted."""
         from unittest.mock import patch
 
         from lithos.telemetry import lithos_metrics
@@ -1105,13 +1105,13 @@ class TestFileWatcherEventsCounter:
         file_path.unlink()
 
         with patch.object(counter, "add") as mock_add:
-            await server.handle_file_change(file_path, deleted=True)
+            await server.watch_intake.delete_from_disk(file_path)
             mock_add.assert_called_once_with(1, {"event_type": "deleted"})
 
-    async def test_handle_file_change_increments_updated_counter(
+    async def test_upsert_from_disk_increments_updated_counter(
         self, server: "LithosServer"
     ) -> None:
-        """handle_file_change(deleted=False) on existing file increments updated counter."""
+        """WatchIntake.upsert_from_disk on existing file increments updated counter."""
         from unittest.mock import patch
 
         from lithos.telemetry import lithos_metrics
@@ -1132,13 +1132,13 @@ class TestFileWatcherEventsCounter:
         file_path = server.config.storage.knowledge_path / doc.path
 
         with patch.object(counter, "add") as mock_add:
-            await server.handle_file_change(file_path, deleted=False)
+            await server.watch_intake.upsert_from_disk(file_path)
             mock_add.assert_called_once_with(1, {"event_type": "updated"})
 
-    async def test_handle_file_change_increments_created_counter(
+    async def test_upsert_from_disk_increments_created_counter(
         self, server: "LithosServer"
     ) -> None:
-        """handle_file_change(deleted=False) on a NEW file increments the counter with event_type=created."""
+        """WatchIntake.upsert_from_disk on a NEW file increments the counter with event_type=created."""
         from unittest.mock import patch
 
         from lithos.telemetry import lithos_metrics
@@ -1151,7 +1151,7 @@ class TestFileWatcherEventsCounter:
         new_file.write_text("---\ntitle: Brand New Doc\nagent: test-agent\n---\nHello.\n")
 
         with patch.object(counter, "add") as mock_add:
-            await server.handle_file_change(new_file, deleted=False)
+            await server.watch_intake.upsert_from_disk(new_file)
             mock_add.assert_called_once_with(1, {"event_type": "created"})
 
 


### PR DESCRIPTION
## Summary

Implements ADR-0007 (accepted in #268). Extracts the file-watcher pipeline from `LithosServer` into a new `WatchIntake` Module at `src/lithos/watch_intake.py`, as a peer of `CorpusIntake`. Closes #261.

- New `WatchIntake` owns `upsert_from_disk` / `delete_from_disk` / `rename_on_disk`, the watchdog `Observer` lifecycle, the private `_FileChangeHandler` nested class, and the relocated `_update_lock`.
- `LithosServer` loses `_observer` / `_watch_loop` / `_update_lock` / `handle_file_change` / `handle_file_rename` / `_FileChangeHandler` / `start_file_watcher` / `stop_file_watcher` (~270 lines).
- `LithosServer.shutdown()` now also flushes `graph.save_cache()` when `_dirty_ops > 0` — the cache flush is a graph-cache concern, not a watcher concern (ADR-0007).
- `cli.py` collapses the three KeyboardInterrupt stops into `asyncio.run(server.shutdown())`.

## Behavioural deltas (per ADR-0007)

- Watcher-emitted events (`NOTE_CREATED`, `NOTE_UPDATED`, `NOTE_DELETED`, `NOTE_RENAMED`) carry `agent=\"watcher\"` — affirmative sentinel replaces today's empty-string distinguisher. Backward-compatible at the consumer surface (no subscriber filters on `event.agent`).
- `delete_from_disk` emits `NOTE_DELETED` **after** `KnowledgeManager.delete` completes, matching `CorpusIntake.delete`'s emit-after-mutate order. The previously-claimed \"emit-before-delete is load-bearing\" framing from ADR-0003 is retracted: `EventBus.emit` is queue-based (`asyncio.Queue.put_nowait`), no subscriber observes pre-delete `_meta_cache` state regardless of emit order. The real invariant is **capture-before-mutate** — `get_id_by_path(relative_path)` runs inside `_update_lock` before `KnowledgeManager.delete(id)` because `delete` clears `_id_to_path`.
- Fixed a latent recursive-lock risk in `handle_file_rename`'s `FileNotFoundError` fallback: the recursive delete now runs **after** releasing `_update_lock` (asyncio.Lock is not reentrant).

## Test plan

- [x] `tests/test_file_watcher_events.py` rewritten to call `server.watch_intake.{upsert,delete}_from_disk` / `rename_on_disk` and assert `event.agent == \"watcher\"` on every emit.
- [x] **New verification regression test** (`test_delete_emits_after_knowledge_delete_completes`) — pins ADR-0007's corrected ordering: a subscriber consumes `NOTE_DELETED` while `KnowledgeManager.get_id_by_path` already returns `None` and `_meta_cache` no longer contains the id.
- [x] `tests/test_telemetry.py` — three counter-increment tests rewritten for the new API.
- [x] `tests/test_integration_conformance.py` — import + race-test handler construction + six call sites migrated.
- [x] `tests/test_server.py` — eight watcher tests migrated, including idempotency and handler routing.
- [x] `tests/test_cli_contract.py` — three `_DummyServer` mocks updated to expose `watch_intake.start` / `watch_intake.stop` and `async shutdown()` instead of `start_file_watcher` / `stop_file_watcher`.
- [x] `tests/test_provenance_conformance.py` — two call sites migrated.
- [x] `make check` (lint + pyright + 1142 unit tests) green.
- [x] All directly-touched integration tests green: 10 `test_file_watcher_events`, 8 watcher tests in `test_server`, 6 in `TestSyncFromDisk`, 2 in `TestReadPathNormalization`, 1 in `TestFileWatcherRace`, 4 in `TestFileWatcherEventsCounter`, all three `test_cli_contract` serve tests.

Integration suite has CUDA OOM flakes unrelated to this PR (sentence-transformer model accumulates across sequential tests); each affected test passes in isolation.

## Acceptance criteria (issue #261)

- [x] `src/lithos/watch_intake.py` with `WatchIntake` matching the signature in the issue; private `_update_lock`, private nested `_FileChangeHandler`.
- [x] `LithosServer` strips all watcher state and methods; `initialize()` builds `WatchIntake` after `SearchEngine.create()` returns; `shutdown()` calls `watch_intake.stop()` then conditional `graph.save_cache()`.
- [x] All four watcher emits carry `agent=\"watcher\"`.
- [x] `delete_from_disk` emits `NOTE_DELETED` after `KnowledgeManager.delete`; capture-before-mutate enforced inside `_update_lock`.
- [x] Verification regression test added.

## Out of scope (per issue)

- Dropping `_update_lock` entirely in favour of idempotency under benign-race semantics.
- Surfacing `agent=\"watcher\"` in `lithos_events` filtering UX or SSE client docs.