### PR TITLE
feat(task): per-key metadata merge in lithos_task_update (#290)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -711,7 +711,7 @@ Create a coordination task.
 **Returns:** `{ task_id: string }`
 
 #### `lithos_task_update`
-Update mutable task metadata.
+Update mutable task fields.
 
 **Arguments:**
 | Name | Type | Required | Description |
@@ -721,12 +721,14 @@ Update mutable task metadata.
 | `title` | string | No | Replacement title |
 | `description` | string | No | Replacement description |
 | `tags` | string[] | No | Replacement tags |
+| `metadata` | object | No | Additive per-key merge patch into the existing task metadata dict. See **Behavior** for merge semantics. |
 
 **Returns:** `{ success: true, message }` on success, or `{ status: "error", code, message }` on failure (codes: `invalid_input`, `task_not_found`).
 
 **Behavior:**
-- At least one of `title`, `description`, or `tags` must be provided.
+- At least one of `title`, `description`, `tags`, or `metadata` must be provided.
 - Only `open` tasks can be updated. Completed and cancelled tasks are treated as not found at the MCP boundary.
+- `metadata` is applied as an **additive per-key merge**: keys with non-null values overwrite the existing value, keys whose value is `null` are deleted from the existing metadata, and keys not mentioned are preserved. `metadata={}` is a no-op (preserves all existing keys); there is no wholesale-clear affordance. To clear a specific key, pass `{"key": null}`. The merge is performed atomically (single `BEGIN IMMEDIATE` transaction) so concurrent writers updating different keys never clobber each other.
 
 #### `lithos_task_claim`
 Claim an aspect of a task.

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -193,6 +193,45 @@ def _format_datetime(dt: datetime) -> str:
     return dt.isoformat()
 
 
+def _decode_metadata(raw: Any) -> dict[str, Any]:
+    """Decode a stored ``tasks.metadata`` JSON column into a dict, safely.
+
+    The schema expects a JSON object, but real-world ``raw`` can be any
+    of three problem shapes: ``NULL``/empty (legitimately missing), a
+    non-string Python value produced by SQLite's loose type affinity
+    (e.g. a row written with a bare numeric literal comes back as
+    ``int``), or a valid JSON string whose top-level value isn't an
+    object (``null``, arrays, scalars). Treat all three as ``{}`` so
+    downstream consumers (``get_task``, the merge path) never see a
+    non-dict for a field typed as ``dict[str, Any]``. Log a warning on
+    the corruption cases — operators will want to know.
+    """
+    import json
+
+    if raw is None or raw == "":
+        return {}
+    if not isinstance(raw, (str, bytes, bytearray)):
+        logger.warning(
+            "tasks.metadata stored as non-string %s; treating as empty: %r",
+            type(raw).__name__,
+            raw,
+        )
+        return {}
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("tasks.metadata is not valid JSON; treating as empty: %r", raw)
+        return {}
+    if not isinstance(decoded, dict):
+        logger.warning(
+            "tasks.metadata is not a JSON object (got %s); treating as empty: %r",
+            type(decoded).__name__,
+            raw,
+        )
+        return {}
+    return decoded
+
+
 def _merge_metadata(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
     """Apply an additive per-key patch to a metadata dict.
 
@@ -620,9 +659,8 @@ class CoordinationService:
             resolved_at_raw = row["resolved_at"] if "resolved_at" in row_keys else None
 
             task_metadata: dict[str, Any] = {}
-            if "metadata" in row_keys and row["metadata"]:
-                with contextlib.suppress(json.JSONDecodeError):
-                    task_metadata = json.loads(row["metadata"])
+            if "metadata" in row_keys:
+                task_metadata = _decode_metadata(row["metadata"])
 
             return Task(
                 id=row["id"],
@@ -757,11 +795,7 @@ class CoordinationService:
                     await db.execute("ROLLBACK")
                     return False
 
-                existing: dict[str, Any] = {}
-                if row[0]:
-                    with contextlib.suppress(json.JSONDecodeError):
-                        existing = json.loads(row[0])
-
+                existing = _decode_metadata(row[0])
                 merged = _merge_metadata(existing, metadata_patch)
                 merged_json = json.dumps(merged)
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -193,6 +193,28 @@ def _format_datetime(dt: datetime) -> str:
     return dt.isoformat()
 
 
+def _merge_metadata(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    """Apply an additive per-key patch to a metadata dict.
+
+    Keys in ``patch`` whose value is ``None`` are removed from the result
+    (silently if absent). Keys with any other value overwrite the existing
+    entry. Keys present in ``existing`` but absent from ``patch`` are
+    preserved. ``patch == {}`` is a no-op that returns a fresh copy of
+    ``existing``.
+
+    Pure: returns a new dict; neither argument is mutated. The
+    multi-writer guarantee in #290 depends on this being called inside a
+    BEGIN IMMEDIATE transaction so the read-merge-write cycle is atomic.
+    """
+    merged = dict(existing)
+    for key, value in patch.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    return merged
+
+
 class CoordinationService:
     """SQLite-based coordination service."""
 
@@ -631,7 +653,10 @@ class CoordinationService:
         Only open tasks can be updated; completed or cancelled tasks are
         treated as not found (consistent with complete_task behaviour).
 
-        To clear metadata entirely, pass an empty dict ``{}``.
+        ``metadata`` is applied as an additive per-key merge: keys with
+        non-null values overwrite, keys whose value is ``None`` are deleted,
+        keys not in the patch are preserved. ``metadata={}`` is a no-op.
+        There is no wholesale-clear affordance (#290).
 
         Returns:
             True if task was found, is open, and was updated; False otherwise
@@ -641,40 +666,57 @@ class CoordinationService:
         lithos_metrics.coordination_ops.add(1, {"op": "update_task"})
         await self.ensure_agent_known(agent)
 
-        sets: list[str] = []
-        params: list[Any] = []
+        non_metadata_sets: list[str] = []
+        non_metadata_params: list[Any] = []
 
         if title is not None:
-            sets.append("title = ?")
-            params.append(title)
+            non_metadata_sets.append("title = ?")
+            non_metadata_params.append(title)
         if description is not None:
-            sets.append("description = ?")
-            params.append(description)
+            non_metadata_sets.append("description = ?")
+            non_metadata_params.append(description)
         if tags is not None:
-            sets.append("tags = ?")
-            params.append(json.dumps(tags))
-        if metadata is not None:
-            sets.append("metadata = ?")
-            params.append(json.dumps(metadata))
+            non_metadata_sets.append("tags = ?")
+            non_metadata_params.append(json.dumps(tags))
 
+        if metadata is None:
+            return await self._update_task_fast(
+                task_id, agent, non_metadata_sets, non_metadata_params
+            )
+        return await self._update_task_with_merge(
+            task_id, agent, non_metadata_sets, non_metadata_params, metadata
+        )
+
+    async def _update_task_fast(
+        self,
+        task_id: str,
+        agent: str,
+        sets: list[str],
+        params: list[Any],
+    ) -> bool:
+        """Update title/description/tags without touching metadata.
+
+        Single UPDATE, no SELECT needed. When ``sets`` is empty the caller
+        passed only no-op arguments — we still return True/False based on
+        whether the task exists and is open, matching the contract of the
+        merge path.
+        """
         if not sets:
-            # Nothing to update; check task exists and is open
             async with aiosqlite.connect(self.db_path) as db:
                 cursor = await db.execute(
                     "SELECT id FROM tasks WHERE id = ? AND status = 'open'", (task_id,)
                 )
                 return await cursor.fetchone() is not None
 
-        params.append(task_id)
+        params_with_id = [*params, task_id]
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
                 f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'open'",
-                params,
+                params_with_id,
             )
             await db.commit()
             updated = cursor.rowcount > 0
             if updated:
-                # Derive logical field names from SQL clauses (e.g. "title = ?" -> "title")
                 updated_fields = [clause.split(" = ")[0] for clause in sets]
                 logger.info(
                     "Task updated: task_id=%s agent=%s fields=%s",
@@ -684,6 +726,67 @@ class CoordinationService:
                     extra={"task_id": task_id, "agent": agent, "fields": updated_fields},
                 )
             return updated
+
+    async def _update_task_with_merge(
+        self,
+        task_id: str,
+        agent: str,
+        non_metadata_sets: list[str],
+        non_metadata_params: list[Any],
+        metadata_patch: dict[str, Any],
+    ) -> bool:
+        """Read-merge-write the metadata column inside BEGIN IMMEDIATE.
+
+        BEGIN IMMEDIATE acquires the database-level write lock at the start
+        of the transaction, so two concurrent callers writing different
+        keys cannot both pass the SELECT and then race on the UPDATE — the
+        second caller blocks until the first commits, then reads the merged
+        state. This is the property the #290 multi-writer guarantee relies on.
+        """
+        import json
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "SELECT metadata FROM tasks WHERE id = ? AND status = 'open'",
+                    (task_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    await db.execute("ROLLBACK")
+                    return False
+
+                existing: dict[str, Any] = {}
+                if row[0]:
+                    with contextlib.suppress(json.JSONDecodeError):
+                        existing = json.loads(row[0])
+
+                merged = _merge_metadata(existing, metadata_patch)
+                merged_json = json.dumps(merged)
+
+                sets = [*non_metadata_sets, "metadata = ?"]
+                params = [*non_metadata_params, merged_json, task_id]
+                await db.execute(
+                    f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'open'",
+                    params,
+                )
+                await db.commit()
+            except Exception:
+                with contextlib.suppress(Exception):
+                    await db.execute("ROLLBACK")
+                raise
+
+        updated_fields = [clause.split(" = ")[0] for clause in non_metadata_sets]
+        updated_fields.append("metadata")
+        logger.info(
+            "Task updated: task_id=%s agent=%s fields=%s",
+            task_id,
+            agent,
+            updated_fields,
+            extra={"task_id": task_id, "agent": agent, "fields": updated_fields},
+        )
+        return True
 
     @traced("lithos.coordination.complete_task")
     async def complete_task(

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2327,10 +2327,16 @@ class LithosServer:
             tags: list[str] | None = None,
             metadata: dict[str, Any] | None = None,
         ) -> dict[str, Any]:
-            """Update mutable task metadata (title, description, tags, metadata).
+            """Update mutable task fields (title, description, tags, metadata).
 
             At least one of title, description, tags, or metadata must be provided.
-            Pass an empty dict ``{}`` for metadata to clear it.
+
+            ``metadata`` is applied as an additive per-key merge: keys with non-null
+            values overwrite the existing value, keys whose value is ``None`` are
+            deleted from the existing metadata, and keys not mentioned are preserved.
+            To clear a specific key, pass ``{"key": None}``. There is no
+            wholesale-clear affordance — ``metadata={}`` is a no-op that preserves
+            all existing keys.
 
             Args:
                 task_id: Task ID to update
@@ -2338,7 +2344,8 @@ class LithosServer:
                 title: New task title (optional)
                 description: New task description (optional)
                 tags: New task tags (optional)
-                metadata: Arbitrary JSON metadata dict; pass {} to clear (optional)
+                metadata: Per-key merge patch into the existing metadata dict
+                    (optional). See merge contract above.
 
             Returns:
                 Dict with success and message

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1742,6 +1742,47 @@ class TestTaskUpdateMetadataMerge:
         assert task.title == "New Title"
         assert task.metadata == {"a": 1, "b": 2}
 
+    @pytest.mark.parametrize(
+        "stored_raw",
+        ["null", "[1, 2]", '"x"', "42", "true"],
+        ids=["null", "array", "string", "number", "bool"],
+    )
+    @pytest.mark.asyncio
+    async def test_merge_resilient_to_non_dict_stored_metadata(
+        self, coordination_service: CoordinationService, stored_raw: str
+    ):
+        """Merge degrades to {} when stored metadata is valid JSON but not an object.
+
+        Regression for the Copilot/reviewer finding on #291: ``json.loads(null)``,
+        arrays, and scalars all decode to non-dict values that would otherwise
+        crash ``_merge_metadata`` via ``dict(existing)``. The decode helper
+        treats any non-object as empty and logs a warning; the merge proceeds.
+        """
+        task_id = await coordination_service.create_task(
+            title="Corrupt Meta Task",
+            agent="agent",
+            metadata={"will_be": "clobbered"},
+        )
+
+        # Force on-disk corruption by writing a non-object JSON directly.
+        async with aiosqlite.connect(coordination_service.db_path) as db:
+            await db.execute(
+                "UPDATE tasks SET metadata = ? WHERE id = ?",
+                (stored_raw, task_id),
+            )
+            await db.commit()
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"new": 1}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        # Corrupt stored value collapsed to {} before the merge; patch
+        # applies cleanly on top of the empty dict.
+        assert task.metadata == {"new": 1}
+
     @pytest.mark.asyncio
     async def test_merge_concurrent_writers_do_not_clobber(
         self, coordination_service: CoordinationService

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1433,46 +1433,6 @@ class TestTaskMetadata:
         assert task.metadata == {}
 
     @pytest.mark.asyncio
-    async def test_update_task_metadata(self, coordination_service: CoordinationService):
-        """update_task(metadata=...) replaces the stored metadata."""
-        task_id = await coordination_service.create_task(
-            title="Updatable Task",
-            agent="agent",
-            metadata={"initial": True},
-        )
-
-        updated = await coordination_service.update_task(
-            task_id=task_id,
-            agent="agent",
-            metadata={"priority": "low", "revised": True},
-        )
-        assert updated
-
-        task = await coordination_service.get_task(task_id)
-        assert task is not None
-        assert task.metadata == {"priority": "low", "revised": True}
-
-    @pytest.mark.asyncio
-    async def test_update_task_metadata_clear(self, coordination_service: CoordinationService):
-        """Passing metadata={} clears the stored metadata."""
-        task_id = await coordination_service.create_task(
-            title="Task To Clear",
-            agent="agent",
-            metadata={"to_be": "cleared"},
-        )
-
-        updated = await coordination_service.update_task(
-            task_id=task_id,
-            agent="agent",
-            metadata={},
-        )
-        assert updated
-
-        task = await coordination_service.get_task(task_id)
-        assert task is not None
-        assert task.metadata == {}
-
-    @pytest.mark.asyncio
     async def test_list_tasks_includes_metadata(self, coordination_service: CoordinationService):
         """list_tasks response dicts include the metadata field."""
         meta = {"env": "test"}
@@ -1562,6 +1522,257 @@ class TestTaskMetadata:
         task = await service.get_task("legacy-task-215")
         assert task is not None
         assert task.metadata == {}
+
+
+class TestMergeMetadataHelper:
+    """Tests for the module-level _merge_metadata pure helper (#290)."""
+
+    def test_empty_patch_returns_copy_of_existing(self):
+        from lithos.coordination import _merge_metadata
+
+        existing = {"a": 1, "b": 2}
+        result = _merge_metadata(existing, {})
+        assert result == {"a": 1, "b": 2}
+        # Pure function: must not mutate inputs and must return a new dict.
+        assert result is not existing
+
+    def test_set_new_key(self):
+        from lithos.coordination import _merge_metadata
+
+        assert _merge_metadata({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_overwrite_existing_key(self):
+        from lithos.coordination import _merge_metadata
+
+        assert _merge_metadata({"a": 1, "b": 2}, {"a": 99}) == {"a": 99, "b": 2}
+
+    def test_null_deletes_key(self):
+        from lithos.coordination import _merge_metadata
+
+        assert _merge_metadata({"a": 1, "b": 2}, {"a": None}) == {"b": 2}
+
+    def test_null_for_absent_key_is_silent_noop(self):
+        from lithos.coordination import _merge_metadata
+
+        assert _merge_metadata({"a": 1}, {"absent": None}) == {"a": 1}
+
+    def test_combined_set_and_delete(self):
+        from lithos.coordination import _merge_metadata
+
+        assert _merge_metadata({"a": 1, "b": 2}, {"a": None, "c": 3}) == {"b": 2, "c": 3}
+
+
+class TestTaskUpdateMetadataMerge:
+    """Tests for additive per-key metadata merge on update_task (#290)."""
+
+    @pytest.mark.asyncio
+    async def test_merge_sets_new_key_preserves_existing(
+        self, coordination_service: CoordinationService
+    ):
+        task_id = await coordination_service.create_task(
+            title="Merge New Key",
+            agent="agent",
+            metadata={"a": 1, "b": 2},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"c": 3}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 1, "b": 2, "c": 3}
+
+    @pytest.mark.asyncio
+    async def test_merge_overwrites_existing_key_preserves_others(
+        self, coordination_service: CoordinationService
+    ):
+        task_id = await coordination_service.create_task(
+            title="Merge Overwrite",
+            agent="agent",
+            metadata={"a": 1, "b": 2},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"a": 99}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 99, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_merge_null_deletes_key(self, coordination_service: CoordinationService):
+        task_id = await coordination_service.create_task(
+            title="Merge Delete",
+            agent="agent",
+            metadata={"a": 1, "b": 2},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"a": None}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"b": 2}
+
+    @pytest.mark.asyncio
+    async def test_merge_combined_set_and_delete_in_one_call(
+        self, coordination_service: CoordinationService
+    ):
+        task_id = await coordination_service.create_task(
+            title="Merge Combined",
+            agent="agent",
+            metadata={"a": 1, "b": 2},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id,
+            agent="agent",
+            metadata={"a": None, "c": 3},
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"b": 2, "c": 3}
+
+    @pytest.mark.asyncio
+    async def test_merge_empty_dict_is_noop(self, coordination_service: CoordinationService):
+        """metadata={} preserves all existing keys (no wholesale-clear affordance)."""
+        task_id = await coordination_service.create_task(
+            title="Merge Empty Patch",
+            agent="agent",
+            metadata={"a": 1, "b": 2},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={}
+        )
+        # Task exists and is open, so the call still reports success.
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 1, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_merge_into_initially_empty_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        """Patch into a task created with no metadata (NULL column) yields the patch."""
+        task_id = await coordination_service.create_task(
+            title="Merge From Empty",
+            agent="agent",
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"a": 1}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_merge_null_for_missing_key_is_silent(
+        self, coordination_service: CoordinationService
+    ):
+        """Deleting a key that isn't present is a silent no-op, not an error."""
+        task_id = await coordination_service.create_task(
+            title="Merge Delete Missing",
+            agent="agent",
+            metadata={"a": 1},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"absent": None}
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_merge_on_completed_task_returns_false(
+        self, coordination_service: CoordinationService
+    ):
+        """Completed tasks are treated as not-found; metadata is not mutated."""
+        task_id = await coordination_service.create_task(
+            title="Completed Task",
+            agent="agent",
+            metadata={"a": 1},
+        )
+        await coordination_service.complete_task(task_id, agent="agent", outcome="done")
+
+        updated = await coordination_service.update_task(
+            task_id=task_id, agent="agent", metadata={"b": 2}
+        )
+        assert updated is False
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_merge_preserves_other_columns(self, coordination_service: CoordinationService):
+        """Title and metadata merge in the same call both take effect."""
+        task_id = await coordination_service.create_task(
+            title="Original Title",
+            agent="agent",
+            metadata={"a": 1},
+        )
+
+        updated = await coordination_service.update_task(
+            task_id=task_id,
+            agent="agent",
+            title="New Title",
+            metadata={"b": 2},
+        )
+        assert updated
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.title == "New Title"
+        assert task.metadata == {"a": 1, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_merge_concurrent_writers_do_not_clobber(
+        self, coordination_service: CoordinationService
+    ):
+        """Two concurrent updates writing different keys both land in the final state.
+
+        Regression guard for the multi-writer property that motivates #290:
+        without BEGIN IMMEDIATE serialisation, two callers could both pass
+        the SELECT and the loser's write would clobber the winner's key.
+        """
+        task_id = await coordination_service.create_task(
+            title="Concurrent Writers",
+            agent="agent",
+            metadata={"base": "seed"},
+        )
+
+        results = await asyncio.gather(
+            coordination_service.update_task(
+                task_id=task_id, agent="writer-a", metadata={"a": "from-a"}
+            ),
+            coordination_service.update_task(
+                task_id=task_id, agent="writer-b", metadata={"b": "from-b"}
+            ),
+        )
+        assert all(results)
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        # Both keys must survive — neither writer clobbered the other, and
+        # the original "base" key is preserved.
+        assert task.metadata == {"base": "seed", "a": "from-a", "b": "from-b"}
 
 
 class TestParseDatetimeWarnsOnFailure:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2531,46 +2531,70 @@ class TestTaskMetadataTool:
         assert task.metadata == {}
 
     @pytest.mark.asyncio
-    async def test_task_update_metadata(self, server: LithosServer):
-        """lithos_task_update: metadata field is updated correctly."""
+    async def test_task_update_metadata_merges_per_key(self, server: LithosServer):
+        """lithos_task_update merges metadata per-key without clobbering others (#290)."""
         task_id = await server.coordination.create_task(
-            title="Update Meta Task",
+            title="Merge Meta Task",
             agent="test-agent",
-            metadata={"old_key": "old_val"},
+            metadata={"existing": "stay", "old_key": "old_val"},
         )
 
         result = await self._call_task_update(
             server,
             task_id=task_id,
             agent="test-agent",
-            metadata={"new_key": "new_val", "count": 99},
+            metadata={"new_key": "new_val", "old_key": "updated"},
         )
         assert result["success"] is True
 
         task = await server.coordination.get_task(task_id)
         assert task is not None
-        assert task.metadata == {"new_key": "new_val", "count": 99}
+        assert task.metadata == {
+            "existing": "stay",
+            "old_key": "updated",
+            "new_key": "new_val",
+        }
 
     @pytest.mark.asyncio
-    async def test_task_update_clear_metadata(self, server: LithosServer):
-        """lithos_task_update: passing {} clears metadata."""
+    async def test_task_update_metadata_null_deletes_key(self, server: LithosServer):
+        """lithos_task_update with metadata={k: None} deletes that key only (#290)."""
         task_id = await server.coordination.create_task(
-            title="Clear Meta Task",
+            title="Delete-Key Meta Task",
             agent="test-agent",
-            metadata={"to_be": "cleared"},
+            metadata={"keep": "yes", "drop": "soon"},
         )
 
         result = await self._call_task_update(
             server,
             task_id=task_id,
             agent="test-agent",
-            metadata={},
+            metadata={"drop": None},
         )
         assert result["success"] is True
 
         task = await server.coordination.get_task(task_id)
         assert task is not None
-        assert task.metadata == {}
+        assert task.metadata == {"keep": "yes"}
+
+    @pytest.mark.asyncio
+    async def test_task_update_metadata_only_arg_satisfies_at_least_one(self, server: LithosServer):
+        """metadata={k: v} alone is enough to satisfy the at-least-one check (#290)."""
+        task_id = await server.coordination.create_task(
+            title="Metadata-Only Update",
+            agent="test-agent",
+        )
+
+        result = await self._call_task_update(
+            server,
+            task_id=task_id,
+            agent="test-agent",
+            metadata={"priority": "high"},
+        )
+        assert result.get("success") is True
+
+        task = await server.coordination.get_task(task_id)
+        assert task is not None
+        assert task.metadata == {"priority": "high"}
 
     @pytest.mark.asyncio
     async def test_task_list_includes_metadata(self, server: LithosServer):


### PR DESCRIPTION
## Summary

Replaces the wholesale-replace behaviour of `lithos_task_update(metadata=...)` with an additive per-key merge. Multiple consumers (lithos-loom priority sync, lithos-lens, future Track 1 PRD fields like `depends_on` / `scheduled_for` / `story_doc_id`) can now update independent metadata keys on the same task without clobbering each other.

Closes #290.

## Behaviour

| Call | Effect on `tasks.metadata` |
| --- | --- |
| `metadata=None` (omitted) | No change — column not touched |
| `metadata={}` | No-op — preserves all existing keys |
| `metadata={k: v}` (v not null) | Merge — set/overwrite key `k`; other keys preserved |
| `metadata={k: null}` | Merge — delete key `k` if present; other keys preserved |
| `metadata={k1: v, k2: null, ...}` | Combined set/delete in one call, atomically |

### Breaking change

Callers that relied on `metadata={}` to wipe the dict wholesale will no longer see that effect — this is exactly the multi-writer footgun #290 closes (any caller could otherwise clobber every other consumer's keys with one line). There is no wholesale-clear affordance. To clear specific keys, callers must pass `{"k": null}` per key.

## Atomicity

The merge path runs inside a `BEGIN IMMEDIATE` transaction so two concurrent writers updating different keys cannot both pass the SELECT and then race on the UPDATE — the second caller blocks until the first commits, then reads the merged state. `test_merge_concurrent_writers_do_not_clobber` (asyncio.gather + assert both keys survive) guards this.

## Changes

- **`src/lithos/coordination.py`** — new module-level `_merge_metadata` pure helper; `update_task` forked into `_update_task_fast` (metadata is None — original single-UPDATE path) and `_update_task_with_merge` (metadata is not None — BEGIN IMMEDIATE + SELECT + merge + UPDATE).
- **`src/lithos/server.py`** — `lithos_task_update` docstring rewritten to document the merge contract.
- **`docs/SPECIFICATION.md` §5.4** — `metadata` row added to Arguments table; behaviour bullets updated to include `metadata` in the at-least-one constraint and to document the merge contract.
- **`tests/test_coordination.py`** — deleted 2 replace-semantics tests; added `TestMergeMetadataHelper` (6 cases on the pure helper) and `TestTaskUpdateMetadataMerge` (10 cases including the concurrent-writers regression guard).
- **`tests/test_server.py`** — deleted 2 replace-semantics tests; added 3 MCP-layer merge-semantics tests.

No schema change or migration is needed — the `metadata JSON` column already exists.

## Test plan

- [x] `make check` — 1188 unit tests pass (+14 net from this PR).
- [x] `make test-integration` — 354 integration tests pass.
- [ ] Manual MCP verification once CI is green:
  ```
  # Create a task with two metadata keys.
  lithos_task_create(title="...", agent="me", metadata={"priority": "high", "scheduled_for": "2026-06-01"})
  # Merge: change one key, keep the other.
  lithos_task_update(task_id, agent="me", metadata={"priority": "medium"})
  # → get_task reports {"priority": "medium", "scheduled_for": "2026-06-01"}
  # Delete one key.
  lithos_task_update(task_id, agent="me", metadata={"priority": null})
  # → get_task reports {"scheduled_for": "2026-06-01"}
  # Empty patch — no-op.
  lithos_task_update(task_id, agent="me", metadata={})
  # → get_task still reports {"scheduled_for": "2026-06-01"}; call returns success.
  ```

Closes #290