### PR TITLE
feat(cognitive-memory): migrate node_stats and edge_upsert/list/delete to CognitiveMemory

### DIFF
--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -4,10 +4,13 @@ See docs/adr/0005-cognitive-memory-module.md.
 
 Issue #255 landed the seam and lifecycle ordering. Issue #257 migrated
 ``retrieve`` into the Module; the ``lithos_retrieve`` MCP handler in
-``LithosServer`` is now a one-line envelope wrapper. The remaining write
-methods (edge_*, reinforce_*, etc.) migrate in subsequent slices
-(#258-#260); their MCP handlers continue to call LCMA internals directly
-through server-level aliases until then.
+``LithosServer`` is now a one-line envelope wrapper. Issue #258 lands
+:meth:`node_stats` and :meth:`edge_upsert` / :meth:`edge_list` /
+:meth:`edge_delete`; the corresponding MCP handlers are now one-line
+wrappers. The remaining methods (``reinforce_*``, ``cache_lookup``,
+``conflict_resolve``) migrate in subsequent slices (#259-#260); their
+MCP handlers continue to call LCMA internals directly through
+server-level aliases until then.
 
 Method ordering convention: lifecycle methods first (``create``,
 ``attach_coordination``, ``start``, ``stop``), then public agent-facing
@@ -17,8 +20,10 @@ methods grouped by domain (retrieve / edges / reinforcement / stats).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
+from lithos.events import EDGE_UPSERTED, LithosEvent
 from lithos.lcma.enrich import EnrichWorker
 from lithos.lcma.stats import StatsStore
 
@@ -33,7 +38,65 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["CognitiveMemory"]
+__all__ = ["CognitiveMemory", "NodeStats"]
+
+
+# Default values for ``node_stats`` columns. Used both when a node is
+# known to the corpus but has no row in ``node_stats`` yet, and as the
+# column-default backstop when shaping a row pulled from the table.
+# Keeping the canonical defaults next to the dataclass guarantees the
+# wire shape returned by :meth:`CognitiveMemory.node_stats` matches the
+# legacy MCP handler exactly.
+_NODE_STATS_DEFAULTS: dict[str, Any] = {
+    "salience": 0.5,
+    "retrieval_count": 0,
+    "cited_count": 0,
+    "last_retrieved_at": None,
+    "last_used_at": None,
+    "ignored_count": 0,
+    "misleading_count": 0,
+    "decay_rate": 0.0,
+    "spaced_rep_strength": 0.0,
+    "last_decay_applied_at": None,
+}
+
+
+@dataclass(frozen=True)
+class NodeStats:
+    """Per-node retrieval / salience stats returned by :meth:`CognitiveMemory.node_stats`."""
+
+    node_id: str
+    salience: float
+    retrieval_count: int
+    cited_count: int
+    last_retrieved_at: str | None
+    last_used_at: str | None
+    ignored_count: int
+    misleading_count: int
+    decay_rate: float
+    spaced_rep_strength: float
+    last_decay_applied_at: str | None
+
+
+def _as_int(value: object, default: int) -> int:
+    """Coerce a raw ``object`` cell from ``StatsStore.get_node_stats`` to ``int``."""
+    if value is None:
+        return default
+    return int(value)  # type: ignore[arg-type]
+
+
+def _as_float(value: object, default: float) -> float:
+    """Coerce a raw ``object`` cell from ``StatsStore.get_node_stats`` to ``float``."""
+    if value is None:
+        return default
+    return float(value)  # type: ignore[arg-type]
+
+
+def _as_optional_str(value: object) -> str | None:
+    """Coerce a raw ``object`` cell to ``str`` or ``None`` (nullable timestamp)."""
+    if value is None:
+        return None
+    return str(value)
 
 
 class CognitiveMemory:
@@ -227,3 +290,134 @@ class CognitiveMemory:
             tags=tags,
             path_prefix=path_prefix,
         )
+
+    # ------------------------------------------------------------------
+    # Edges + node stats (issue #258)
+    # ------------------------------------------------------------------
+
+    async def node_stats(self, node_id: str) -> NodeStats | dict[str, Any]:
+        """Return per-node retrieval stats.
+
+        Returns the legacy error envelope ``{"status": "error",
+        "code": "doc_not_found", "message": ...}`` when *node_id* is not
+        known to the corpus, matching the wire shape today's
+        ``lithos_node_stats`` MCP handler returns. Otherwise returns a
+        :class:`NodeStats` dataclass — empty/default-valued when the
+        ``node_stats`` table has no row for the node, populated from the
+        row when it does.
+        """
+        if self._knowledge.get_cached_meta(node_id) is None:
+            return {
+                "status": "error",
+                "code": "doc_not_found",
+                "message": f"Node '{node_id}' not found in knowledge base.",
+            }
+
+        row = await self._stats_store.get_node_stats(node_id)
+        if row is None:
+            return NodeStats(node_id=node_id, **_NODE_STATS_DEFAULTS)
+        # ``get_node_stats`` returns ``dict[str, object]`` (raw aiosqlite
+        # row); coerce per-field so the dataclass shape stays honest.
+        return NodeStats(
+            node_id=node_id,
+            salience=_as_float(row.get("salience"), 0.5),
+            retrieval_count=_as_int(row.get("retrieval_count"), 0),
+            cited_count=_as_int(row.get("cited_count"), 0),
+            last_retrieved_at=_as_optional_str(row.get("last_retrieved_at")),
+            last_used_at=_as_optional_str(row.get("last_used_at")),
+            ignored_count=_as_int(row.get("ignored_count"), 0),
+            misleading_count=_as_int(row.get("misleading_count"), 0),
+            decay_rate=_as_float(row.get("decay_rate"), 0.0),
+            spaced_rep_strength=_as_float(row.get("spaced_rep_strength"), 0.0),
+            last_decay_applied_at=_as_optional_str(row.get("last_decay_applied_at")),
+        )
+
+    async def edge_upsert(
+        self,
+        *,
+        from_id: str,
+        to_id: str,
+        edge_type: str,
+        weight: float,
+        namespace: str,
+        provenance_actor: str | None = None,
+        provenance_type: str | None = None,
+        evidence: str | None = None,
+        conflict_state: str | None = None,
+    ) -> str:
+        """Upsert an edge and emit :data:`EDGE_UPSERTED`. Returns the edge id.
+
+        Interim shape per ADR-0005: writes call the projection's internal
+        ``EdgeStore`` directly. ADR-0006 / issue #263 relocates this to
+        ``CorpusIntake.assert_edge`` — keeping the body small (a single
+        upsert + the emit) makes that move a one-method swap.
+        """
+        # Interim: ADR-0005 / #263 will replace this direct edge-store call
+        # with ``self._intake.assert_edge(...)`` once CorpusIntake owns
+        # assertion. Not a layering bug today.
+        edge_id = await self._projection._edge_store.upsert(
+            from_id=from_id,
+            to_id=to_id,
+            edge_type=edge_type,
+            weight=weight,
+            namespace=namespace,
+            provenance_actor=provenance_actor,
+            provenance_type=provenance_type,
+            evidence=evidence,
+            conflict_state=conflict_state,
+        )
+        try:
+            await self._event_bus.emit(
+                LithosEvent(
+                    type=EDGE_UPSERTED,
+                    payload={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "type": edge_type,
+                        "namespace": namespace,
+                    },
+                )
+            )
+        except Exception:
+            logger.exception("Failed to emit %s event", EDGE_UPSERTED)
+        return edge_id
+
+    async def edge_list(
+        self,
+        *,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+        namespace: str | None = None,
+    ) -> list[dict[str, object]]:
+        """List edges through the projection's public read API (ADR-0004).
+
+        Reads go through ``ProvenanceProjection.list_edges`` so the
+        asserted-vs-derived predicate that lives in the projection
+        applies uniformly. ADR-0004 designates the projection as the
+        public read surface; only writes still reach through to the
+        edge store (ADR-0005, see :meth:`edge_upsert` /
+        :meth:`edge_delete`).
+        """
+        return await self._projection.list_edges(
+            from_id=from_id,
+            to_id=to_id,
+            edge_type=edge_type,
+            namespace=namespace,
+        )
+
+    async def edge_delete(self, *, edge_ids: list[str]) -> int:
+        """Delete edges by id. Returns the number of rows deleted.
+
+        No MCP surface today — provided for the four-method shape ADR-0005
+        describes and for future asserted-edge retraction work (e.g.
+        agent-driven contradictions). Mirrors the interim
+        ``self._projection._edge_store.delete_edges`` reach-through that
+        the enrich worker still uses; ADR-0005 / future #263 will route
+        this through a projection-owned write API once it exists.
+        """
+        # Interim: direct edge-store call mirrors today's use sites and
+        # collapses to a public projection write in ADR-0005's successor
+        # issue (#263).
+        return await self._projection._edge_store.delete_edges(edge_ids=edge_ids)

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -3,6 +3,7 @@
 import asyncio
 import collections
 import contextlib
+import dataclasses
 import hashlib
 import json
 import logging
@@ -1740,7 +1741,7 @@ class LithosServer:
 
                 evidence_str = json.dumps(evidence) if evidence is not None else None
 
-                edge_id = await self.edge_store.upsert(
+                edge_id = await self.memory.edge_upsert(
                     from_id=from_id,
                     to_id=to_id,
                     edge_type=type,
@@ -1750,22 +1751,6 @@ class LithosServer:
                     provenance_type=provenance_type,
                     evidence=evidence_str,
                     conflict_state=conflict_state,
-                )
-
-                # Publish edge.upserted event
-                from lithos.events import EDGE_UPSERTED
-
-                await self._emit(
-                    LithosEvent(
-                        type=EDGE_UPSERTED,
-                        payload={
-                            "edge_id": edge_id,
-                            "from_id": from_id,
-                            "to_id": to_id,
-                            "type": type,
-                            "namespace": namespace,
-                        },
-                    )
                 )
 
                 return {
@@ -1799,7 +1784,7 @@ class LithosServer:
             with tracer.start_as_current_span("lithos.tool.edge_list") as span:
                 span.set_attribute("lithos.tool", "lithos_edge_list")
 
-                edges = await self.projection.list_edges(
+                edges = await self.memory.edge_list(
                     from_id=from_id,
                     to_id=to_id,
                     edge_type=type,
@@ -2989,44 +2974,8 @@ class LithosServer:
                 span.set_attribute("lithos.tool", "lithos_node_stats")
                 span.set_attribute("lithos.node_id", node_id)
 
-                # Verify node exists in knowledge manager
-                if self.knowledge.get_cached_meta(node_id) is None:
-                    return {
-                        "status": "error",
-                        "code": "doc_not_found",
-                        "message": f"Node '{node_id}' not found in knowledge base.",
-                    }
-
-                stats = await self.stats_store.get_node_stats(node_id)
-                if stats is None:
-                    # Node exists but has no stats row — return defaults
-                    return {
-                        "node_id": node_id,
-                        "salience": 0.5,
-                        "retrieval_count": 0,
-                        "cited_count": 0,
-                        "last_retrieved_at": None,
-                        "last_used_at": None,
-                        "ignored_count": 0,
-                        "misleading_count": 0,
-                        "decay_rate": 0.0,
-                        "spaced_rep_strength": 0.0,
-                        "last_decay_applied_at": None,
-                    }
-
-                return {
-                    "node_id": node_id,
-                    "salience": stats.get("salience", 0.5),
-                    "retrieval_count": stats.get("retrieval_count", 0),
-                    "cited_count": stats.get("cited_count", 0),
-                    "last_retrieved_at": stats.get("last_retrieved_at"),
-                    "last_used_at": stats.get("last_used_at"),
-                    "ignored_count": stats.get("ignored_count", 0),
-                    "misleading_count": stats.get("misleading_count", 0),
-                    "decay_rate": stats.get("decay_rate", 0.0),
-                    "spaced_rep_strength": stats.get("spaced_rep_strength", 0.0),
-                    "last_decay_applied_at": stats.get("last_decay_applied_at"),
-                }
+                result = await self.memory.node_stats(node_id)
+                return result if isinstance(result, dict) else dataclasses.asdict(result)
 
         @self.mcp.tool()
         @tool_metrics()

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -1,12 +1,15 @@
 """Tests for the CognitiveMemory Module (ADR-0005).
 
 Issue #255 covered construction and start/stop. Issue #257 adds the
-``retrieve`` seam tests below. Remaining write methods migrate in
-subsequent slices (#258-#260) with their tests.
+``retrieve`` seam tests; issue #258 adds tests for the migrated public
+methods ``node_stats`` and ``edge_upsert / edge_list / edge_delete``.
+Remaining methods (``reinforce_*``, ``cache_lookup``, ``conflict_resolve``)
+migrate in sibling slices (#259, #260) with their tests.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -18,10 +21,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
-from lithos.cognitive_memory import CognitiveMemory
+from lithos.cognitive_memory import CognitiveMemory, NodeStats
 from lithos.config import LithosConfig
 from lithos.errors import ScoutFailure
-from lithos.events import EventBus
+from lithos.events import EDGE_UPSERTED, EventBus
 from lithos.lcma.utils import Candidate
 from lithos.provenance import ProvenanceProjection
 
@@ -459,6 +462,153 @@ class TestRetrieve:
         results = result["results"]
         assert isinstance(results, list)
         assert len(results) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Edges + node stats (issue #258)
+# ---------------------------------------------------------------------------
+
+
+class TestNodeStats:
+    """``CognitiveMemory.node_stats`` returns NodeStats or the legacy error envelope."""
+
+    async def test_returns_defaults_for_known_node_with_no_row(
+        self, memory: CognitiveMemory, mock_knowledge: MagicMock
+    ) -> None:
+        # ``get_cached_meta`` only needs to be non-None for the node-exists check.
+        mock_knowledge.get_cached_meta.return_value = MagicMock()
+        await memory.start()
+
+        result = await memory.node_stats("node-xyz")
+
+        assert isinstance(result, NodeStats)
+        assert result.node_id == "node-xyz"
+        assert result.salience == 0.5
+        assert result.retrieval_count == 0
+        assert result.cited_count == 0
+        assert result.last_retrieved_at is None
+        assert result.last_used_at is None
+        assert result.ignored_count == 0
+        assert result.misleading_count == 0
+        assert result.decay_rate == 0.0
+        assert result.spaced_rep_strength == 0.0
+        assert result.last_decay_applied_at is None
+
+    async def test_returns_error_envelope_for_unknown_node(
+        self, memory: CognitiveMemory, mock_knowledge: MagicMock
+    ) -> None:
+        mock_knowledge.get_cached_meta.return_value = None
+        await memory.start()
+
+        result = await memory.node_stats("missing")
+
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert result["code"] == "doc_not_found"
+        assert "missing" in result["message"]
+
+    async def test_returns_persisted_row_after_increment(
+        self, memory: CognitiveMemory, mock_knowledge: MagicMock
+    ) -> None:
+        mock_knowledge.get_cached_meta.return_value = MagicMock()
+        await memory.start()
+
+        await memory._stats_store.increment_node_stats(node_id="node-1")
+        result = await memory.node_stats("node-1")
+
+        assert isinstance(result, NodeStats)
+        assert result.node_id == "node-1"
+        assert result.retrieval_count == 1
+        # ``increment_node_stats`` initialises salience at 0.5 on first touch.
+        assert result.salience == 0.5
+        assert result.last_retrieved_at is not None
+
+
+class TestEdgeMethods:
+    """``CognitiveMemory.edge_upsert / edge_list / edge_delete`` round-trips."""
+
+    async def test_edge_upsert_then_list_round_trip(self, memory: CognitiveMemory) -> None:
+        await memory.start()
+
+        edge_id = await memory.edge_upsert(
+            from_id="a",
+            to_id="b",
+            edge_type="related_to",
+            weight=0.7,
+            namespace="default",
+        )
+        assert edge_id.startswith("edge_")
+
+        edges = await memory.edge_list(from_id="a")
+        assert len(edges) == 1
+        assert edges[0]["edge_id"] == edge_id
+        assert edges[0]["to_id"] == "b"
+        assert edges[0]["type"] == "related_to"
+        assert edges[0]["weight"] == 0.7
+
+    async def test_edge_list_reads_through_projection(
+        self, memory: CognitiveMemory, projection: ProvenanceProjection
+    ) -> None:
+        """edge_list MUST hit ProvenanceProjection.list_edges, not EdgeStore directly.
+
+        Seed via the projection's internal edge store (the same path
+        ``edge_upsert`` uses today) and assert ``edge_list`` surfaces the
+        row — proving the read goes through the projection's API.
+        """
+        await memory.start()
+        await projection._edge_store.upsert(
+            from_id="x",
+            to_id="y",
+            edge_type="derived_from",
+            weight=1.0,
+            namespace="default",
+            provenance_type="frontmatter",
+        )
+
+        edges = await memory.edge_list(edge_type="derived_from")
+
+        assert any(e["from_id"] == "x" and e["to_id"] == "y" for e in edges)
+
+    async def test_edge_delete_removes_edge(self, memory: CognitiveMemory) -> None:
+        await memory.start()
+        edge_id = await memory.edge_upsert(
+            from_id="a",
+            to_id="b",
+            edge_type="related_to",
+            weight=0.5,
+            namespace="default",
+        )
+
+        deleted = await memory.edge_delete(edge_ids=[edge_id])
+
+        assert deleted == 1
+        assert await memory.edge_list(from_id="a") == []
+
+    async def test_edge_delete_with_empty_list_is_noop(self, memory: CognitiveMemory) -> None:
+        await memory.start()
+        assert await memory.edge_delete(edge_ids=[]) == 0
+
+    async def test_edge_upsert_emits_edge_upserted_event(
+        self, memory: CognitiveMemory, event_bus: EventBus
+    ) -> None:
+        queue = event_bus.subscribe(event_types=[EDGE_UPSERTED])
+        await memory.start()
+
+        edge_id = await memory.edge_upsert(
+            from_id="a",
+            to_id="b",
+            edge_type="related_to",
+            weight=0.5,
+            namespace="default",
+        )
+
+        event = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert event.type == EDGE_UPSERTED
+        assert event.payload["edge_id"] == edge_id
+        assert event.payload["from_id"] == "a"
+        assert event.payload["to_id"] == "b"
+        assert event.payload["type"] == "related_to"
+        assert event.payload["namespace"] == "default"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Migrates `lithos_node_stats`, `lithos_edge_upsert`, `lithos_edge_list` into `CognitiveMemory`. The corresponding MCP tool handlers in `server.py` collapse to one-line wrappers.

**Scope note**: `CognitiveMemory.edge_delete()` is added as a Module-internal method only — `lithos_edge_delete` does not exist as an MCP tool today (verified by grep, and confirmed by #263) and this slice intentionally does not invent one. The four-method ADR-0005 surface is now complete on the Module; future asserted-edge retraction work and the projection-owned write API in #263 can call `edge_delete` directly.

ADR-0005 interim shape (writes via `self._projection._edge_store`, reads via `self._projection.list_edges`) is documented inline with comments referencing #263 so a future reader doesn't read it as a layering bug.

## Test plan

- [x] `make check` green (lint + pyright + 1150 unit tests pass)
- [x] `make test-integration` green (346 integration tests pass)
- [x] 8 new tests in `tests/test_cognitive_memory.py::TestNodeStats` + `TestEdgeMethods`
- [x] No new `from lithos.lcma.stats` or `from lithos.lcma.edges` import in `server.py` for these methods

Closes #258.