### PR TITLE
feat(cognitive-memory): migrate cache_lookup and conflict_resolve to CognitiveMemory

### DIFF
--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -3,30 +3,34 @@
 See docs/adr/0005-cognitive-memory-module.md.
 
 Issue #255 landed the seam and lifecycle ordering. Issue #257 migrated
-``retrieve`` into the Module; the ``lithos_retrieve`` MCP handler in
-``LithosServer`` is now a one-line envelope wrapper. Issue #258 lands
-:meth:`node_stats` and :meth:`edge_upsert` / :meth:`edge_list` /
-:meth:`edge_delete`; the corresponding MCP handlers are now one-line
-wrappers. The remaining methods (``reinforce_*``, ``cache_lookup``,
-``conflict_resolve``) migrate in subsequent slices (#259-#260); their
-MCP handlers continue to call LCMA internals directly through
-server-level aliases until then.
+``retrieve`` into the Module; #258 added ``node_stats`` and the
+``edge_*`` methods; #259 added ``reinforce_*``; #260 adds
+``cache_lookup`` and ``conflict_resolve``. The corresponding MCP
+handlers in ``LithosServer`` are all one-line envelope wrappers
+around these methods.
 
 Method ordering convention: lifecycle methods first (``create``,
 ``attach_coordination``, ``start``, ``stop``), then public agent-facing
-methods grouped by domain (retrieve / edges / reinforcement / stats).
+methods grouped by domain (retrieve / edges / reinforcement /
+cache + conflict resolve).
 """
 
 from __future__ import annotations
 
+import asyncio
 import itertools
 import logging
+import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
+from lithos.errors import SearchBackendError
 from lithos.events import EDGE_UPSERTED, LithosEvent
+from lithos.knowledge import _normalize_datetime
 from lithos.lcma.enrich import EnrichWorker
 from lithos.lcma.stats import StatsStore
+from lithos.telemetry import get_tracer, lithos_metrics
 
 if TYPE_CHECKING:
     from lithos.config import LithosConfig
@@ -643,3 +647,292 @@ class CognitiveMemory:
             "CognitiveMemory.reinforce_misleading: edges weakened",
             extra={"node_count": len(misleading_ids), "edges_weakened": len(seen)},
         )
+
+    # ------------------------------------------------------------------
+    # Cache + conflict resolve (issue #260)
+    # ------------------------------------------------------------------
+
+    async def _emit(self, event: LithosEvent) -> None:
+        """Emit an event, logging any failure without propagating."""
+        try:
+            await self._event_bus.emit(event)
+        except Exception:
+            logger.exception("Failed to emit %s event", event.type)
+
+    async def cache_lookup(
+        self,
+        query: str,
+        *,
+        source_url: str | None = None,
+        max_age_hours: float | None = None,
+        min_confidence: float = 0.5,
+        limit: int = 3,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Check if fresh cached knowledge exists before doing expensive research.
+
+        Returns a hit envelope, a stale-reference envelope, or a clean miss.
+        Validation errors return ``{"status": "error", "code": ..., "message": ...}``.
+        """
+        logger.info("lithos_cache_lookup query_len=%d source_url=%s", len(query), source_url)
+
+        # Input validation
+        if max_age_hours is not None and max_age_hours <= 0:
+            return {
+                "status": "error",
+                "code": "invalid_input",
+                "message": "max_age_hours must be positive.",
+            }
+        if limit < 1:
+            return {
+                "status": "error",
+                "code": "invalid_input",
+                "message": "limit must be >= 1.",
+            }
+        if not (0.0 <= min_confidence <= 1.0):
+            return {
+                "status": "error",
+                "code": "invalid_input",
+                "message": "min_confidence must be between 0.0 and 1.0.",
+            }
+
+        _lookup_start = time.perf_counter()
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.cache_lookup") as span:
+            span.set_attribute("lithos.tool", "lithos_cache_lookup")
+            span.set_attribute("cache.source_url_used", source_url is not None)
+
+            candidates: list[str] = []
+            candidates_evaluated = 0
+
+            # Fast path: source_url exact lookup
+            if source_url is not None:
+                fast_doc = await self._knowledge.find_by_source_url(source_url)
+                if fast_doc is not None:
+                    # Tag filtering on fast path
+                    if tags:
+                        doc_tags = fast_doc.metadata.tags
+                        if all(t in doc_tags for t in tags):
+                            candidates = [fast_doc.id]
+                        # else: tag filter failed, fall through to semantic
+                    else:
+                        candidates = [fast_doc.id]
+
+            # Fallback: semantic search
+            if not candidates:
+                try:
+                    sem_results = await asyncio.to_thread(
+                        self._search.semantic_search,
+                        query=query,
+                        limit=limit,
+                        threshold=0.0,
+                        tags=tags,
+                    )
+                    candidates = [r.id for r in sem_results[:limit]]
+                except SearchBackendError as exc:
+                    span.set_attribute("cache.search_error", True)
+                    elapsed_ms = (time.perf_counter() - _lookup_start) * 1000
+                    lithos_metrics.cache_lookup_duration.record(elapsed_ms)
+                    lithos_metrics.cache_lookups.add(1, {"outcome": "error_search_backend"})
+                    return {
+                        "status": "error",
+                        "code": "search_backend_error",
+                        "message": f"Semantic search backend failed: {exc}",
+                    }
+
+            # Evaluate candidates
+            best_hit = None
+            first_stale_id: str | None = None
+            now = datetime.now(timezone.utc)
+            passing_docs: list[Any] = []
+
+            for doc_id in candidates:
+                try:
+                    doc, _ = await self._knowledge.read(id=doc_id)
+                except (FileNotFoundError, ValueError):
+                    continue
+
+                candidates_evaluated += 1
+                meta = doc.metadata
+
+                # Skip if below confidence threshold
+                if meta.confidence < min_confidence:
+                    continue
+
+                # Check staleness (explicit expiry)
+                if meta.is_stale:
+                    if first_stale_id is None:
+                        first_stale_id = doc_id
+                    continue
+
+                # Check max_age_hours
+                if max_age_hours is not None:
+                    updated = _normalize_datetime(meta.updated_at)
+                    cutoff = now - timedelta(hours=max_age_hours)
+                    if updated < cutoff:
+                        if first_stale_id is None:
+                            first_stale_id = doc_id
+                        continue
+
+                passing_docs.append(doc)
+
+            if passing_docs:
+                best_hit = max(passing_docs, key=lambda d: d.metadata.confidence)
+
+            span.set_attribute("cache.candidates_evaluated", candidates_evaluated)
+
+            elapsed_ms = (time.perf_counter() - _lookup_start) * 1000
+            lithos_metrics.cache_lookup_duration.record(elapsed_ms)
+
+            if best_hit is not None:
+                span.set_attribute("cache.hit", True)
+                span.set_attribute("cache.stale_exists", False)
+                lithos_metrics.cache_lookups.add(1, {"outcome": "hit"})
+                return {
+                    "hit": True,
+                    "document": {
+                        "id": best_hit.id,
+                        "title": best_hit.title,
+                        "content": best_hit.content,
+                        "confidence": best_hit.metadata.confidence,
+                        "updated_at": best_hit.metadata.updated_at.isoformat(),
+                        "expires_at": (
+                            best_hit.metadata.expires_at.isoformat()
+                            if best_hit.metadata.expires_at
+                            else None
+                        ),
+                        "tags": best_hit.metadata.tags,
+                        "source_url": best_hit.metadata.source_url,
+                    },
+                    "stale_exists": False,
+                    "stale_id": None,
+                }
+            elif first_stale_id is not None:
+                span.set_attribute("cache.hit", False)
+                span.set_attribute("cache.stale_exists", True)
+                lithos_metrics.cache_lookups.add(1, {"outcome": "miss_stale"})
+                return {
+                    "hit": False,
+                    "document": None,
+                    "stale_exists": True,
+                    "stale_id": first_stale_id,
+                }
+            else:
+                span.set_attribute("cache.hit", False)
+                span.set_attribute("cache.stale_exists", False)
+                lithos_metrics.cache_lookups.add(1, {"outcome": "miss_clean"})
+                return {
+                    "hit": False,
+                    "document": None,
+                    "stale_exists": False,
+                    "stale_id": None,
+                }
+
+    async def conflict_resolve(
+        self,
+        edge_id: str,
+        resolution: str,
+        resolver: str,
+        winner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a contradiction between two notes.
+
+        Sets ``conflict_state`` on a ``contradicts`` edge and, when superseded,
+        records the supersedes link via ``KnowledgeManager.update``.
+        """
+        logger.info(
+            "lithos_conflict_resolve edge_id=%s resolution=%s resolver=%s",
+            edge_id,
+            resolution,
+            resolver,
+        )
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.tool.conflict_resolve") as span:
+            span.set_attribute("lithos.tool", "lithos_conflict_resolve")
+
+            valid_resolutions = {"accepted_dual", "superseded", "refuted", "merged"}
+            if resolution not in valid_resolutions:
+                return {
+                    "status": "error",
+                    "code": "invalid_input",
+                    "message": (
+                        f"Invalid resolution '{resolution}'. "
+                        f"Must be one of: {', '.join(sorted(valid_resolutions))}"
+                    ),
+                }
+
+            edge = await self._projection.get_edge(edge_id)
+            if edge is None:
+                return {
+                    "status": "error",
+                    "code": "not_found",
+                    "message": f"Edge '{edge_id}' not found",
+                }
+
+            if edge["type"] != "contradicts":
+                return {
+                    "status": "error",
+                    "code": "invalid_input",
+                    "message": (f"Edge '{edge_id}' is type '{edge['type']}', not 'contradicts'"),
+                }
+
+            from_id = str(edge["from_id"])
+            to_id = str(edge["to_id"])
+
+            loser_id: str | None = None
+            if resolution == "superseded":
+                if winner_id is None:
+                    return {
+                        "status": "error",
+                        "code": "invalid_input",
+                        "message": "winner_id is required when resolution is 'superseded'",
+                    }
+                if winner_id not in (from_id, to_id):
+                    return {
+                        "status": "error",
+                        "code": "invalid_input",
+                        "message": (
+                            f"winner_id '{winner_id}' must be either "
+                            f"from_id '{from_id}' or to_id '{to_id}'"
+                        ),
+                    }
+                loser_id = to_id if winner_id == from_id else from_id
+
+            updated = await self._projection._edge_store.update_conflict_resolution(
+                edge_id,
+                conflict_state=resolution,
+                provenance_actor=resolver,
+            )
+
+            if not updated:
+                return {
+                    "status": "error",
+                    "code": "update_failed",
+                    "message": f"Edge '{edge_id}' could not be updated",
+                }
+
+            if resolution == "superseded" and winner_id is not None:
+                await self._knowledge.update(
+                    id=winner_id,
+                    agent=resolver,
+                    supersedes=loser_id,
+                )
+
+            await self._emit(
+                LithosEvent(
+                    type=EDGE_UPSERTED,
+                    payload={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "type": "contradicts",
+                        "conflict_state": resolution,
+                    },
+                )
+            )
+
+            return {
+                "status": "ok",
+                "edge_id": edge_id,
+                "conflict_state": resolution,
+            }

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -65,9 +65,10 @@ if TYPE_CHECKING:
     # ``lithos.lcma.edges`` directly so the rule "no edges-module import
     # outside provenance.py" holds for the source tree. The remaining
     # direct ``self.edge_store.<mutation>`` call sites
-    # (``lithos_edge_upsert``, ``update_conflict_resolution``, the enrich
-    # worker, reinforcement helpers) move to projection-owned APIs in the
-    # follow-up slices (#254/#255/#258/#263).
+    # (``lithos_edge_upsert``, the enrich worker, reinforcement helpers)
+    # move to projection-owned APIs in the follow-up slices
+    # (#254/#255/#258/#263). ``update_conflict_resolution`` now lives
+    # behind ``CognitiveMemory`` (issue #260).
     from lithos.lcma.enrich import EnrichWorker
     from lithos.lcma.stats import StatsStore
     from lithos.provenance import EdgeStore
@@ -1805,106 +1806,12 @@ class LithosServer:
                 winner_id: Required when resolution is 'superseded'; must be
                     either from_id or to_id of the edge
             """
-            logger.info(
-                "lithos_conflict_resolve edge_id=%s resolution=%s resolver=%s",
-                edge_id,
-                resolution,
-                resolver,
+            return await self.memory.conflict_resolve(
+                edge_id=edge_id,
+                resolution=resolution,
+                resolver=resolver,
+                winner_id=winner_id,
             )
-            tracer = get_tracer()
-            with tracer.start_as_current_span("lithos.tool.conflict_resolve") as span:
-                span.set_attribute("lithos.tool", "lithos_conflict_resolve")
-
-                valid_resolutions = {"accepted_dual", "superseded", "refuted", "merged"}
-                if resolution not in valid_resolutions:
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": (
-                            f"Invalid resolution '{resolution}'. "
-                            f"Must be one of: {', '.join(sorted(valid_resolutions))}"
-                        ),
-                    }
-
-                edge = await self.projection.get_edge(edge_id)
-                if edge is None:
-                    return {
-                        "status": "error",
-                        "code": "not_found",
-                        "message": f"Edge '{edge_id}' not found",
-                    }
-
-                if edge["type"] != "contradicts":
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": (
-                            f"Edge '{edge_id}' is type '{edge['type']}', not 'contradicts'"
-                        ),
-                    }
-
-                from_id = str(edge["from_id"])
-                to_id = str(edge["to_id"])
-
-                loser_id: str | None = None
-                if resolution == "superseded":
-                    if winner_id is None:
-                        return {
-                            "status": "error",
-                            "code": "invalid_input",
-                            "message": "winner_id is required when resolution is 'superseded'",
-                        }
-                    if winner_id not in (from_id, to_id):
-                        return {
-                            "status": "error",
-                            "code": "invalid_input",
-                            "message": (
-                                f"winner_id '{winner_id}' must be either "
-                                f"from_id '{from_id}' or to_id '{to_id}'"
-                            ),
-                        }
-                    loser_id = to_id if winner_id == from_id else from_id
-
-                updated = await self.edge_store.update_conflict_resolution(
-                    edge_id,
-                    conflict_state=resolution,
-                    provenance_actor=resolver,
-                )
-
-                if not updated:
-                    return {
-                        "status": "error",
-                        "code": "update_failed",
-                        "message": f"Edge '{edge_id}' could not be updated",
-                    }
-
-                if resolution == "superseded" and winner_id is not None:
-                    await self.knowledge.update(
-                        id=winner_id,
-                        agent=resolver,
-                        supersedes=loser_id,
-                    )
-
-                from lithos.events import EDGE_UPSERTED
-
-                await self._emit(
-                    LithosEvent(
-                        type=EDGE_UPSERTED,
-                        payload={
-                            "edge_id": edge_id,
-                            "from_id": from_id,
-                            "to_id": to_id,
-                            "type": "contradicts",
-                            "conflict_state": resolution,
-                        },
-                    )
-                )
-
-                return {
-                    "status": "ok",
-                    "edge_id": edge_id,
-                    "conflict_state": resolution,
-                }
 
         @self.mcp.tool()
         @tool_metrics()
@@ -1935,161 +1842,14 @@ class LithosServer:
             Returns:
                 Dict with hit, document, stale_exists, stale_id
             """
-            logger.info("lithos_cache_lookup query_len=%d source_url=%s", len(query), source_url)
-
-            # Input validation
-            if max_age_hours is not None and max_age_hours <= 0:
-                return {
-                    "status": "error",
-                    "code": "invalid_input",
-                    "message": "max_age_hours must be positive.",
-                }
-            if limit < 1:
-                return {
-                    "status": "error",
-                    "code": "invalid_input",
-                    "message": "limit must be >= 1.",
-                }
-            if not (0.0 <= min_confidence <= 1.0):
-                return {
-                    "status": "error",
-                    "code": "invalid_input",
-                    "message": "min_confidence must be between 0.0 and 1.0.",
-                }
-
-            _lookup_start = time.perf_counter()
-            tracer = get_tracer()
-            with tracer.start_as_current_span("lithos.cache_lookup") as span:
-                span.set_attribute("lithos.tool", "lithos_cache_lookup")
-                span.set_attribute("cache.source_url_used", source_url is not None)
-
-                candidates: list[str] = []
-                candidates_evaluated = 0
-
-                # Fast path: source_url exact lookup
-                if source_url is not None:
-                    fast_doc = await self.knowledge.find_by_source_url(source_url)
-                    if fast_doc is not None:
-                        # Tag filtering on fast path
-                        if tags:
-                            doc_tags = fast_doc.metadata.tags
-                            if all(t in doc_tags for t in tags):
-                                candidates = [fast_doc.id]
-                            # else: tag filter failed, fall through to semantic
-                        else:
-                            candidates = [fast_doc.id]
-
-                # Fallback: semantic search
-                if not candidates:
-                    try:
-                        sem_results = await asyncio.to_thread(
-                            self.search.semantic_search,
-                            query=query,
-                            limit=limit,
-                            threshold=0.0,
-                            tags=tags,
-                        )
-                        candidates = [r.id for r in sem_results[:limit]]
-                    except SearchBackendError as exc:
-                        span.set_attribute("cache.search_error", True)
-                        elapsed_ms = (time.perf_counter() - _lookup_start) * 1000
-                        lithos_metrics.cache_lookup_duration.record(elapsed_ms)
-                        lithos_metrics.cache_lookups.add(1, {"outcome": "error_search_backend"})
-                        return {
-                            "status": "error",
-                            "code": "search_backend_error",
-                            "message": f"Semantic search backend failed: {exc}",
-                        }
-
-                # Evaluate candidates
-                best_hit = None
-                first_stale_id: str | None = None
-                now = datetime.now(timezone.utc)
-                passing_docs: list[Any] = []
-
-                for doc_id in candidates:
-                    try:
-                        doc, _ = await self.knowledge.read(id=doc_id)
-                    except (FileNotFoundError, ValueError):
-                        continue
-
-                    candidates_evaluated += 1
-                    meta = doc.metadata
-
-                    # Skip if below confidence threshold
-                    if meta.confidence < min_confidence:
-                        continue
-
-                    # Check staleness (explicit expiry)
-                    if meta.is_stale:
-                        if first_stale_id is None:
-                            first_stale_id = doc_id
-                        continue
-
-                    # Check max_age_hours
-                    if max_age_hours is not None:
-                        from lithos.knowledge import _normalize_datetime
-
-                        updated = _normalize_datetime(meta.updated_at)
-                        cutoff = now - timedelta(hours=max_age_hours)
-                        if updated < cutoff:
-                            if first_stale_id is None:
-                                first_stale_id = doc_id
-                            continue
-
-                    passing_docs.append(doc)
-
-                if passing_docs:
-                    best_hit = max(passing_docs, key=lambda d: d.metadata.confidence)
-
-                span.set_attribute("cache.candidates_evaluated", candidates_evaluated)
-
-                elapsed_ms = (time.perf_counter() - _lookup_start) * 1000
-                lithos_metrics.cache_lookup_duration.record(elapsed_ms)
-
-                if best_hit is not None:
-                    span.set_attribute("cache.hit", True)
-                    span.set_attribute("cache.stale_exists", False)
-                    lithos_metrics.cache_lookups.add(1, {"outcome": "hit"})
-                    return {
-                        "hit": True,
-                        "document": {
-                            "id": best_hit.id,
-                            "title": best_hit.title,
-                            "content": best_hit.content,
-                            "confidence": best_hit.metadata.confidence,
-                            "updated_at": best_hit.metadata.updated_at.isoformat(),
-                            "expires_at": (
-                                best_hit.metadata.expires_at.isoformat()
-                                if best_hit.metadata.expires_at
-                                else None
-                            ),
-                            "tags": best_hit.metadata.tags,
-                            "source_url": best_hit.metadata.source_url,
-                        },
-                        "stale_exists": False,
-                        "stale_id": None,
-                    }
-                elif first_stale_id is not None:
-                    span.set_attribute("cache.hit", False)
-                    span.set_attribute("cache.stale_exists", True)
-                    lithos_metrics.cache_lookups.add(1, {"outcome": "miss_stale"})
-                    return {
-                        "hit": False,
-                        "document": None,
-                        "stale_exists": True,
-                        "stale_id": first_stale_id,
-                    }
-                else:
-                    span.set_attribute("cache.hit", False)
-                    span.set_attribute("cache.stale_exists", False)
-                    lithos_metrics.cache_lookups.add(1, {"outcome": "miss_clean"})
-                    return {
-                        "hit": False,
-                        "document": None,
-                        "stale_exists": False,
-                        "stale_id": None,
-                    }
+            return await self.memory.cache_lookup(
+                query=query,
+                source_url=source_url,
+                max_age_hours=max_age_hours,
+                min_confidence=min_confidence,
+                limit=limit,
+                tags=tags,
+            )
 
         @self.mcp.tool()
         @tool_metrics()

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -23,11 +23,12 @@ import pytest_asyncio
 
 from lithos.cognitive_memory import CognitiveMemory, NodeStats
 from lithos.config import LithosConfig
-from lithos.errors import ScoutFailure
+from lithos.errors import ScoutFailure, SearchBackendError
 from lithos.events import EDGE_UPSERTED, EventBus
 from lithos.knowledge import KnowledgeManager
 from lithos.lcma.utils import Candidate
 from lithos.provenance import ProvenanceProjection
+from lithos.search import SearchEngine
 
 
 @pytest_asyncio.fixture
@@ -992,3 +993,200 @@ class TestReinforceMisleading:
         )
         assert len(edges) == 1
         assert edges[0]["weight"] == pytest.approx(0.45)
+
+
+# ---------------------------------------------------------------------------
+# Cache + conflict resolve (issue #260)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheLookup:
+    """Validation paths and search-backend errors of ``cache_lookup``.
+
+    Hit-path / staleness coverage stays in ``tests/test_server.py::TestCacheLookup``,
+    which exercises the same code through the MCP wrapper.
+    """
+
+    async def test_clean_miss_returns_empty_envelope(self, memory: CognitiveMemory) -> None:
+        memory._search.semantic_search = MagicMock(return_value=[])
+        result = await memory.cache_lookup(query="nothing matches")
+        assert result == {
+            "hit": False,
+            "document": None,
+            "stale_exists": False,
+            "stale_id": None,
+        }
+
+    async def test_invalid_max_age_hours_returns_error_envelope(
+        self, memory: CognitiveMemory
+    ) -> None:
+        result = await memory.cache_lookup(query="x", max_age_hours=-1)
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+        assert "max_age_hours" in result["message"]
+
+    async def test_invalid_limit_returns_error_envelope(self, memory: CognitiveMemory) -> None:
+        result = await memory.cache_lookup(query="x", limit=0)
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+
+    async def test_invalid_min_confidence_returns_error_envelope(
+        self, memory: CognitiveMemory
+    ) -> None:
+        result = await memory.cache_lookup(query="x", min_confidence=1.5)
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+
+    async def test_search_backend_error_returns_error_envelope(
+        self, memory: CognitiveMemory
+    ) -> None:
+        err = SearchBackendError("chroma down", {"chroma": RuntimeError("boom")})
+        memory._search.semantic_search = MagicMock(side_effect=err)
+        result = await memory.cache_lookup(query="x")
+        assert result["status"] == "error"
+        assert result["code"] == "search_backend_error"
+        assert "chroma" in result["message"]
+
+
+class TestCacheLookupHitPath:
+    """Hit-path coverage that exercises real KnowledgeManager + SearchEngine.
+
+    Uses a dedicated fixture instead of the ``memory`` fixture (which mocks
+    the knowledge / search collaborators) so the document round-trip is
+    real and the ``meta.is_stale`` / ``confidence`` filters fire on actual
+    frontmatter rather than mock returns.
+    """
+
+    @pytest_asyncio.fixture
+    async def real_memory(
+        self,
+        test_config: LithosConfig,
+        projection: ProvenanceProjection,
+        event_bus: EventBus,
+        mock_coordination: AsyncMock,
+    ):
+        knowledge = KnowledgeManager(test_config)
+        search = await SearchEngine.create(test_config)
+        cm = await CognitiveMemory.create(
+            config=test_config,
+            knowledge=knowledge,
+            search=search,
+            graph=MagicMock(),
+            projection=projection,
+            event_bus=event_bus,
+        )
+        cm.attach_coordination(mock_coordination)
+        try:
+            yield cm
+        finally:
+            await cm.stop()
+
+    async def test_hit_returns_document_envelope(self, real_memory: CognitiveMemory) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        doc = (
+            await real_memory._knowledge.create(
+                title="Quantum Computing Notes",
+                content="Information about quantum computing.",
+                agent="agent",
+                tags=["research"],
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+            )
+        ).document
+        real_memory._search.index(KnowledgeManager.to_indexable(doc))
+
+        result = await real_memory.cache_lookup(query="quantum computing", tags=["research"])
+        assert result["hit"] is True
+        assert result["document"]["id"] == doc.id
+
+
+class TestConflictResolve:
+    """Routing and persistence checks for the migrated ``conflict_resolve``."""
+
+    async def _make_contradiction_edge(
+        self, memory: CognitiveMemory, *, from_id: str = "note-a", to_id: str = "note-b"
+    ) -> str:
+        return await memory._projection._edge_store.upsert(
+            from_id=from_id,
+            to_id=to_id,
+            edge_type="contradicts",
+            weight=1.0,
+            namespace="default",
+        )
+
+    async def test_happy_path_persists_and_returns_ok(self, memory: CognitiveMemory) -> None:
+        edge_id = await self._make_contradiction_edge(memory)
+
+        result = await memory.conflict_resolve(
+            edge_id=edge_id,
+            resolution="accepted_dual",
+            resolver="agent-x",
+        )
+        assert result == {
+            "status": "ok",
+            "edge_id": edge_id,
+            "conflict_state": "accepted_dual",
+        }
+
+        roundtrip = await memory._projection.get_edge(edge_id)
+        assert roundtrip is not None
+        assert roundtrip["conflict_state"] == "accepted_dual"
+        assert roundtrip["provenance_actor"] == "agent-x"
+
+    async def test_invalid_resolution_rejected(self, memory: CognitiveMemory) -> None:
+        edge_id = await self._make_contradiction_edge(memory)
+        result = await memory.conflict_resolve(
+            edge_id=edge_id,
+            resolution="bogus",
+            resolver="agent-x",
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+
+    async def test_unknown_edge_returns_not_found(self, memory: CognitiveMemory) -> None:
+        result = await memory.conflict_resolve(
+            edge_id="00000000-0000-0000-0000-000000000000",
+            resolution="accepted_dual",
+            resolver="agent-x",
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "not_found"
+
+    async def test_non_contradicts_edge_rejected(self, memory: CognitiveMemory) -> None:
+        edge_id = await memory._projection._edge_store.upsert(
+            from_id="note-a",
+            to_id="note-b",
+            edge_type="related_to",
+            weight=0.5,
+            namespace="default",
+        )
+        result = await memory.conflict_resolve(
+            edge_id=edge_id,
+            resolution="accepted_dual",
+            resolver="agent-x",
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+        assert "not 'contradicts'" in result["message"]
+
+    async def test_superseded_requires_winner_id(self, memory: CognitiveMemory) -> None:
+        edge_id = await self._make_contradiction_edge(memory)
+        result = await memory.conflict_resolve(
+            edge_id=edge_id,
+            resolution="superseded",
+            resolver="agent-x",
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+        assert "winner_id" in result["message"]
+
+    async def test_superseded_winner_must_be_endpoint(self, memory: CognitiveMemory) -> None:
+        edge_id = await self._make_contradiction_edge(memory)
+        result = await memory.conflict_resolve(
+            edge_id=edge_id,
+            resolution="superseded",
+            resolver="agent-x",
+            winner_id="note-c",
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"


### PR DESCRIPTION
## Summary

Migrates `lithos_cache_lookup` and `lithos_conflict_resolve` MCP tool implementations into `CognitiveMemory`. Both handlers in `server.py` collapse to one-line wrappers.

Both handlers exist today, so the issue's "if present" clause for `conflict_resolve` resolves to in-scope. Wire shape is preserved (`dict[str, Any]` returns) — introducing typed dataclasses (e.g. `CachedResult`) is a separate refactor and would change the envelope `tests/test_server.py::TestCacheLookup` depends on.

- `CognitiveMemory.cache_lookup(query) -> dict[str, Any]`
- `CognitiveMemory.conflict_resolve(...) -> dict[str, Any]`
- No direct LCMA internal imports for these methods in `server.py`

## Test plan

- [x] `make check` green (lint + pyright + 1154 unit tests pass)
- [x] `make test-integration` green (346 integration tests pass)
- [x] New tests in `tests/test_cognitive_memory.py` covering both methods through the Module's interface

Closes #260.