### PR TITLE
refactor(reconcile): route cli reindex and server _rebuild_indices through KnowledgeManager.plan_reconcile

### DIFF
--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -187,6 +187,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
     """Rebuild search indices from knowledge files."""
     from lithos.graph import KnowledgeGraph
     from lithos.knowledge import KnowledgeManager
+    from lithos.provenance import ProvenanceProjection
     from lithos.search import SearchEngine
 
     config: LithosConfig = ctx.obj["config"]
@@ -197,47 +198,52 @@ def reindex(ctx: click.Context, clear: bool) -> None:
 
     async def do_reindex() -> None:
         search = await SearchEngine.create(config)
-        if clear:
-            click.echo("Clearing existing indices...")
-            logger.info("reindex: clearing existing indices clear=True")
-            search.clear_all()
-            graph.clear()
+        projection = await ProvenanceProjection.create(config)
+        try:
+            if clear:
+                click.echo("Clearing existing indices...")
+                logger.info("reindex: clearing existing indices clear=True")
+                search.clear_all()
+                graph.clear()
 
-        knowledge_path = config.storage.knowledge_path
-        files = list(knowledge_path.rglob("*.md"))
+            # --clear forces a full rebuild; otherwise plan_reconcile is the
+            # single source of truth for what needs touching.
+            knowledge_path = config.storage.knowledge_path
+            files = list(knowledge_path.rglob("*.md"))
 
-        click.echo(f"Found {len(files)} markdown files")
-        logger.info("reindex started: file_count=%d clear=%s", len(files), clear)
+            click.echo(f"Found {len(files)} markdown files")
+            logger.info("reindex started: file_count=%d clear=%s", len(files), clear)
 
-        indexed = 0
-        errors = 0
+            plan = await knowledge.plan_reconcile(search=search, graph=graph, projection=projection)
+            result = await knowledge.apply_reconcile(
+                plan, search=search, graph=graph, projection=projection
+            )
 
-        with click.progressbar(files, label="Indexing") as bar:
-            for file_path in bar:
-                try:
-                    relative_path = file_path.relative_to(knowledge_path)
-                    doc, _ = await knowledge.read(path=str(relative_path))
-                    search.index(KnowledgeManager.to_indexable(doc))
-                    graph.add_document(doc)
-                    indexed += 1
-                except Exception as e:
-                    errors += 1
-                    click.echo(f"\nError indexing {file_path}: {e}", err=True)
-                    logger.error("reindex error: path=%s error=%s", file_path, e)
+            indexed = result.search.scanned if result.search else 0
+            errors = len(result.search.failed) if result.search else 0
+            if result.search:
+                for failure in result.search.failed:
+                    click.echo(
+                        f"\nError indexing {failure.backend} backend: {failure.detail}", err=True
+                    )
+                    logger.error(
+                        "reindex error: backend=%s error=%s",
+                        failure.backend,
+                        failure.detail,
+                    )
 
-        # Save graph cache
-        graph.save_cache()
+            click.echo(f"\nIndexed {indexed} documents")
+            logger.info("reindex complete: indexed=%d errors=%d", indexed, errors)
+            if errors:
+                click.echo(f"Errors: {errors}", err=True)
 
-        click.echo(f"\nIndexed {indexed} documents")
-        logger.info("reindex complete: indexed=%d errors=%d", indexed, errors)
-        if errors:
-            click.echo(f"Errors: {errors}", err=True)
-
-        # Show stats
-        stats = search.get_stats()
-        click.echo(f"Total chunks: {stats.get('chroma_chunk_count', 0)}")
-        click.echo(f"Graph nodes: {graph.node_count()}")
-        click.echo(f"Graph edges: {graph.edge_count()}")
+            # Show stats
+            stats = search.get_stats()
+            click.echo(f"Total chunks: {stats.get('chroma_chunk_count', 0)}")
+            click.echo(f"Graph nodes: {graph.node_count()}")
+            click.echo(f"Graph edges: {graph.edge_count()}")
+        finally:
+            await projection.close()
 
     asyncio.run(do_reindex())
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -867,28 +867,34 @@ class LithosServer:
         """Rebuild all search indices from files."""
         tracer = get_tracer()
         with tracer.start_as_current_span("lithos.index.rebuild") as span:
+            # Hard reset so plan_reconcile sees an empty world and re-emits
+            # an `add` per doc — preserves today's full-rebuild semantics.
             self.search.clear_all()
             self.graph.clear()
             self.knowledge.rescan()
 
-            knowledge_path = self.config.storage.knowledge_path
-            file_count = 0
-            error_count = 0
-            for file_path in knowledge_path.rglob("*.md"):
-                try:
-                    relative_path = file_path.relative_to(knowledge_path)
-                    doc, _ = await self.knowledge.read(path=str(relative_path))
-                    indexable = KnowledgeManager.to_indexable(doc)
-                    await asyncio.to_thread(self.search.index, indexable)
-                    self.graph.add_document(doc)
-                    file_count += 1
-                except Exception as e:
-                    error_count += 1
-                    logger.error("Error indexing %s: %s", file_path, e)
+            plan = await self.knowledge.plan_reconcile(
+                search=self.search,
+                graph=self.graph,
+                projection=self.projection,
+            )
+            result = await self.knowledge.apply_reconcile(
+                plan,
+                search=self.search,
+                graph=self.graph,
+                projection=self.projection,
+            )
+
+            file_count = result.search.scanned if result.search else 0
+            error_count = len(result.search.failed) if result.search else 0
+            if result.search:
+                for failure in result.search.failed:
+                    logger.error("Error indexing %s backend: %s", failure.backend, failure.detail)
 
             span.set_attribute("lithos.file_count", file_count)
             span.set_attribute("lithos.error_count", error_count)
-            self.graph.save_cache()
+            # KnowledgeGraph._apply_reconcile flushes the cache itself
+            # (graph.py:929-948); explicit save_cache() is redundant.
 
     def _bfs_provenance(self, start_id: str, direction: str, depth: int) -> list[dict[str, str]]:
         """BFS traversal over provenance indexes.

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -66,6 +66,37 @@ class TestCLIContracts:
         assert "1. CLI Contract Seed (score:" in search.output
         assert "Path:" in search.output
 
+    def test_reindex_is_idempotent_via_plan_apply(self, temp_dir):
+        """Issue #256: routing reindex through plan_reconcile/apply_reconcile
+        means a second run against the same corpus must still report the same
+        indexed-document count and exit cleanly. The manual loop never had to
+        survive a no-op-on-clean-corpus pass; the new seam does."""
+        config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
+        config.ensure_directories()
+        set_config(config)
+
+        knowledge = KnowledgeManager(config)
+
+        async def _seed() -> None:
+            await knowledge.create(
+                title="Idempotent Reindex Seed",
+                content="ReindexIdempotentTerm seeded once, indexed twice.",
+                agent="cli-test",
+            )
+
+        asyncio.run(_seed())
+
+        runner = CliRunner()
+        first = runner.invoke(cli, ["--data-dir", str(temp_dir), "reindex"])
+        assert first.exit_code == 0, first.output
+        assert "Found 1 markdown files" in first.output
+        assert "Indexed 1 documents" in first.output
+
+        second = runner.invoke(cli, ["--data-dir", str(temp_dir), "reindex"])
+        assert second.exit_code == 0, second.output
+        assert "Found 1 markdown files" in second.output
+        assert "Indexed 1 documents" in second.output
+
     def test_inspect_doc_output_shape(self, temp_dir):
         config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
         config.ensure_directories()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -174,6 +174,56 @@ class TestServerInitialization:
             await server.shutdown()
 
     @pytest.mark.asyncio
+    async def test_rebuild_indices_routes_through_knowledge_manager(self, server: LithosServer):
+        """_rebuild_indices uses KnowledgeManager.plan_reconcile/apply_reconcile.
+
+        Integration-level guard for issue #256: the manual per-doc loop is
+        gone, so _rebuild_indices must produce the same final state via the
+        unified plan/apply seam.
+        """
+        await server.knowledge.create(
+            title="Rebuild Note A",
+            content="Body A mentions ReindexTerm and links to [[Rebuild Note B]].",
+            agent="rebuild-test",
+            path="rebuild-a",
+        )
+        await server.knowledge.create(
+            title="Rebuild Note B",
+            content="Body B also mentions ReindexTerm.",
+            agent="rebuild-test",
+            path="rebuild-b",
+        )
+
+        await server._rebuild_indices()
+
+        assert server.search.count_documents() == 2
+        assert server.graph.node_count() >= 2
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indices_passes_projection(self, server: LithosServer):
+        """_rebuild_indices wires the server's projection through the seam.
+
+        Pins the wiring so a future caller cannot accidentally reconcile
+        search+graph without also reconciling the provenance projection.
+        """
+        captured: dict[str, object] = {}
+        original_plan = server.knowledge.plan_reconcile
+
+        async def _capture_plan(**kwargs):
+            captured.update(kwargs)
+            return await original_plan(**kwargs)
+
+        server.knowledge.plan_reconcile = _capture_plan  # type: ignore[method-assign]
+        try:
+            await server._rebuild_indices()
+        finally:
+            server.knowledge.plan_reconcile = original_plan  # type: ignore[method-assign]
+
+        assert captured.get("search") is server.search
+        assert captured.get("graph") is server.graph
+        assert captured.get("projection") is server.projection
+
+    @pytest.mark.asyncio
     async def test_start_and_stop_watch_intake_is_idempotent(self, server: LithosServer):
         """Starting twice and stopping twice should not raise."""
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary

Sweeps the two pre-ADR-0001 reindex paths through the unified `KnowledgeManager.plan_reconcile / apply_reconcile` seam:

- `cli.py reindex` command — manual `clear_all()` + per-doc loop replaced with `plan_reconcile`/`apply_reconcile`. CLI now opens its own `ProvenanceProjection` lifecycle.
- `server._rebuild_indices` — same migration. `graph.save_cache()` removed since `KnowledgeGraph._apply_reconcile` flushes itself.

`ReconcileFailure` carries `backend` + `detail` (per-backend) — the plan's example used a hypothetical `.doc_id`; per-backend errors more honestly reflect what `plan_reconcile` actually surfaces.

## Test plan

- [x] `make check` green (lint + pyright + 1142 unit tests pass)
- [x] `make test-integration` green (349 integration tests pass)
- [x] Manual `lithos reindex` smoke against a 2-note corpus produces identical output before vs after on `main`
- [x] Two new tests added: `test_reindex_is_idempotent_via_plan_apply` (cli contract), `test_rebuild_indices_routes_through_knowledge_manager` + `test_rebuild_indices_passes_projection` (server)

Closes #256.