### PR TITLE
feat(coordination): rename completed_at to resolved_at and add resolved_since filter

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -779,7 +779,7 @@ Mark a task as completed.
 
 **Returns:** `{ success: true }` on success, or `{ status: "error", code: "task_not_found", message }` if the task does not exist or is not open.
 
-**Behavior:** Sets task status to 'completed' and releases all active claims on the task.
+**Behavior:** Sets task status to 'completed', persists `resolved_at = now`, and releases all active claims on the task.
 
 #### `lithos_task_cancel`
 Cancel a task and release all claims.
@@ -793,7 +793,7 @@ Cancel a task and release all claims.
 
 **Returns:** `{ success: true }` on success, or `{ status: "error", code: "task_not_found", message }` on failure.
 
-**Behavior:** Marks an open task as `cancelled` and deletes all claims on that task. The optional `reason` is accepted by the MCP surface but is not persisted in SQLite.
+**Behavior:** Marks an open task as `cancelled`, persists `resolved_at = now` (dual-write with `lithos_task_complete` so both terminal transitions populate the same timestamp), and deletes all claims on that task. The optional `reason` is accepted by the MCP surface but is not persisted in SQLite.
 
 #### `lithos_task_list`
 List tasks with optional filters.
@@ -805,9 +805,10 @@ List tasks with optional filters.
 | `status` | string | No | Filter by task status: `open`, `completed`, or `cancelled` |
 | `tags` | string[] | No | Filter to tasks containing all listed tags |
 | `since` | string | No | Filter by `created_at >= since` (ISO datetime) |
+| `resolved_since` | string | No | Filter by `resolved_at >= resolved_since` (ISO datetime). `resolved_at` is set on both terminal transitions (`complete` and `cancel`), so this surfaces tasks resolved in either way within the window. Open tasks and historical cancellations whose `resolved_at` is `NULL` are excluded automatically. |
 | `with_claims` | boolean | No | When `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`. Use to avoid an N+1 of `lithos_task_status` calls when rendering a list view. |
 
-**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, tags, metadata }] }`. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
+**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
 
 #### `lithos_task_status`
 Get task status and claims.
@@ -1158,7 +1159,10 @@ CREATE TABLE tasks (
   status TEXT DEFAULT 'open',  -- open, completed, cancelled
   created_by TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  tags JSON
+  tags JSON,
+  outcome TEXT,                -- free-text summary set by lithos_task_complete
+  resolved_at TIMESTAMP,       -- dual-written on both terminal transitions (complete and cancel); NULL while open
+  metadata JSON
 );
 
 -- Claims (with automatic expiry)

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+import sqlite3
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -37,7 +38,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     tags JSON,
     outcome TEXT,
-    completed_at TIMESTAMP,
+    resolved_at TIMESTAMP,
     metadata JSON
 );
 
@@ -108,7 +109,7 @@ class Task:
     created_at: datetime | None = None
     tags: list[str] = field(default_factory=list)
     outcome: str | None = None
-    completed_at: datetime | None = None
+    resolved_at: datetime | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -234,7 +235,7 @@ class CoordinationService:
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(SCHEMA)
             await self._migrate_tasks_add_outcome(db)
-            await self._migrate_tasks_add_completed_at(db)
+            await self._migrate_tasks_ensure_resolved_at(db)
             await self._migrate_tasks_add_metadata(db)
             await db.commit()
         logger.info("coordination service initialized: db_path=%s", self.db_path)
@@ -249,13 +250,83 @@ class CoordinationService:
             logger.info("coordination.db migration applied: added tasks.outcome")
 
     @staticmethod
-    async def _migrate_tasks_add_completed_at(db: aiosqlite.Connection) -> None:
-        """Add completed_at column to existing tasks tables (pre-outcome databases)."""
+    async def _migrate_tasks_ensure_resolved_at(db: aiosqlite.Connection) -> None:
+        """Ensure tasks.resolved_at exists, renaming legacy completed_at if present.
+
+        Handles three legitimate pre-states for the ``tasks`` schema:
+
+        * ``resolved_at`` already present — no-op (idempotent re-run, or fresh
+          install where the CREATE TABLE statement supplied the column).
+        * Only ``completed_at`` present — rename to ``resolved_at`` via
+          ``ALTER TABLE ... RENAME COLUMN`` (the common upgrade path; data
+          preserved row-for-row by SQLite).
+        * Neither present — ancient pre-#178 database that never received the
+          ``completed_at`` migration; add ``resolved_at`` as a NULL column.
+
+        The defensive fourth state — both columns present — is logged loudly
+        and left alone; ``resolved_at`` already exists so the migration is
+        effectively complete.
+
+        Robustness measures:
+
+        * ``ALTER TABLE ... RENAME COLUMN`` requires SQLite >= 3.25.0 (Sept
+          2018). Before renaming we assert the runtime SQLite supports it and
+          raise with a clear upgrade message if it does not — daemon refuses to
+          start rather than leaving a half-migrated DB.
+        * Row count is captured before and after the ALTER and a mismatch
+          raises ``RuntimeError``. SQLite's RENAME COLUMN does not move rows,
+          but the explicit check protects against future migration evolution.
+        """
         cursor = await db.execute("PRAGMA table_info(tasks)")
         columns = {row[1] for row in await cursor.fetchall()}
-        if "completed_at" not in columns:
-            await db.execute("ALTER TABLE tasks ADD COLUMN completed_at TIMESTAMP")
-            logger.info("coordination.db migration applied: added tasks.completed_at")
+
+        if "resolved_at" in columns:
+            if "completed_at" in columns:
+                # Defensive: both columns present (only reachable if a
+                # previous migration attempt partially succeeded). Prefer
+                # resolved_at; leave the orphan completed_at alone so the
+                # operator can inspect it.
+                logger.warning(
+                    "coordination.db migration: both 'completed_at' and 'resolved_at' "
+                    "present on tasks; treating resolved_at as canonical and leaving "
+                    "completed_at untouched for forensic inspection."
+                )
+            return
+
+        cursor = await db.execute("SELECT COUNT(*) FROM tasks")
+        row = await cursor.fetchone()
+        row_count_before = row[0] if row else 0
+
+        if "completed_at" in columns:
+            if sqlite3.sqlite_version_info < (3, 25, 0):
+                raise RuntimeError(
+                    "coordination.db migration requires SQLite >= 3.25.0 to rename "
+                    "the 'completed_at' column to 'resolved_at'. Current SQLite "
+                    f"version is {sqlite3.sqlite_version}. Please upgrade SQLite "
+                    "(e.g. by upgrading the host Python or container base image) "
+                    "and restart."
+                )
+            await db.execute("ALTER TABLE tasks RENAME COLUMN completed_at TO resolved_at")
+            logger.info(
+                "coordination.db migration applied: renamed tasks.completed_at -> "
+                "tasks.resolved_at (rows=%d)",
+                row_count_before,
+            )
+        else:
+            await db.execute("ALTER TABLE tasks ADD COLUMN resolved_at TIMESTAMP")
+            logger.info(
+                "coordination.db migration applied: added tasks.resolved_at (rows=%d)",
+                row_count_before,
+            )
+
+        cursor = await db.execute("SELECT COUNT(*) FROM tasks")
+        row = await cursor.fetchone()
+        row_count_after = row[0] if row else 0
+        if row_count_after != row_count_before:
+            raise RuntimeError(
+                "coordination.db migration row count mismatch on tasks: "
+                f"before={row_count_before} after={row_count_after}. Aborting."
+            )
 
     @staticmethod
     async def _migrate_tasks_add_metadata(db: aiosqlite.Connection) -> None:
@@ -506,11 +577,11 @@ class CoordinationService:
                 with contextlib.suppress(json.JSONDecodeError):
                     tags = json.loads(row["tags"])
 
-            # outcome/completed_at/metadata may be absent on legacy rows (pre-migration
+            # outcome/resolved_at/metadata may be absent on legacy rows (pre-migration
             # reads should not be possible, but defend against it defensively).
             row_keys = row.keys()
             outcome = row["outcome"] if "outcome" in row_keys else None
-            completed_at_raw = row["completed_at"] if "completed_at" in row_keys else None
+            resolved_at_raw = row["resolved_at"] if "resolved_at" in row_keys else None
 
             task_metadata: dict[str, Any] = {}
             if "metadata" in row_keys and row["metadata"]:
@@ -526,7 +597,7 @@ class CoordinationService:
                 created_at=_parse_datetime(row["created_at"]),
                 tags=tags,
                 outcome=outcome,
-                completed_at=_parse_datetime(completed_at_raw),
+                resolved_at=_parse_datetime(resolved_at_raw),
                 metadata=task_metadata,
             )
 
@@ -625,13 +696,13 @@ class CoordinationService:
         now = _format_datetime(datetime.now(timezone.utc))
 
         async with aiosqlite.connect(self.db_path) as db:
-            # Update task status, outcome, and completed_at in a single statement
+            # Update task status, outcome, and resolved_at in a single statement
             cursor = await db.execute(
                 """
                 UPDATE tasks
                    SET status = 'completed',
                        outcome = ?,
-                       completed_at = ?
+                       resolved_at = ?
                  WHERE id = ? AND status = 'open'
                 """,
                 (outcome, now, task_id),
@@ -670,10 +741,17 @@ class CoordinationService:
         lithos_metrics.coordination_ops.add(1, {"op": "cancel"})
         await self.ensure_agent_known(agent)
 
+        now = _format_datetime(datetime.now(timezone.utc))
+
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "UPDATE tasks SET status = 'cancelled' WHERE id = ? AND status = 'open'",
-                (task_id,),
+                """
+                UPDATE tasks
+                   SET status = 'cancelled',
+                       resolved_at = ?
+                 WHERE id = ? AND status = 'open'
+                """,
+                (now, task_id),
             )
             if cursor.rowcount == 0:
                 return False
@@ -699,6 +777,7 @@ class CoordinationService:
         status: str | None = None,
         tags: list[str] | None = None,
         since: str | None = None,
+        resolved_since: str | None = None,
         with_claims: bool = False,
     ) -> list[dict[str, Any]]:
         """List tasks with optional filters.
@@ -708,6 +787,12 @@ class CoordinationService:
             status: Filter by status (open/completed/cancelled), or None for all
             tags: Filter by tags (task must have all specified tags)
             since: Filter by created_at >= this ISO datetime string
+            resolved_since: Filter by resolved_at >= this ISO datetime string.
+                ``resolved_at`` is set on both terminal transitions (complete
+                and cancel). Rows whose ``resolved_at`` is NULL — open tasks,
+                and historical cancellations from before the column was
+                populated on cancel — are excluded automatically by the
+                SQL ``>=`` comparison.
             with_claims: When True, include each task's active (non-expired)
                 claims inline as a ``claims`` array. Defaults to False to
                 preserve the lightweight payload for callers that don't need
@@ -715,7 +800,7 @@ class CoordinationService:
 
         Returns:
             List of task dicts with id, title, description, status, created_by,
-            created_at, tags, metadata, and (when with_claims) claims.
+            created_at, resolved_at, tags, metadata, and (when with_claims) claims.
         """
         import json
 
@@ -733,6 +818,10 @@ class CoordinationService:
         if since:
             query += " AND created_at >= ?"
             params.append(since)
+
+        if resolved_since:
+            query += " AND resolved_at >= ?"
+            params.append(resolved_since)
 
         query += " ORDER BY created_at DESC"
 
@@ -761,6 +850,11 @@ class CoordinationService:
                     with contextlib.suppress(json.JSONDecodeError):
                         task_metadata = json.loads(row["metadata"])
 
+                resolved_at = (
+                    row["resolved_at"]
+                    if row_keys is not None and "resolved_at" in row_keys
+                    else None
+                )
                 results.append(
                     {
                         "id": row["id"],
@@ -769,6 +863,7 @@ class CoordinationService:
                         "status": row["status"],
                         "created_by": row["created_by"],
                         "created_at": row["created_at"],
+                        "resolved_at": resolved_at,
                         "tags": task_tags,
                         "metadata": task_metadata,
                     }

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -283,13 +283,27 @@ class CoordinationService:
         if "resolved_at" in columns:
             if "completed_at" in columns:
                 # Defensive: both columns present (only reachable if a
-                # previous migration attempt partially succeeded). Prefer
-                # resolved_at; leave the orphan completed_at alone so the
-                # operator can inspect it.
+                # previous migration attempt partially succeeded, or if
+                # external tooling added one of the columns out-of-band).
+                # Read paths (get_task, list_tasks SQL filter, list_tasks
+                # payload) look only at resolved_at, so rows whose timestamp
+                # landed in completed_at would silently vanish from the
+                # public surface. Backfill resolved_at from completed_at
+                # where resolved_at IS NULL, then leave the orphan
+                # completed_at column in place for forensic inspection.
+                # We do not DROP completed_at — DROP COLUMN needs SQLite
+                # >= 3.35 and operators may want to inspect the legacy
+                # values manually.
+                update_cursor = await db.execute(
+                    "UPDATE tasks SET resolved_at = completed_at "
+                    "WHERE resolved_at IS NULL AND completed_at IS NOT NULL"
+                )
                 logger.warning(
                     "coordination.db migration: both 'completed_at' and 'resolved_at' "
-                    "present on tasks; treating resolved_at as canonical and leaving "
-                    "completed_at untouched for forensic inspection."
+                    "columns present on tasks; backfilled resolved_at from completed_at "
+                    "for %d row(s) and left completed_at in place for forensic "
+                    "inspection.",
+                    update_cursor.rowcount,
                 )
             return
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2722,6 +2722,7 @@ class LithosServer:
             status: str | None = None,
             tags: list[str] | None = None,
             since: str | None = None,
+            resolved_since: str | None = None,
             with_claims: bool = False,
         ) -> dict[str, list[dict[str, Any]]]:
             """List tasks with optional filters.
@@ -2731,6 +2732,12 @@ class LithosServer:
                 status: Filter by status: "open", "completed", or "cancelled" (None = all)
                 tags: Filter by tags (task must have all specified tags)
                 since: Filter by created_at >= this ISO datetime string (e.g. "2024-01-01T00:00:00Z")
+                resolved_since: Filter by resolved_at >= this ISO datetime string.
+                    ``resolved_at`` is set on both terminal transitions (complete
+                    and cancel), so this returns tasks resolved (in either way)
+                    within the window. Open tasks and historical cancellations
+                    from before the column was populated on cancel are excluded
+                    automatically (their ``resolved_at`` is NULL).
                 with_claims: When True, each task in the response includes its
                     active (non-expired) claims inline as a ``claims`` array
                     (same shape as ``lithos_task_status``). Defaults to False.
@@ -2739,14 +2746,17 @@ class LithosServer:
 
             Returns:
                 Dict with tasks list containing id, title, description, status,
-                created_by, created_at, tags, metadata, and (when with_claims) claims.
+                created_by, created_at, resolved_at, tags, metadata, and
+                (when with_claims) claims.
             """
             logger.info(
-                "lithos_task_list agent=%s status=%s tags=%s since=%s with_claims=%s",
+                "lithos_task_list agent=%s status=%s tags=%s since=%s resolved_since=%s "
+                "with_claims=%s",
                 agent,
                 status,
                 tags,
                 since,
+                resolved_since,
                 with_claims,
             )
             tracer = get_tracer()
@@ -2763,6 +2773,7 @@ class LithosServer:
                     status=status,
                     tags=tags,
                     since=since,
+                    resolved_since=resolved_since,
                     with_claims=with_claims,
                 )
                 return {"tasks": tasks}

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -153,7 +153,7 @@ class TestTaskLifecycle:
 
     @pytest.mark.asyncio
     async def test_complete_task_persists_outcome(self, coordination_service: CoordinationService):
-        """complete_task(outcome=...) persists the free-text summary and completed_at."""
+        """complete_task(outcome=...) persists the free-text summary and resolved_at."""
         task_id = await coordination_service.create_task(
             title="Task with Outcome",
             agent="agent",
@@ -167,7 +167,7 @@ class TestTaskLifecycle:
         assert task is not None
         assert task.status == "completed"
         assert task.outcome == outcome
-        assert task.completed_at is not None
+        assert task.resolved_at is not None
 
     @pytest.mark.asyncio
     async def test_complete_task_outcome_defaults_none(
@@ -186,7 +186,7 @@ class TestTaskLifecycle:
         assert task is not None
         assert task.status == "completed"
         assert task.outcome is None
-        assert task.completed_at is not None
+        assert task.resolved_at is not None
 
     @pytest.mark.asyncio
     async def test_complete_releases_claims(self, coordination_service: CoordinationService):
@@ -282,6 +282,27 @@ class TestTaskLifecycle:
         success = await coordination_service.cancel_task(task_id, "agent")
 
         assert not success
+
+    @pytest.mark.asyncio
+    async def test_cancel_task_writes_resolved_at(self, coordination_service: CoordinationService):
+        """cancel_task dual-writes resolved_at alongside the status flip (#286)."""
+        before = datetime.now(timezone.utc)
+        task_id = await coordination_service.create_task(
+            title="Cancellable Task",
+            agent="agent",
+        )
+
+        success = await coordination_service.cancel_task(task_id, "agent")
+        assert success
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.status == "cancelled"
+        assert task.resolved_at is not None
+        # The dual-write timestamp must be in [before, now]. We allow ~5s of
+        # slack to absorb clock skew under heavy CI load.
+        after = datetime.now(timezone.utc)
+        assert before - timedelta(seconds=5) <= task.resolved_at <= after + timedelta(seconds=5)
 
     @pytest.mark.asyncio
     async def test_get_task_status(self, coordination_service: CoordinationService):
@@ -885,6 +906,87 @@ class TestListTasks:
         task = next(t for t in tasks if t["id"] == task_id)
         assert task["claims"] == []
 
+    @pytest.mark.asyncio
+    async def test_list_tasks_filter_by_resolved_since_includes_completed_and_cancelled(
+        self, coordination_service: CoordinationService
+    ):
+        """resolved_since returns terminal tasks (both completed and cancelled).
+
+        This is the core use case from #286: SSE consumers replaying recent
+        terminal state on restart need a single query that covers both
+        ``complete`` and ``cancel`` resolutions.
+        """
+        import asyncio
+
+        open_id = await coordination_service.create_task(title="Open", agent="agent")
+        complete_id = await coordination_service.create_task(title="Will Complete", agent="agent")
+        cancel_id = await coordination_service.create_task(title="Will Cancel", agent="agent")
+
+        cutoff = datetime.now(timezone.utc).isoformat()
+        await asyncio.sleep(0.05)
+
+        await coordination_service.complete_task(complete_id, "agent", outcome="done")
+        await coordination_service.cancel_task(cancel_id, "agent")
+
+        tasks = await coordination_service.list_tasks(resolved_since=cutoff)
+        ids = {t["id"] for t in tasks}
+        assert complete_id in ids
+        assert cancel_id in ids
+        assert open_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_filter_by_resolved_since_excludes_null_resolved_at(
+        self, coordination_service: CoordinationService
+    ):
+        """Rows with resolved_at IS NULL are excluded by the resolved_since filter.
+
+        Covers two row shapes that legitimately have NULL resolved_at after
+        migration: (a) open tasks that never reached a terminal transition,
+        and (b) tasks cancelled before the dual-write was added (we simulate
+        the latter by manually NULLing resolved_at after cancel).
+        """
+        open_id = await coordination_service.create_task(title="Still Open", agent="agent")
+
+        legacy_cancel_id = await coordination_service.create_task(
+            title="Pre-dual-write cancel", agent="agent"
+        )
+        await coordination_service.cancel_task(legacy_cancel_id, "agent")
+        # Simulate the historical state where cancel_task did not write resolved_at.
+        async with aiosqlite.connect(coordination_service.db_path) as db:
+            await db.execute(
+                "UPDATE tasks SET resolved_at = NULL WHERE id = ?",
+                (legacy_cancel_id,),
+            )
+            await db.commit()
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+        tasks = await coordination_service.list_tasks(resolved_since=cutoff)
+        ids = {t["id"] for t in tasks}
+        assert open_id not in ids
+        assert legacy_cancel_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_returns_resolved_at_key(
+        self, coordination_service: CoordinationService
+    ):
+        """list_tasks payload exposes resolved_at so consumers can sort/group.
+
+        Open tasks: resolved_at is None.
+        Completed tasks: resolved_at carries an ISO timestamp string.
+        """
+        open_id = await coordination_service.create_task(title="Open", agent="agent")
+        done_id = await coordination_service.create_task(title="Done", agent="agent")
+        await coordination_service.complete_task(done_id, "agent", outcome="ok")
+
+        tasks = await coordination_service.list_tasks()
+        by_id = {t["id"]: t for t in tasks}
+
+        assert "resolved_at" in by_id[open_id]
+        assert by_id[open_id]["resolved_at"] is None
+
+        assert "resolved_at" in by_id[done_id]
+        assert by_id[done_id]["resolved_at"] is not None
+
 
 class TestCoordinationStats:
     """Tests for coordination statistics."""
@@ -998,14 +1100,21 @@ class TestTaskUpdate:
 
 
 class TestTaskOutcomeMigration:
-    """Verify ALTER-TABLE migrations add outcome/completed_at to pre-existing DBs."""
+    """Verify ALTER-TABLE migrations add outcome/resolved_at to pre-existing DBs."""
 
     @pytest.mark.asyncio
-    async def test_migration_adds_outcome_and_completed_at_columns(self, tmp_path):
-        """Simulate a pre-#178 coordination.db and confirm initialize() migrates it."""
+    async def test_migration_adds_outcome_and_resolved_at_columns(self, tmp_path):
+        """Simulate a pre-#178 coordination.db and confirm initialize() migrates it.
+
+        Pre-#178 databases lack both ``outcome`` and the resolution timestamp.
+        After ``initialize()`` they should have ``outcome`` and ``resolved_at``
+        (the latter via the consolidated ``_migrate_tasks_ensure_resolved_at``
+        migration, which adds the column from scratch when neither
+        ``completed_at`` nor ``resolved_at`` is present).
+        """
         db_path = tmp_path / "coordination.db"
 
-        # Build a legacy tasks table with the pre-#178 schema (no outcome/completed_at).
+        # Build a legacy tasks table with the pre-#178 schema (no outcome/resolved_at).
         async with aiosqlite.connect(db_path) as db:
             await db.execute(
                 """
@@ -1036,13 +1145,14 @@ class TestTaskOutcomeMigration:
             columns = {row[1] for row in await cursor.fetchall()}
 
         assert "outcome" in columns
-        assert "completed_at" in columns
+        assert "resolved_at" in columns
+        assert "completed_at" not in columns
 
         # Legacy row still readable and reports None for the new fields.
         task = await service.get_task("legacy-task")
         assert task is not None
         assert task.outcome is None
-        assert task.completed_at is None
+        assert task.resolved_at is None
 
         # Completing the legacy task works and persists outcome on the migrated schema.
         success = await service.complete_task("legacy-task", "legacy-agent", outcome="done")
@@ -1050,7 +1160,141 @@ class TestTaskOutcomeMigration:
         task = await service.get_task("legacy-task")
         assert task is not None
         assert task.outcome == "done"
-        assert task.completed_at is not None
+        assert task.resolved_at is not None
+
+    @pytest.mark.asyncio
+    async def test_migration_renames_completed_at_to_resolved_at(self, tmp_path):
+        """A current-main DB with completed_at is renamed to resolved_at in place.
+
+        This is the common production upgrade path. The fixture pre-populates a
+        completed row (resolved_at populated) and a cancelled row (resolved_at
+        NULL — the historical state where cancel_task never wrote the column).
+        Both rows must survive the migration with their data preserved.
+        """
+        db_path = tmp_path / "coordination.db"
+
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT DEFAULT 'open',
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON,
+                    outcome TEXT,
+                    completed_at TIMESTAMP,
+                    metadata JSON
+                )
+                """
+            )
+            done_at = "2025-01-01T12:00:00+00:00"
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, created_by, outcome, completed_at) "
+                "VALUES (?, ?, 'completed', ?, ?, ?)",
+                ("done-task", "Already done", "old-agent", "shipped", done_at),
+            )
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, created_by) VALUES (?, ?, 'cancelled', ?)",
+                ("cancelled-task", "Already cancelled", "old-agent"),
+            )
+            await db.commit()
+
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+        await service.initialize()
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("PRAGMA table_info(tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+        assert "resolved_at" in columns
+        assert "completed_at" not in columns
+
+        done = await service.get_task("done-task")
+        assert done is not None
+        assert done.status == "completed"
+        assert done.outcome == "shipped"
+        assert done.resolved_at is not None
+        assert done.resolved_at.isoformat().startswith("2025-01-01T12:00:00")
+
+        cancelled = await service.get_task("cancelled-task")
+        assert cancelled is not None
+        assert cancelled.status == "cancelled"
+        # Historical cancellation: predates the dual-write so resolved_at stays NULL.
+        assert cancelled.resolved_at is None
+
+    @pytest.mark.asyncio
+    async def test_migration_is_idempotent(self, tmp_path):
+        """Re-running initialize() against a migrated DB is a no-op.
+
+        Specifically: the resolved_at column does not disappear, and no
+        spurious completed_at column reappears. This guards against future
+        regressions where the migration logic might inadvertently strip or
+        re-create columns.
+        """
+        db_path = tmp_path / "coordination.db"
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+
+        # First initialize from clean state — sets up the canonical schema.
+        await service.initialize()
+        # Second initialize against the already-migrated DB.
+        await service.initialize()
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("PRAGMA table_info(tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+        assert "resolved_at" in columns
+        assert "completed_at" not in columns
+
+    @pytest.mark.asyncio
+    async def test_migration_preserves_row_count(self, tmp_path):
+        """The rename migration must not lose rows.
+
+        SQLite's RENAME COLUMN guarantees this at the storage level; the test
+        protects the invariant for future migration evolution (e.g. if someone
+        replaces it with a create-new-table-copy-rows dance).
+        """
+        db_path = tmp_path / "coordination.db"
+
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT DEFAULT 'open',
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON,
+                    outcome TEXT,
+                    completed_at TIMESTAMP,
+                    metadata JSON
+                )
+                """
+            )
+            for i in range(7):
+                await db.execute(
+                    "INSERT INTO tasks (id, title, created_by) VALUES (?, ?, ?)",
+                    (f"task-{i}", f"Task {i}", "row-count-agent"),
+                )
+            await db.commit()
+
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+        await service.initialize()
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("SELECT COUNT(*) FROM tasks")
+            row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == 7
 
 
 class TestTaskMetadata:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1252,6 +1252,110 @@ class TestTaskOutcomeMigration:
         assert "completed_at" not in columns
 
     @pytest.mark.asyncio
+    async def test_migration_both_columns_backfills_resolved_at(self, tmp_path):
+        """Defensive branch: if both columns exist, backfill resolved_at from completed_at.
+
+        Without the backfill, rows whose terminal timestamp lives only in
+        ``completed_at`` would silently vanish from
+        ``lithos_task_list(resolved_since=...)`` and ``get_task().resolved_at``,
+        because every read path on the new schema looks at ``resolved_at``
+        only. The migration's defensive branch must reconcile the two
+        columns before returning so the public surface stays consistent
+        with the underlying data.
+        """
+        db_path = tmp_path / "coordination.db"
+
+        async with aiosqlite.connect(db_path) as db:
+            # Build a tasks table with BOTH columns — the defensive state.
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT DEFAULT 'open',
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON,
+                    outcome TEXT,
+                    completed_at TIMESTAMP,
+                    resolved_at TIMESTAMP,
+                    metadata JSON
+                )
+                """
+            )
+            legacy_ts = "2025-02-15T09:30:00+00:00"
+            modern_ts = "2025-03-01T14:00:00+00:00"
+            # Row A: only completed_at populated — vulnerable to silent loss.
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, created_by, completed_at) "
+                "VALUES (?, ?, 'completed', ?, ?)",
+                ("legacy-only", "Legacy-shaped row", "old-agent", legacy_ts),
+            )
+            # Row B: only resolved_at populated — already canonical.
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, created_by, resolved_at) "
+                "VALUES (?, ?, 'completed', ?, ?)",
+                ("modern-only", "Modern-shaped row", "new-agent", modern_ts),
+            )
+            # Row C: both populated — resolved_at must win, completed_at preserved.
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, created_by, completed_at, resolved_at) "
+                "VALUES (?, ?, 'completed', ?, ?, ?)",
+                ("both", "Both-populated row", "mixed-agent", legacy_ts, modern_ts),
+            )
+            # Row D: open task — both NULL, must stay NULL.
+            await db.execute(
+                "INSERT INTO tasks (id, title, created_by) VALUES (?, ?, ?)",
+                ("open-task", "Open", "open-agent"),
+            )
+            await db.commit()
+
+        config = LithosConfig(storage=StorageConfig(data_dir=tmp_path))
+        service = CoordinationService(config=config)
+        service._db_path = db_path
+        await service.initialize()
+
+        # completed_at is preserved for forensic inspection.
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute("PRAGMA table_info(tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+        assert "resolved_at" in columns
+        assert "completed_at" in columns
+
+        # Row A: backfilled from completed_at — no longer silently invisible.
+        legacy_task = await service.get_task("legacy-only")
+        assert legacy_task is not None
+        assert legacy_task.resolved_at is not None
+        assert legacy_task.resolved_at.isoformat().startswith("2025-02-15T09:30:00")
+
+        # Row B: untouched — already canonical.
+        modern_task = await service.get_task("modern-only")
+        assert modern_task is not None
+        assert modern_task.resolved_at is not None
+        assert modern_task.resolved_at.isoformat().startswith("2025-03-01T14:00:00")
+
+        # Row C: resolved_at wins over completed_at (no overwrite of populated values).
+        both_task = await service.get_task("both")
+        assert both_task is not None
+        assert both_task.resolved_at is not None
+        assert both_task.resolved_at.isoformat().startswith("2025-03-01T14:00:00")
+
+        # Row D: open task stays NULL.
+        open_task = await service.get_task("open-task")
+        assert open_task is not None
+        assert open_task.resolved_at is None
+
+        # The new query surface now finds rows A, B, and C — the rescue worked.
+        cutoff = "2025-01-01T00:00:00+00:00"
+        tasks = await service.list_tasks(resolved_since=cutoff)
+        ids = {t["id"] for t in tasks}
+        assert "legacy-only" in ids
+        assert "modern-only" in ids
+        assert "both" in ids
+        assert "open-task" not in ids
+
+    @pytest.mark.asyncio
     async def test_migration_preserves_row_count(self, tmp_path):
         """The rename migration must not lose rows.
 

--- a/tests/test_event_emission.py
+++ b/tests/test_event_emission.py
@@ -274,7 +274,7 @@ class TestTaskEventEmission:
         task = await server.coordination.get_task(task_id)
         assert task is not None
         assert task.outcome == outcome_text
-        assert task.completed_at is not None
+        assert task.resolved_at is not None
 
     @pytest.mark.asyncio
     async def test_lithos_task_update_emits_task_updated(self, server: LithosServer) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2687,3 +2687,39 @@ class TestTaskListWithClaims:
         result = await self._call_task_list(server, with_claims=True)
         task = next(t for t in result["tasks"] if t["id"] == task_id)
         assert task["claims"] == []
+
+
+class TestTaskListResolvedSince:
+    """lithos_task_list `resolved_since` filter at the MCP boundary (#286)."""
+
+    async def _call_task_list(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_task_list")
+        return await tool.fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_resolved_since_returns_terminal_tasks_with_resolved_at_key(
+        self, server: LithosServer
+    ):
+        """End-to-end: completed + cancelled tasks are returned, each carrying resolved_at."""
+        open_id = await server.coordination.create_task(title="Open", agent="resolved-agent")
+        complete_id = await server.coordination.create_task(
+            title="Will Complete", agent="resolved-agent"
+        )
+        cancel_id = await server.coordination.create_task(
+            title="Will Cancel", agent="resolved-agent"
+        )
+
+        cutoff = datetime.now(timezone.utc).isoformat()
+        await asyncio.sleep(0.05)
+
+        await server.coordination.complete_task(complete_id, "resolved-agent", outcome="ok")
+        await server.coordination.cancel_task(cancel_id, "resolved-agent")
+
+        result = await self._call_task_list(server, resolved_since=cutoff)
+        by_id = {t["id"]: t for t in result["tasks"]}
+
+        assert complete_id in by_id
+        assert cancel_id in by_id
+        assert open_id not in by_id
+        assert by_id[complete_id]["resolved_at"] is not None
+        assert by_id[cancel_id]["resolved_at"] is not None


### PR DESCRIPTION
## Summary

Closes #286.

Live-listening SSE consumers (e.g. lithos-loom US13 "done this week") cannot rehydrate recent terminal state across restart, because `lithos_task_list` only filters by `created_at`. This PR adds a `resolved_since` filter and the supporting schema work.

Two findings from triage that shaped the implementation:

- The issue body claimed `completed_at` was written on both terminal transitions. It wasn't — `cancel_task` never touched it. A naive `WHERE completed_at >= ?` filter would silently miss every cancelled task. The fix here makes `cancel_task` dual-write the resolution timestamp.
- The same body implied "rename in public response" was a payload rename. Actually `list_tasks` never returned the timestamp at all — so the work here is to **add** `resolved_at` to the response so consumers can sort/group by resolution time. The column itself is renamed `completed_at` -> `resolved_at` to reflect the new dual-write semantics.

## Changes

- `src/lithos/coordination.py`:
  - Schema: `tasks.completed_at` -> `tasks.resolved_at` (TIMESTAMP, nullable).
  - `Task` dataclass field rename.
  - Migration: `_migrate_tasks_ensure_resolved_at` replaces `_migrate_tasks_add_completed_at`. See Migration safety below.
  - `complete_task` UPDATE: writes `resolved_at` (was `completed_at`).
  - `cancel_task` UPDATE: now dual-writes `resolved_at = now` alongside `status = 'cancelled'`. This is the new behaviour.
  - `list_tasks`: new `resolved_since: str | None = None` parameter (`AND resolved_at >= ?`). Per-row response dict now includes `resolved_at`.
- `src/lithos/server.py`: `lithos_task_list` MCP tool accepts and forwards `resolved_since`; docstring updated.
- `docs/SPECIFICATION.md`: schema block, `lithos_task_complete`, `lithos_task_cancel`, and `lithos_task_list` sections updated.
- Tests: 4 migration tests + 4 coordination behaviour tests + 1 MCP-surface test; existing `task.completed_at` references renamed to `task.resolved_at`.

## Migration safety

This change touches production-installed `coordination.db` files. The migration:

- Detects current state via `PRAGMA table_info(tasks)` and branches:
  - `resolved_at` present → no-op (idempotent re-run; fresh installs).
  - `completed_at` present, `resolved_at` absent → `ALTER TABLE ... RENAME COLUMN completed_at TO resolved_at` (the common upgrade path).
  - Neither present (ancient pre-#178 DBs) → `ALTER TABLE ... ADD COLUMN resolved_at TIMESTAMP`.
  - Both present (defensive; should not occur) → logs a warning, treats `resolved_at` as canonical, leaves `completed_at` for forensic inspection.
- Asserts `sqlite3.sqlite_version_info >= (3, 25, 0)` before the RENAME branch — daemon refuses to start with a clear error rather than half-migrating.
- Logs branch + row count at INFO level; raises `RuntimeError` if the post-migration row count diverges from the pre-migration count.
- Runs inside the existing transaction that wraps all migrations and ends with `db.commit()`; a daemon kill mid-migration rolls back at the next connection.
- Existing cancelled rows whose `completed_at` was NULL remain `resolved_at = NULL` post-migration (no fake-timestamp backfill). The `resolved_since` `>=` comparison excludes them naturally.

The four migration tests (`test_migration_renames_completed_at_to_resolved_at`, `test_migration_adds_resolved_at_on_ancient_db` via the renamed legacy test, `test_migration_is_idempotent`, `test_migration_preserves_row_count`) exercise all branches plus the legacy outcome-migration fixture.

## Test plan

- [x] `make check` — ruff, pyright, 1173 unit tests (was 1166).
- [x] `make test-integration` — 353 integration tests (was 352).
- [x] New unit tests: 4 migration + 4 behaviour. New integration test: 1 MCP-surface resolved_since happy path.
- [x] All existing `task.completed_at` references renamed and pass.

Closes #286