### PR TITLE
fix(server): emit task.updated event from lithos_task_update

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1212,6 +1212,7 @@ Lithos includes an in-memory event bus that emits `LithosEvent` on all write, de
 | `note.renamed` | `WatchIntake.rename_on_disk` (in-corpus rename detected by the watcher) | `id`, `src_path`, `dest_path` |
 | `edge.upserted` | `lithos_edge_upsert` via `CorpusIntake.assert_edge`; also `lithos_conflict_resolve` when it updates a `contradicts` edge | `edge_id`, `from_id`, `to_id`, `type`, `namespace` (assert_edge); `edge_id`, `from_id`, `to_id`, `type`, `conflict_state` (conflict_resolve) |
 | `task.created` | `lithos_task_create` | `task_id`, `title` |
+| `task.updated` | `lithos_task_update` | `task_id` |
 | `task.claimed` | `lithos_task_claim` | `task_id`, `agent`, `aspect` |
 | `task.released` | `lithos_task_release` | `task_id`, `agent`, `aspect` |
 | `task.completed` | `lithos_task_complete` | `task_id`, `agent` |

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -33,6 +33,7 @@ NOTE_DELETED = "note.deleted"
 NOTE_RENAMED = "note.renamed"
 
 TASK_CREATED = "task.created"
+TASK_UPDATED = "task.updated"
 TASK_CLAIMED = "task.claimed"
 TASK_RELEASED = "task.released"
 TASK_COMPLETED = "task.completed"

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -30,6 +30,7 @@ from lithos.events import (
     TASK_COMPLETED,
     TASK_CREATED,
     TASK_RELEASED,
+    TASK_UPDATED,
     EventBus,
     LithosEvent,
 )
@@ -2366,6 +2367,13 @@ class LithosServer:
                 span.set_attribute("lithos.success", updated)
 
                 if updated:
+                    await self._emit(
+                        LithosEvent(
+                            type=TASK_UPDATED,
+                            agent=agent,
+                            payload={"task_id": task_id},
+                        )
+                    )
                     return {"success": True, "message": f"Task {task_id} updated"}
                 return {
                     "status": "error",

--- a/tests/test_event_emission.py
+++ b/tests/test_event_emission.py
@@ -15,6 +15,7 @@ from lithos.events import (
     TASK_COMPLETED,
     TASK_CREATED,
     TASK_RELEASED,
+    TASK_UPDATED,
     LithosEvent,
 )
 from lithos.server import LithosServer
@@ -274,6 +275,68 @@ class TestTaskEventEmission:
         assert task is not None
         assert task.outcome == outcome_text
         assert task.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_lithos_task_update_emits_task_updated(self, server: LithosServer) -> None:
+        """#283: lithos_task_update must emit task.updated so live SSE
+        consumers see metadata mutations without restarting."""
+        create_result = await _call_tool(
+            server,
+            "lithos_task_create",
+            {"title": "Updatable Task", "agent": "test-agent"},
+        )
+        task_id = create_result["task_id"]
+
+        queue = server.event_bus.subscribe(event_types=[TASK_UPDATED])
+        update_result = await _call_tool(
+            server,
+            "lithos_task_update",
+            {"task_id": task_id, "agent": "test-agent", "metadata": {"project": "demo"}},
+        )
+        assert update_result["success"] is True
+
+        event = queue.get_nowait()
+        assert event.type == TASK_UPDATED
+        assert event.agent == "test-agent"
+        assert event.payload["task_id"] == task_id
+        server.event_bus.unsubscribe(queue)
+
+    @pytest.mark.asyncio
+    async def test_lithos_task_update_no_event_on_task_not_found(
+        self, server: LithosServer
+    ) -> None:
+        """Failed updates against unknown task ids must not emit task.updated."""
+        queue = server.event_bus.subscribe(event_types=[TASK_UPDATED])
+        result = await _call_tool(
+            server,
+            "lithos_task_update",
+            {"task_id": "does-not-exist", "agent": "test-agent", "title": "x"},
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "task_not_found"
+        assert queue.empty()
+        server.event_bus.unsubscribe(queue)
+
+    @pytest.mark.asyncio
+    async def test_lithos_task_update_no_event_on_invalid_input(self, server: LithosServer) -> None:
+        """Invalid-input rejections (no fields supplied) must not emit task.updated."""
+        create_result = await _call_tool(
+            server,
+            "lithos_task_create",
+            {"title": "Invalid-Update Target", "agent": "test-agent"},
+        )
+        task_id = create_result["task_id"]
+
+        queue = server.event_bus.subscribe(event_types=[TASK_UPDATED])
+        result = await _call_tool(
+            server,
+            "lithos_task_update",
+            {"task_id": task_id, "agent": "test-agent"},
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_input"
+        assert queue.empty()
+        server.event_bus.unsubscribe(queue)
 
 
 class TestFindingEventEmission:


### PR DESCRIPTION
## Summary

`lithos_task_update` was the only task tool that did not emit a bus event on success. SSE consumers subscribed to `?types=task.*` silently missed every title / description / tags / metadata mutation until a daemon restart triggered a bootstrap re-fetch — see #283 for the full evidence, reproduction, and impact (notably the lithos-loom obsidian-projection subscription, which had been subscribing to `task.updated` for forward-compatibility and never receiving it).

This change is purely additive — one new constant, one `_emit` call on the success branch, three integration tests. No schema change, no on-disk change, no behavior change for the other five task tools, no consumer-side migration. Existing subscribers that don't subscribe to `task.updated` continue to behave identically.

## Changes

- `src/lithos/events.py` — add `TASK_UPDATED = "task.updated"` alongside the existing five `TASK_*` constants.
- `src/lithos/server.py` — emit a `TASK_UPDATED` event from `lithos_task_update` on the success branch only, payload `{"task_id": task_id}`, mirroring `lithos_task_create`. No emission on `invalid_input` or `task_not_found`.
- `tests/test_event_emission.py` — three new tests in `TestTaskEventEmission` covering success emission, no-emission on `task_not_found`, and no-emission on invalid-input.

## Test plan

- [x] `make check` — 1166 unit tests passed, ruff + pyright clean.
- [x] `make test-integration` — 352 integration tests passed (including the three new ones in `test_event_emission.py`).

## Note on the agent brief's SSE-level test

The brief on #283 suggested an SSE-level end-to-end test. `tests/test_integration_mcp_sse.py` does not currently subscribe to `/events`; building that infrastructure is meaningfully larger than this fix. Since the SSE endpoint's type filter is plain string equality in `EventBus._matches` — proven for the five existing task events using identical code paths — the bus-level tests added here cover the same risk surface. The brief's mention of a separate "SSE allowlist" step is also a no-op in current code (the filter accepts any string the client sends). A dedicated SSE end-to-end test would benefit every task event, not just `task.updated`, and is better landed as a follow-up.

Closes #283