### PR TITLE
feat(cognitive-memory): migrate retrieve to CognitiveMemory + add error taxonomy

### DIFF
--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -2,13 +2,16 @@
 
 See docs/adr/0005-cognitive-memory-module.md.
 
-This slice (issue #255) lands the seam and lifecycle ordering only.
-``CognitiveMemory`` owns the ``StatsStore`` and the ``EnrichWorker``;
-``LithosServer.initialize()`` constructs the Module after the projection
-is ready and ``LithosServer.shutdown()`` stops it first. Public read /
-write methods (retrieve, edge_*, reinforce_*, etc.) migrate in
-subsequent slices (#257-#260); existing MCP tool handlers continue to
-call LCMA internals directly through server-level aliases.
+Issue #255 landed the seam and lifecycle ordering. Issue #257 migrated
+``retrieve`` into the Module; the ``lithos_retrieve`` MCP handler in
+``LithosServer`` is now a one-line envelope wrapper. The remaining write
+methods (edge_*, reinforce_*, etc.) migrate in subsequent slices
+(#258-#260); their MCP handlers continue to call LCMA internals directly
+through server-level aliases until then.
+
+Method ordering convention: lifecycle methods first (``create``,
+``attach_coordination``, ``start``, ``stop``), then public agent-facing
+methods grouped by domain (retrieve / edges / reinforcement / stats).
 """
 
 from __future__ import annotations
@@ -151,3 +154,76 @@ class CognitiveMemory:
             self._enrich_worker = None
         await self._stats_store.close()
         self._started = False
+
+    # ------------------------------------------------------------------
+    # Retrieve (issue #257)
+    # ------------------------------------------------------------------
+
+    async def retrieve(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        namespace_filter: list[str] | None = None,
+        agent_id: str | None = None,
+        task_id: str | None = None,
+        surface_conflicts: bool = False,
+        max_context_nodes: int | None = None,
+        tags: list[str] | None = None,
+        path_prefix: str | None = None,
+    ) -> dict[str, object]:
+        """Run the parallel-terraced-scan retrieve pipeline.
+
+        See ``docs/adr/0005-cognitive-memory-module.md`` and
+        ``src/lithos/lcma/retrieve.py`` for the algorithm. This method is the
+        public seam — the ``lithos_retrieve`` MCP handler is a thin envelope
+        around it.
+
+        Errors:
+            - ``ScoutFailure`` is raised inside the orchestrator when a single
+              scout's backend fails, then **caught and logged** at one
+              documented boundary inside this method. Callers do not see it.
+            - ``CognitiveMemoryError`` (other subtypes — e.g. RetrieveTimeout)
+              **propagates** to the caller. The MCP envelope translates it to
+              an error response.
+            - ``RuntimeError`` is raised if called before :meth:`start`.
+            - Any other exception (e.g. StatsStore I/O failure on receipt
+              write) propagates; they are not part of the retrieve contract.
+
+        Precondition:
+            ``config.lcma.enabled`` is True. The ``lcma_disabled``
+            short-circuit lives in the MCP handler envelope; this method
+            asserts ``self._coordination is not None`` (which ``start()``
+            enforces when LCMA is enabled).
+        """
+        if not self._started:
+            raise RuntimeError("CognitiveMemory.retrieve called before start()")
+        assert self._coordination is not None, (
+            "CognitiveMemory.retrieve requires coordination; the MCP handler's "
+            "lcma_disabled short-circuit must run before reaching this method."
+        )
+
+        # Local import keeps the orchestrator implementation a leaf module;
+        # importing it at module load would create an import cycle through
+        # lithos.lcma.scouts → lithos.search/knowledge.
+        from lithos.lcma.retrieve import _run_retrieve_impl
+
+        return await _run_retrieve_impl(
+            query=query,
+            search=self._search,
+            knowledge=self._knowledge,
+            graph=self._graph,
+            coordination=self._coordination,
+            edge_store=self._projection._edge_store,
+            projection=self._projection,
+            stats_store=self._stats_store,
+            lcma_config=self._config.lcma,
+            limit=limit,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            surface_conflicts=surface_conflicts,
+            max_context_nodes=max_context_nodes,
+            tags=tags,
+            path_prefix=path_prefix,
+        )

--- a/src/lithos/errors.py
+++ b/src/lithos/errors.py
@@ -66,3 +66,39 @@ class IndexingError(LithosError):
     def __str__(self) -> str:
         detail = ", ".join(f"{backend}: {exc}" for backend, exc in self.backend_errors.items())
         return f"{super().__str__()} [{detail}]"
+
+
+class CognitiveMemoryError(LithosError):
+    """Base error for any failure originating inside CognitiveMemory.
+
+    Catch this to handle "the cognitive memory subsystem could not satisfy
+    the request" without caring which sub-component failed.
+    """
+
+
+class ScoutFailure(CognitiveMemoryError):
+    """A single retrieval scout's backend raised.
+
+    Caught and logged inside CognitiveMemory.retrieve so one bad scout does
+    not kill the whole retrieve. Carried as an exception type (rather than a
+    log line) so future code can branch on it — e.g. degraded-mode reporting
+    in the result envelope.
+
+    Attributes:
+        scout: The canonical scout name (e.g. ``"scout_vector"``).
+        cause: The underlying exception the scout raised.
+    """
+
+    def __init__(self, scout: str, cause: BaseException) -> None:
+        super().__init__(f"scout {scout!r} failed: {cause}")
+        self.scout = scout
+        self.cause = cause
+
+
+class RetrieveTimeout(CognitiveMemoryError):
+    """Retrieve exceeded its configured wall-clock budget.
+
+    Reserved for the Phase A gather timeout (when LcmaConfig grows the knob).
+    Defined now so #258/#259/#260 — and a future timeout slice — share one
+    base hierarchy.
+    """

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -24,6 +24,7 @@ import re
 import time
 from typing import TYPE_CHECKING
 
+from lithos.errors import ScoutFailure
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
     scout_coactivation,
@@ -296,7 +297,7 @@ async def compute_temperature(
     return temperature
 
 
-async def run_retrieve(
+async def _run_retrieve_impl(
     *,
     query: str,
     search: SearchEngine,
@@ -316,10 +317,23 @@ async def run_retrieve(
     tags: list[str] | None = None,
     path_prefix: str | None = None,
 ) -> dict[str, object]:
-    """Execute the full LCMA retrieval pipeline.
+    """Execute the full LCMA retrieval pipeline (module-private).
+
+    The public seam is :meth:`lithos.cognitive_memory.CognitiveMemory.retrieve`,
+    which wires the six store dependencies from its own state and forwards the
+    request here. Direct callers (tests, future internal pipelines) may import
+    this implementation function under its private name.
 
     Returns the response envelope with results, temperature, terrace_reached,
     and receipt_id.
+
+    Errors:
+        - Per-scout backend failures are wrapped in :class:`ScoutFailure` and
+          caught at one documented boundary inside this function (so a single
+          misbehaving backend cannot kill the whole retrieve). The audit trail
+          (``scouts_fired``) reflects which scouts ran cleanly.
+        - All other exceptions (e.g. ``StatsStore`` I/O failures) propagate
+          to the caller; they are not wrapped in ``ScoutFailure``.
     """
     if max_context_nodes is None:
         max_context_nodes = limit
@@ -395,10 +409,18 @@ async def run_retrieve(
         all_candidates: list[Candidate] = []
         for name, result in zip(phase_a_names, phase_a_results, strict=True):
             if isinstance(result, BaseException):
-                logger.warning(
-                    "run_retrieve: phase A scout failed",
-                    extra={"scout": name, "error": str(result)},
-                )
+                # ADR-0005 contract: per-scout failures are caught here so a
+                # single misbehaving backend cannot kill the whole retrieve.
+                # Anything escaping is a CognitiveMemoryError and propagates
+                # to the caller.
+                try:
+                    raise ScoutFailure(scout=name, cause=result) from result
+                except ScoutFailure as scout_err:
+                    logger.warning(
+                        "run_retrieve: phase A scout failed",
+                        extra={"scout": name, "error": str(scout_err.cause)},
+                        exc_info=True,
+                    )
                 continue
             executed_scouts.add(name)
             all_candidates.extend(result)
@@ -454,12 +476,19 @@ async def run_retrieve(
                     "run_retrieve: phase B scout completed",
                     extra={"scout": "scout_provenance", "candidates": len(prov_candidates)},
                 )
-            except Exception:
-                logger.warning(
-                    "run_retrieve: phase B scout failed",
-                    extra={"scout": "scout_provenance"},
-                    exc_info=True,
-                )
+            except Exception as exc:
+                # ADR-0005 contract: per-scout failures are caught here so a
+                # single misbehaving backend cannot kill the whole retrieve.
+                # Anything escaping is a CognitiveMemoryError and propagates
+                # to the caller.
+                try:
+                    raise ScoutFailure(scout="scout_provenance", cause=exc) from exc
+                except ScoutFailure:
+                    logger.warning(
+                        "run_retrieve: phase B scout failed",
+                        extra={"scout": "scout_provenance"},
+                        exc_info=True,
+                    )
 
             try:
                 _t = time.perf_counter()
@@ -479,12 +508,16 @@ async def run_retrieve(
                     "run_retrieve: phase B scout completed",
                     extra={"scout": "scout_graph", "candidates": len(graph_candidates)},
                 )
-            except Exception:
-                logger.warning(
-                    "run_retrieve: phase B scout failed",
-                    extra={"scout": "scout_graph"},
-                    exc_info=True,
-                )
+            except Exception as exc:
+                # ADR-0005 contract: per-scout failures are caught here.
+                try:
+                    raise ScoutFailure(scout="scout_graph", cause=exc) from exc
+                except ScoutFailure:
+                    logger.warning(
+                        "run_retrieve: phase B scout failed",
+                        extra={"scout": "scout_graph"},
+                        exc_info=True,
+                    )
 
             try:
                 _t = time.perf_counter()
@@ -504,12 +537,16 @@ async def run_retrieve(
                     "run_retrieve: phase B scout completed",
                     extra={"scout": "scout_coactivation", "candidates": len(coact_candidates)},
                 )
-            except Exception:
-                logger.warning(
-                    "run_retrieve: phase B scout failed",
-                    extra={"scout": "scout_coactivation"},
-                    exc_info=True,
-                )
+            except Exception as exc:
+                # ADR-0005 contract: per-scout failures are caught here.
+                try:
+                    raise ScoutFailure(scout="scout_coactivation", cause=exc) from exc
+                except ScoutFailure:
+                    logger.warning(
+                        "run_retrieve: phase B scout failed",
+                        extra={"scout": "scout_coactivation"},
+                        exc_info=True,
+                    )
 
             try:
                 _t = time.perf_counter()
@@ -529,12 +566,16 @@ async def run_retrieve(
                     "run_retrieve: phase B scout completed",
                     extra={"scout": "scout_source_url", "candidates": len(src_url_candidates)},
                 )
-            except Exception:
-                logger.warning(
-                    "run_retrieve: phase B scout failed",
-                    extra={"scout": "scout_source_url"},
-                    exc_info=True,
-                )
+            except Exception as exc:
+                # ADR-0005 contract: per-scout failures are caught here.
+                try:
+                    raise ScoutFailure(scout="scout_source_url", cause=exc) from exc
+                except ScoutFailure:
+                    logger.warning(
+                        "run_retrieve: phase B scout failed",
+                        extra={"scout": "scout_source_url"},
+                        exc_info=True,
+                    )
 
         # Contradictions — only fire when surface_conflicts is True
         conflicts_found: list[dict[str, object]] = []
@@ -552,12 +593,16 @@ async def run_retrieve(
                     "run_retrieve: contradictions surfaced",
                     extra={"conflict_count": len(conflicts_found)},
                 )
-            except Exception:
-                logger.warning(
-                    "run_retrieve: phase B scout failed",
-                    extra={"scout": "scout_contradictions"},
-                    exc_info=True,
-                )
+            except Exception as exc:
+                # ADR-0005 contract: per-scout failures are caught here.
+                try:
+                    raise ScoutFailure(scout="scout_contradictions", cause=exc) from exc
+                except ScoutFailure:
+                    logger.warning(
+                        "run_retrieve: phase B scout failed",
+                        extra={"scout": "scout_contradictions"},
+                        exc_info=True,
+                    )
 
         # Record scouts_fired using canonical names in order. A scout
         # appears here iff it executed without raising — empty result

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1642,9 +1642,11 @@ class LithosServer:
                 span.set_attribute("lithos.query.length", len(query))
                 span.set_attribute("lithos.limit", limit)
 
-                # Check LCMA enabled
-                lcma_config = self._config.lcma
-                if not lcma_config.enabled:
+                # Envelope-shaping short-circuit: when LCMA is disabled the
+                # CognitiveMemory.retrieve precondition would fail, so we
+                # surface a typed error response instead. The Module method
+                # itself stays free of envelope concerns.
+                if not self._config.lcma.enabled:
                     logger.warning("lithos_retrieve: LCMA is disabled")
                     return {
                         "status": "error",
@@ -1652,18 +1654,8 @@ class LithosServer:
                         "message": "LCMA is disabled via configuration",
                     }
 
-                from lithos.lcma.retrieve import run_retrieve
-
-                result = await run_retrieve(
+                result = await self.memory.retrieve(
                     query=query,
-                    search=self.search,
-                    knowledge=self.knowledge,
-                    graph=self.graph,
-                    coordination=self.coordination,
-                    edge_store=self.edge_store,
-                    projection=self.projection,
-                    stats_store=self.stats_store,
-                    lcma_config=lcma_config,
                     limit=limit,
                     namespace_filter=namespace_filter,
                     agent_id=agent_id,

--- a/tests/test_coactivation.py
+++ b/tests/test_coactivation.py
@@ -20,7 +20,7 @@ import pytest_asyncio
 from lithos.config import LcmaConfig, LithosConfig, StorageConfig
 from lithos.graph import KnowledgeGraph
 from lithos.knowledge import KnowledgeManager
-from lithos.lcma.retrieve import _dominant_namespace, run_retrieve
+from lithos.lcma.retrieve import _dominant_namespace, _run_retrieve_impl
 from lithos.lcma.stats import StatsStore
 from lithos.provenance import EdgeStore, ProvenanceProjection
 from lithos.search import SearchEngine
@@ -215,7 +215,7 @@ class TestCoactivationSingleCall:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -257,7 +257,7 @@ class TestCoactivationSingleCall:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -293,7 +293,7 @@ class TestCoactivationSingleCall:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -335,7 +335,7 @@ class TestCoactivationMultiCall:
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
             # First call
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -347,7 +347,7 @@ class TestCoactivationMultiCall:
                 lcma_config=LcmaConfig(),
             )
             # Second call
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -383,7 +383,7 @@ class TestCoactivationMultiCall:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -394,7 +394,7 @@ class TestCoactivationMultiCall:
                 stats_store=stats_store,
                 lcma_config=LcmaConfig(),
             )
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -1,25 +1,28 @@
-"""Tests for the CognitiveMemory Module scaffold and lifecycle (ADR-0005).
+"""Tests for the CognitiveMemory Module (ADR-0005).
 
-This slice (issue #255) only exercises construction and start/stop. Public
-read/write methods migrate in subsequent slices (#257-#260); their tests
-land with those changes.
+Issue #255 covered construction and start/stop. Issue #257 adds the
+``retrieve`` seam tests below. Remaining write methods migrate in
+subsequent slices (#258-#260) with their tests.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
 import textwrap
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
 
 from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig
+from lithos.errors import ScoutFailure
 from lithos.events import EventBus
+from lithos.lcma.utils import Candidate
 from lithos.provenance import ProvenanceProjection
 
 
@@ -267,6 +270,195 @@ class TestLcmaDisabled:
         finally:
             await cm.stop()
             assert cm._stats_store._opened is False
+
+
+# ---------------------------------------------------------------------------
+# Retrieve (issue #257)
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieve:
+    """``CognitiveMemory.retrieve`` is the public seam for the LCMA pipeline.
+
+    These tests exercise the seam in isolation — the ``_run_retrieve_impl``
+    function itself is covered exhaustively by ``tests/test_retrieve.py``.
+    Here we only verify (1) the precondition contract, (2) that
+    ``ScoutFailure`` is raised by the implementation but caught at the
+    documented boundary, (3) that filter kwargs flow through, and (4) that
+    the limit is honoured.
+    """
+
+    async def test_retrieve_before_start_raises(self, memory: CognitiveMemory) -> None:
+        """Calling retrieve before start() is a programmer error."""
+        with pytest.raises(RuntimeError, match="called before start"):
+            await memory.retrieve("alpha", limit=3)
+
+    async def test_retrieve_happy_path(self, memory: CognitiveMemory) -> None:
+        """retrieve delegates to _run_retrieve_impl with the wired stores."""
+        await memory.start()
+
+        envelope: dict[str, object] = {
+            "results": [],
+            "temperature": 0.5,
+            "terrace_reached": 1,
+            "receipt_id": "test-receipt",
+        }
+        with patch(
+            "lithos.lcma.retrieve._run_retrieve_impl",
+            new_callable=AsyncMock,
+            return_value=envelope,
+        ) as impl:
+            result = await memory.retrieve("alpha", limit=3, namespace_filter=["proj-a"])
+
+        assert result is envelope
+        impl.assert_awaited_once()
+        kwargs = impl.await_args.kwargs
+        assert kwargs["query"] == "alpha"
+        assert kwargs["limit"] == 3
+        assert kwargs["namespace_filter"] == ["proj-a"]
+        # Stores wired from self
+        assert kwargs["search"] is memory._search
+        assert kwargs["knowledge"] is memory._knowledge
+        assert kwargs["graph"] is memory._graph
+        assert kwargs["coordination"] is memory._coordination
+        assert kwargs["projection"] is memory._projection
+        assert kwargs["stats_store"] is memory._stats_store
+        assert kwargs["edge_store"] is memory._projection._edge_store
+        assert kwargs["lcma_config"] is memory._config.lcma
+
+    async def test_retrieve_scout_failure_logged_not_raised(
+        self,
+        memory: CognitiveMemory,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A backend that raises is wrapped in ScoutFailure, logged, and the
+        retrieve completes successfully without that scout's results.
+
+        ADR-0005 boundary contract: per-scout failures are caught inside
+        the orchestrator (``_run_retrieve_impl``), not propagated to
+        ``CognitiveMemory.retrieve``'s caller.
+        """
+        await memory.start()
+
+        # Make every scout return [] except scout_vector which raises. The
+        # scouts are imported into ``lithos.lcma.retrieve`` at module load,
+        # so we patch them in *that* namespace, not in lithos.lcma.scouts.
+        empty_scout = AsyncMock(return_value=[])
+        # Stub the projection's edge_store.compute_temperature to a no-op
+        # so we don't hit the real backend either.
+
+        with (
+            patch(
+                "lithos.lcma.retrieve.scout_vector",
+                new=AsyncMock(side_effect=RuntimeError("backend down")),
+            ),
+            patch("lithos.lcma.retrieve.scout_lexical", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_provenance", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_graph", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_coactivation", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_source_url", new=empty_scout),
+            caplog.at_level(logging.WARNING, logger="lithos.lcma.retrieve"),
+        ):
+            result = await memory.retrieve("alpha", limit=5)
+
+        # Pipeline returned normally.
+        assert result["receipt_id"]
+        assert result["results"] == []
+
+        # The phase A scout warning is present; the captured exc chain is a
+        # ScoutFailure naming the failed scout.
+        scout_records = [r for r in caplog.records if "phase A scout failed" in r.getMessage()]
+        assert scout_records, "expected a phase A scout failure log record"
+        record = scout_records[0]
+        assert record.exc_info is not None
+        exc = record.exc_info[1]
+        assert isinstance(exc, ScoutFailure)
+        assert exc.scout == "scout_vector"
+        assert isinstance(exc.cause, RuntimeError)
+
+    async def test_retrieve_namespace_filter_passes_through(self, memory: CognitiveMemory) -> None:
+        """Cross-scout filter contract: every scout receives namespace_filter.
+
+        See ``retrieve.py`` Phase A scout_kw construction — all scouts must
+        enforce the same caller-supplied filters so the global view is
+        consistent regardless of which backend a candidate came from.
+        """
+        await memory.start()
+
+        vector_spy = AsyncMock(return_value=[])
+        lexical_spy = AsyncMock(return_value=[])
+        empty_scout = AsyncMock(return_value=[])
+
+        with (
+            patch("lithos.lcma.retrieve.scout_vector", new=vector_spy),
+            patch("lithos.lcma.retrieve.scout_lexical", new=lexical_spy),
+            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
+        ):
+            await memory.retrieve(
+                "alpha",
+                limit=5,
+                namespace_filter=["proj-a"],
+                tags=["t1"],
+                path_prefix="docs/",
+            )
+
+        for spy in (vector_spy, lexical_spy):
+            spy.assert_awaited_once()
+            kwargs = spy.await_args.kwargs
+            assert kwargs["namespace_filter"] == ["proj-a"]
+            assert kwargs["tags"] == ["t1"]
+            assert kwargs["path_prefix"] == "docs/"
+
+    async def test_retrieve_limit_truncates_results(self, memory: CognitiveMemory) -> None:
+        """The pipeline applies ``limit`` to the post-rerank candidate list."""
+        await memory.start()
+
+        # Build 25 distinct candidates so merge keeps them all (unique node_ids).
+        candidates = [
+            Candidate(
+                node_id=f"node-{i:02d}",
+                score=1.0 - i * 0.01,
+                reasons=[f"reason-{i}"],
+                scouts=["scout_vector"],
+            )
+            for i in range(25)
+        ]
+        empty_scout = AsyncMock(return_value=[])
+
+        # ``knowledge.read`` is called for each result by the result-build
+        # loop. With the fixture's MagicMock, default return is a MagicMock,
+        # which the loop will treat as a present document. To keep the test
+        # focused on truncation we instead patch knowledge.read to raise
+        # FileNotFoundError, which the pipeline gracefully skips. That makes
+        # the assertion ``len(results) <= limit`` the strongest guarantee
+        # we can make without rebuilding the entire knowledge fixture.
+        memory._knowledge.read = AsyncMock(side_effect=FileNotFoundError())
+        memory._knowledge.get_cached_meta = MagicMock(return_value=None)
+
+        with (
+            patch(
+                "lithos.lcma.retrieve.scout_vector",
+                new=AsyncMock(return_value=candidates),
+            ),
+            patch("lithos.lcma.retrieve.scout_lexical", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_provenance", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_graph", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_coactivation", new=empty_scout),
+            patch("lithos.lcma.retrieve.scout_source_url", new=empty_scout),
+        ):
+            result = await memory.retrieve("alpha", limit=5)
+
+        results = result["results"]
+        assert isinstance(results, list)
+        assert len(results) <= 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -20,8 +20,8 @@ from lithos.graph import KnowledgeGraph
 from lithos.knowledge import KnowledgeManager
 from lithos.lcma.retrieve import (
     _rerank_fast,
+    _run_retrieve_impl,
     compute_temperature,
-    run_retrieve,
 )
 from lithos.lcma.stats import StatsStore
 from lithos.lcma.utils import Candidate
@@ -348,7 +348,7 @@ class TestStoredSalienceAffectsRetrieval:
             patch.object(seeded_search, "semantic_search", return_value=equal_results),
             patch.object(seeded_search, "full_text_search", return_value=equal_results),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="testing",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -398,7 +398,7 @@ class TestStoredSalienceAffectsRetrieval:
             patch.object(seeded_search, "semantic_search", return_value=hits),
             patch.object(seeded_search, "full_text_search", return_value=hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="testing",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -441,7 +441,7 @@ class TestStoredSalienceAffectsRetrieval:
             patch.object(seeded_search, "semantic_search", return_value=hits),
             patch.object(seeded_search, "full_text_search", return_value=hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="testing",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -507,7 +507,7 @@ class TestRetrieveSnippetParity:
             patch.object(seeded_search, "semantic_search", return_value=hit),
             patch.object(seeded_search, "full_text_search", return_value=hit),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="Quantum",
                 search=seeded_search,
                 knowledge=km,
@@ -710,7 +710,7 @@ class TestRunRetrievePhaseA:
             patch.object(seeded_search, "semantic_search", return_value=mock_results),
             patch.object(seeded_search, "full_text_search", return_value=mock_results),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="testing",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -744,7 +744,7 @@ class TestRunRetrievePhaseA:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="testing",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -783,7 +783,7 @@ class TestRunRetrievePhaseB:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=_ID1,  # exact_alias should match UUID
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -823,7 +823,7 @@ class TestNormalization:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -860,7 +860,7 @@ class TestReceiptWriting:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="test",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -902,7 +902,7 @@ class TestReceiptWriting:
         broken_search.semantic_search = MagicMock(side_effect=Exception("search failure"))
         broken_search.full_text_search = MagicMock(side_effect=Exception("search failure"))
 
-        result = await run_retrieve(
+        result = await _run_retrieve_impl(
             query="test",
             search=broken_search,
             knowledge=seeded_km,
@@ -940,7 +940,7 @@ class TestReceiptWriting:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="format check",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -997,7 +997,7 @@ class TestWorkingMemory:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1039,7 +1039,7 @@ class TestWorkingMemory:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1084,7 +1084,7 @@ class TestMaxContextNodes:
             patch("lithos.lcma.retrieve.scout_provenance", new_callable=AsyncMock) as mock_prov,
         ):
             mock_prov.return_value = []
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query=_ID1,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1182,7 +1182,7 @@ class TestScoutsFiredAuditTrail:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="zzzz_no_match_anywhere",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1231,7 +1231,7 @@ class TestScoutsFiredAuditTrail:
             patch.object(seeded_search, "semantic_search", side_effect=RuntimeError("boom")),
             patch.object(seeded_search, "full_text_search", return_value=[]),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="anything",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1286,7 +1286,7 @@ class TestScoutsFiredAuditTrail:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             caplog.at_level(logging.WARNING, logger="lithos.search"),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query=title,
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1331,7 +1331,7 @@ class TestReceiptFinalNodesShape:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1390,7 +1390,7 @@ class TestReceiptFields:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1456,7 +1456,7 @@ class TestContradictionSurfacing:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1519,7 +1519,7 @@ class TestContradictionSurfacing:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1576,7 +1576,7 @@ class TestNewScoutsWiredInPhaseB:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1631,7 +1631,7 @@ class TestNewScoutsWiredInPhaseB:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1716,7 +1716,7 @@ class TestNewScoutsWiredInPhaseB:
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="source",
                 search=seeded_search,
                 knowledge=km,
@@ -1768,7 +1768,7 @@ class TestNewScoutsWiredInPhaseB:
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
             patch("lithos.lcma.retrieve.scout_graph", side_effect=RuntimeError("graph boom")),
         ):
-            result = await run_retrieve(
+            result = await _run_retrieve_impl(
                 query="alpha",
                 search=seeded_search,
                 knowledge=seeded_km,
@@ -1825,7 +1825,7 @@ class TestFinallyBlockRobustness:
             ),
             pytest.raises(RuntimeError, match="boom"),
         ):
-            await run_retrieve(
+            await _run_retrieve_impl(
                 query="anything",
                 search=seeded_search,
                 knowledge=seeded_km,


### PR DESCRIPTION
## Summary

Migrates `lithos_retrieve` into `CognitiveMemory` and adds the cognitive-memory error taxonomy per ADR-0005:

- `errors.py` adds `CognitiveMemoryError(LithosError)` base, `ScoutFailure(scout, cause)`, and `RetrieveTimeout` (forward-declared for a future Phase A gather-timeout slice; not raised yet)
- `CognitiveMemory.retrieve(...)` wraps `_run_retrieve_impl` (renamed from `run_retrieve` — no shim); explicit "what propagates vs what is caught-and-logged" docstring per ADR-0005's "one contract, one place"
- `lithos_retrieve` MCP handler collapses to a one-line wrapper around `self.memory.retrieve(...)`
- All 6 scout-call swallows (Phase A line 388-407 plus 5 Phase B blocks) wrap their cause in `ScoutFailure` before logging — type system now reflects the documented catch boundary
- `cognitive_memory.py` module docstring documents the method-ordering convention (lifecycle → public methods grouped by domain) for #258/#259/#260 to follow

`lcma_disabled` short-circuit kept in the handler (not moved into the Module) — deferred per the plan.

## Test plan

- [x] `make check` green (lint + pyright + 1147 unit tests pass)
- [x] `make test-integration` green (346 integration tests pass)
- [x] 5 new tests in `tests/test_cognitive_memory.py::TestRetrieve` (before-start raises, happy path, scout failure logged not raised, namespace filter passes through, limit truncates results)
- [x] No `from lithos.lcma.retrieve import run_retrieve` in `server.py`

Closes #257.