### PR TITLE
fix(search): add SearchConfig.device, force CPU in tests (#272)

### DIFF
--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -111,6 +111,13 @@ class SearchConfig(BaseModel):
     max_results: int = 50
     chunk_size: int = 500
     chunk_max: int = 1000
+    # Device for the SentenceTransformer embedder. ``"auto"`` (the default)
+    # lets sentence-transformers pick — CUDA when available, else CPU —
+    # matching the historical behaviour. Explicit values (``"cpu"``,
+    # ``"cuda"``, ``"cuda:0"``, …) are passed straight through. Tests force
+    # ``"cpu"`` to avoid the GPU-memory accumulation that piles up across
+    # function-scoped fixture rebuilds; see issue #272.
+    device: str = "auto"
 
 
 class CoordinationConfig(BaseModel):

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -659,15 +659,26 @@ def generate_snippet(content: str, query: str, context_chars: int = 150) -> str:
 class ChromaIndex:
     """ChromaDB semantic search index."""
 
-    def __init__(self, chroma_path: Path, model_name: str = "all-MiniLM-L6-v2"):
+    def __init__(
+        self,
+        chroma_path: Path,
+        model_name: str = "all-MiniLM-L6-v2",
+        device: str = "auto",
+    ):
         """Initialize ChromaDB index.
 
         Args:
             chroma_path: Path to store ChromaDB data
             model_name: Sentence transformer model name
+            device: Device passed to SentenceTransformer. ``"auto"`` lets
+                sentence-transformers pick (CUDA if available, else CPU);
+                any other value (``"cpu"``, ``"cuda"``, ``"cuda:0"``, …) is
+                forwarded verbatim. Tests force ``"cpu"`` to keep the GPU
+                idle across function-scoped fixture rebuilds (issue #272).
         """
         self.chroma_path = chroma_path
         self.model_name = model_name
+        self.device = device
         self._client: ClientAPI | None = None
         self._collection: chromadb.Collection | None = None
         self._model: SentenceTransformer | None = None
@@ -678,7 +689,14 @@ class ChromaIndex:
         """Load the embedding model exactly once across sync and async callers."""
         with self._sync_model_lock:
             if self._model is None:
-                self._model = SentenceTransformer(self.model_name)
+                # ``"auto"`` preserves the historical behaviour (let
+                # sentence-transformers pick CUDA when available, else CPU).
+                # Any explicit value is forwarded verbatim — including
+                # ``"cpu"`` for tests, per issue #272.
+                if self.device == "auto":
+                    self._model = SentenceTransformer(self.model_name)
+                else:
+                    self._model = SentenceTransformer(self.model_name, device=self.device)
             return self._model
 
     @property
@@ -1077,6 +1095,7 @@ class SearchEngine:
             self._chroma_idx = ChromaIndex(
                 self.config.storage.chroma_path,
                 self.config.search.embedding_model,
+                device=self.config.search.device,
             )
         return self._chroma_idx
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,20 @@
 """Pytest configuration and fixtures."""
 
+import os
+
+# Hide the GPU from the test process before importing anything that
+# transitively imports torch (lithos.search → sentence_transformers →
+# torch). With a GPU visible, PyTorch lazily initialises a CUDA context
+# on first probe (``torch.cuda.is_available()``, sentence-transformers'
+# device-detect path) and cuDNN/cuBLAS reserve ~4 GiB on the device
+# even when every model is constructed with ``device="cpu"``. Issue
+# #272 covers the long form. ``setdefault`` keeps this overridable: a
+# developer who really wants a GPU for a debug session can set
+# ``CUDA_VISIBLE_DEVICES=0`` explicitly before running pytest.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
 import gc
 import logging
-import os
 import shutil
 import tempfile
 import threading
@@ -12,7 +24,13 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
-from lithos.config import LithosConfig, SearchConfig, StorageConfig, _reset_config, set_config
+from lithos.config import (
+    LithosConfig,
+    SearchConfig,
+    StorageConfig,
+    _reset_config,
+    set_config,
+)
 from lithos.coordination import CoordinationService
 from lithos.graph import KnowledgeGraph
 from lithos.knowledge import KnowledgeManager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
-from lithos.config import LithosConfig, StorageConfig, _reset_config, set_config
+from lithos.config import LithosConfig, SearchConfig, StorageConfig, _reset_config, set_config
 from lithos.coordination import CoordinationService
 from lithos.graph import KnowledgeGraph
 from lithos.knowledge import KnowledgeManager
@@ -122,8 +122,15 @@ def test_config(
     """
     for var in _LITHOS_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+    # Pin the embedder to CPU for tests. The function-scoped ``server``
+    # fixture rebuilds the SentenceTransformer per test; on CUDA hosts
+    # PyTorch's caching allocator and ChromaDB workspaces accumulate
+    # ~20 GB of VRAM across a full integration run (issue #272). Tests
+    # don't need a GPU — MiniLM-L6 on CPU embeds the few short docs
+    # each test produces in well under a second.
     config = LithosConfig(
         storage=StorageConfig(data_dir=temp_dir),
+        search=SearchConfig(device="cpu"),
     )
     config.ensure_directories()
     set_config(config)


### PR DESCRIPTION
## Summary

Closes #272. Stops the integration test suite from accumulating ~20 GiB of VRAM (and crashing other GPU clients on the host) by adding an explicit `device` field on `SearchConfig` and pinning it to `"cpu"` for tests.

- `SearchConfig.device: str = "auto"` — defaults preserve historical behaviour (sentence-transformers picks CUDA when available, else CPU). Any explicit value (`"cpu"`, `"cuda"`, `"cuda:0"`, …) is forwarded verbatim to `SentenceTransformer(device=...)`.
- `ChromaIndex` accepts the field through its constructor; `SearchEngine._chroma` threads `self.config.search.device` into it.
- `tests/conftest.py::test_config` sets `search=SearchConfig(device="cpu")` so the function-scoped `server` fixture never instantiates a GPU embedder.

## Why this is the right shape

Per-test the model is ~120 MiB on GPU, but PyTorch's CUDA caching allocator never returns memory to the driver and ChromaDB's per-test workspace adds more cached blocks. Across ~250 integration tests in a single pytest process this drifts to ~20 GiB and starves the rest of the desktop session.

Other options considered (and rejected) in #272: session-scoped server fixture (breaks per-test isolation), aggressive `gc.collect()` + `torch.cuda.empty_cache()` in teardown (partial relief, slower tests). This option targets the root cause — tests don't need a GPU.

## Verification

- `make check` green: ruff, pyright, **1142 unit tests** in 11m11s.
- Integration slice (`tests/test_file_watcher_events.py`, `tests/test_intake.py`, `tests/test_smoke.py`): **17 passed**.
- `nvidia-smi --query-compute-apps=pid,used_memory` polled every 5s during the run: pytest process held **0 MiB** on the GPU throughout (previously climbed to ~18–20 GiB).
- `LITHOS_SEARCH_DEVICE=cpu` works as an env override via pydantic-settings (free side-benefit of adding the field).

## Test plan

- [x] `make check`
- [x] Targeted integration slice with `nvidia-smi` monitoring
- [ ] Full `make test-integration` on a CUDA host — confirms the previously-flaky CUDA-OOM cascade (which also triggered the pre-existing `_NoOpSpan.set_status` signature bug at `server.py:756`) no longer fires