### PR TITLE
chore(observability): demote routine dedup/intake guardrail logs from WARNING to INFO

### DIFF
--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -345,7 +345,7 @@ class CorpusIntake:
                         summaries=request.summaries,
                     )
             except SlugCollisionError as exc:
-                logger.warning(
+                logger.info(
                     "lithos_write slug_collision: agent=%s title=%.120s slug=%s existing_id=%s",
                     agent,
                     request.title,

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -988,7 +988,7 @@ class KnowledgeManager:
                 if existing_id is not None:
                     try:
                         existing_doc, _ = await self.read(id=existing_id)
-                        logger.warning(
+                        logger.info(
                             "Duplicate URL rejected: url=%s existing_owner=%s rejected_doc title=%r",
                             norm_url,
                             existing_id,
@@ -1343,7 +1343,7 @@ class KnowledgeManager:
                     if existing_owner is not None and existing_owner != id:
                         try:
                             existing_doc, _ = await self.read(id=existing_owner)
-                            logger.warning(
+                            logger.info(
                                 "Duplicate URL rejected: url=%s existing_owner=%s rejected_doc_id=%s",
                                 new_norm,
                                 existing_owner,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2167,11 +2167,16 @@ class TestSlugCollisionServerBoundary:
         assert result["warnings"] == []
 
     @pytest.mark.asyncio
-    async def test_write_slug_collision_emits_warning(self, server: LithosServer, caplog):
-        """A slug collision must emit a WARNING with the squatting id so
+    async def test_write_slug_collision_emits_info(self, server: LithosServer, caplog):
+        """A slug collision must emit an INFO line with the squatting id so
         operators can find the offending note from ``docker logs`` alone,
         even when the client throws away ``existing_id`` from the
         response envelope (2026-05-02 staging incident).
+
+        Demoted from WARNING to INFO in #287: the rejection is a routine
+        guardrail outcome, not a fault — the breadcrumb intent is preserved
+        at INFO so operators can still grep for it without it dominating
+        the warning stream.
         """
         import logging
 
@@ -2179,21 +2184,19 @@ class TestSlugCollisionServerBoundary:
         assert first["status"] == "created"
         existing_id = first["id"]
 
-        with caplog.at_level(logging.WARNING, logger="lithos.server"):
+        with caplog.at_level(logging.INFO, logger="lithos.intake"):
             result = await self._call_write(
                 server, title="Squatter", content="Second.", agent="influx"
             )
 
         assert result["status"] == "slug_collision"
-        # The WARNING must carry enough breadcrumbs to find the squatter:
+        # The INFO line must carry enough breadcrumbs to find the squatter:
         # status keyword, agent, slug, and the existing doc id.
-        warnings_text = "\n".join(
-            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
-        )
-        assert "slug_collision" in warnings_text
-        assert "squatter" in warnings_text  # slug
-        assert existing_id in warnings_text
-        assert "agent=influx" in warnings_text
+        info_text = "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.INFO)
+        assert "slug_collision" in info_text
+        assert "squatter" in info_text  # slug
+        assert existing_id in info_text
+        assert "agent=influx" in info_text
 
     @pytest.mark.asyncio
     async def test_write_invalid_input_returns_canonical_envelope(self, server: LithosServer):


### PR DESCRIPTION
## Summary

Closes #287.

Staging log signal-to-noise is dominated by three call sites emitting at `WARNING` for routine non-success outcomes that the caller already converts into a typed `WriteResult` / `WriteOutcome` returned to the agent. Over a 72h staging window **all 1637 warning lines** came from these three sites (1058 duplicate-URL, 579 slug-collision); the service was otherwise healthy (`RestartCount=0`, `OOMKilled=false`, zero `ERROR`, zero `Traceback`, zero `database is locked`, zero `queue full`).

Demoting to `INFO` (not `DEBUG`, per the triage decision) keeps the structured breadcrumbs greppable for operators but stops them drowning real warnings.

## Changes

- `src/lithos/knowledge.py`: `logger.warning` → `logger.info` on the duplicate-URL rejection path for document **create**.
- `src/lithos/knowledge.py`: `logger.warning` → `logger.info` on the duplicate-URL rejection path for document **update**.
- `src/lithos/intake.py`: `logger.warning` → `logger.info` on the `SlugCollisionError` rejection path in `lithos_write`.
- `tests/test_server.py`: `test_write_slug_collision_emits_warning` renamed to `test_write_slug_collision_emits_info`; `caplog.at_level` switched to `INFO`/`lithos.intake`; docstring updated to note the #287 demote; breadcrumb assertions (`slug_collision`, slug, `existing_id`, agent) unchanged.

Format strings, structured fields, `WriteResult` / `WriteOutcome` / `SlugCollisionError` shapes, the `status` discriminator strings, and the `lithos.write_status` OpenTelemetry span attribute are all unchanged.

## Out of scope

Tightly bounded per the agent brief:

- Other `logger.warning` call sites in `knowledge.py` / `intake.py` (e.g. `derived_from_ids` validation, file-watcher skips, frontmatter parse failures). The staging evidence does not implicate them.
- Startup-time scan messages `"Duplicate source_url"` / `"Slug collision detected"` emitted by `KnowledgeManager._scan_existing()` and the tests that assert them at WARNING — different code path, different log lines.
- New metric counters or threshold-based escalation — both listed in the issue body as alternatives; deferable to follow-ups.

## Test plan

- [x] `make check` — ruff, pyright, 1174 unit tests.
- [x] `make test-integration` — 353 integration tests.
- [ ] Manual JSON-log verification on a running daemon:
  - Drive a `lithos_write` with a `source_url` that already exists; confirm `\"level\": \"INFO\"` (not `\"WARNING\"`) on the resulting `"Duplicate URL rejected"` line, with `url`, `existing_owner`, and title fields preserved.
  - Drive a `lithos_write` whose title slug collides with an existing document; confirm `\"level\": \"INFO\"` on the resulting `"lithos_write slug_collision"` line, with `agent`, `title`, `slug`, and `existing_id` preserved.
  - Confirm response envelopes unchanged: `{\"status\": \"duplicate\", ...}` and `{\"status\": \"slug_collision\", ...}` respectively.

Closes #287