### PR TITLE
feat(task): surface full task record on status, add lithos_task_get

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -810,19 +810,31 @@ List tasks with optional filters.
 | `resolved_since` | string | No | Filter by `resolved_at >= resolved_since` (ISO datetime). `resolved_at` is set on both terminal transitions (`complete` and `cancel`), so this surfaces tasks resolved in either way within the window. Open tasks and historical cancellations whose `resolved_at` is `NULL` are excluded automatically. |
 | `with_claims` | boolean | No | When `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`. Use to avoid an N+1 of `lithos_task_status` calls when rendering a list view. |
 
-**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
+**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). `outcome` is `null` until the task is completed with an outcome. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
 
 #### `lithos_task_status`
-Get task status and claims.
+Get the full record of a task along with its active claims.
 
 **Arguments:**
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `task_id` | string | Yes | Specific task ID |
 
-**Returns:** `{ tasks: [{ id, title, status, claims: [{ agent, aspect, expires_at }] }] }`
+**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome, claims: [{ agent, aspect, expires_at }] }] }`. Returns `{ tasks: [] }` when the task does not exist (mirrors historical behaviour — does not return the error envelope). Use `lithos_task_get` when you want a single-task fetch with an explicit not-found envelope and don't need claims.
 
 **Claim expiry handling:** Expired claims (where `expires_at < now()`) are automatically excluded from results. Cleanup is lazy—expired claims are filtered at query time rather than eagerly deleted.
+
+#### `lithos_task_get`
+Fetch a single task by ID. Returns the full task record without claims; use `lithos_task_status` when claims are needed.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `task_id` | string | Yes | Task ID |
+
+**Returns (success):** `{ task: { id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome } }`
+
+**Returns (unknown task):** `{ status: "error", code: "task_not_found", message: string }`
 
 #### `lithos_finding_post`
 Post a finding to a task.
@@ -1407,7 +1419,7 @@ lithos --data-dir ./data audit --doc <id> --since 2026-01-01T00:00:00
 Tools indicate routine domain failures through return values, and unexpected backend failures may still surface as MCP-level exceptions.
 
 - **Structured status envelopes**: `lithos_write` returns `{ status: "error", code, message, ... }` for invalid input and contract-level failures
-- **Structured error envelopes on many tools**: `lithos_delete`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_update`, `lithos_task_cancel`, `lithos_search`, `lithos_list`, and `lithos_cache_lookup` use `{ status: "error", code, message }` for routine domain failures
+- **Structured error envelopes on many tools**: `lithos_delete`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_update`, `lithos_task_cancel`, `lithos_task_get`, `lithos_search`, `lithos_list`, and `lithos_cache_lookup` use `{ status: "error", code, message }` for routine domain failures
 - **Nullable results**: `lithos_agent_info` returns `null` when the agent is not found
 - **Exceptions**: Unexpected file/index/backend errors may still propagate at the MCP layer
 
@@ -1425,6 +1437,7 @@ Tools indicate routine domain failures through return values, and unexpected bac
 | Completing unknown or non-open task | `lithos_task_complete` returns `{ status: "error", code: "task_not_found" }` |
 | Updating task with no fields provided | `lithos_task_update` returns `{ status: "error", code: "invalid_input" }` |
 | Updating or cancelling unknown/closed task | `lithos_task_update` / `lithos_task_cancel` returns `{ status: "error", code: "task_not_found" }` |
+| Fetching unknown task via `lithos_task_get` | Returns `{ status: "error", code: "task_not_found" }` |
 | Invalid arguments | FastMCP validation rejects the call |
 | Ambiguous wiki-link | Link treated as unresolved (no error raised) |
 | Write content exceeds configured limit | `lithos_write` returns `{ status: "error", code: "content_too_large" }` |

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -143,13 +143,27 @@ class Finding:
 
 @dataclass
 class TaskStatus:
-    """Task status with claims."""
+    """Task status with claims.
+
+    Carries the same persisted fields as :class:`Task` (modulo identity)
+    plus the task's currently-active (non-expired) claims. Earlier revisions
+    of this dataclass returned only ``id``, ``title``, ``status``, ``metadata``
+    and ``claims``; consumers (lithos-loom) ended up doing an N+1 re-fetch
+    via ``lithos_task_list`` just to recover the missing fields. The store
+    already has them — surface them.
+    """
 
     id: str
     title: str
     status: str
     claims: list[Claim]
     metadata: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+    created_by: str = ""
+    created_at: datetime | None = None
+    tags: list[str] = field(default_factory=list)
+    outcome: str | None = None
+    resolved_at: datetime | None = None
 
 
 @dataclass
@@ -951,7 +965,8 @@ class CoordinationService:
 
         Returns:
             List of task dicts with id, title, description, status, created_by,
-            created_at, resolved_at, tags, metadata, and (when with_claims) claims.
+            created_at, resolved_at, tags, metadata, outcome, and (when
+            with_claims) claims.
         """
         import json
 
@@ -1006,6 +1021,7 @@ class CoordinationService:
                     if row_keys is not None and "resolved_at" in row_keys
                     else None
                 )
+                outcome = row["outcome"] if row_keys is not None and "outcome" in row_keys else None
                 results.append(
                     {
                         "id": row["id"],
@@ -1017,6 +1033,7 @@ class CoordinationService:
                         "resolved_at": resolved_at,
                         "tags": task_tags,
                         "metadata": task_metadata,
+                        "outcome": outcome,
                     }
                 )
 
@@ -1126,8 +1143,15 @@ class CoordinationService:
 
                 task_metadata: dict[str, Any] = {}
                 if "metadata" in task_row_keys and task["metadata"]:
+                    task_metadata = _decode_metadata(task["metadata"])
+
+                task_tags: list[str] = []
+                if task["tags"]:
                     with contextlib.suppress(json.JSONDecodeError):
-                        task_metadata = json.loads(task["metadata"])
+                        task_tags = json.loads(task["tags"])
+
+                outcome = task["outcome"] if "outcome" in task_row_keys else None
+                resolved_at_raw = task["resolved_at"] if "resolved_at" in task_row_keys else None
 
                 result.append(
                     TaskStatus(
@@ -1136,6 +1160,12 @@ class CoordinationService:
                         status=task["status"],
                         claims=claims,
                         metadata=task_metadata,
+                        description=task["description"],
+                        created_by=task["created_by"],
+                        created_at=_parse_datetime(task["created_at"]),
+                        tags=task_tags,
+                        outcome=outcome,
+                        resolved_at=_parse_datetime(resolved_at_raw),
                     )
                 )
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1011,10 +1011,15 @@ class CoordinationService:
                 if tags and not all(t in task_tags for t in tags):
                     continue
 
+                # Route metadata decode through _decode_metadata for parity
+                # with get_task / get_task_status. Raw json.loads accepted
+                # legacy/corrupt rows whose JSON parses to non-objects
+                # (`null`, arrays, scalars), causing list_tasks to return a
+                # non-dict metadata payload while the other surfaces regularised
+                # it back to {}.
                 task_metadata: dict[str, Any] = {}
-                if "metadata" in row_keys and row["metadata"]:
-                    with contextlib.suppress(json.JSONDecodeError):
-                        task_metadata = json.loads(row["metadata"])
+                if "metadata" in row_keys:
+                    task_metadata = _decode_metadata(row["metadata"])
 
                 resolved_at = (
                     row["resolved_at"]

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -19,7 +19,7 @@ from starlette.responses import Response, StreamingResponse
 
 from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig, get_config, set_config
-from lithos.coordination import CoordinationService
+from lithos.coordination import CoordinationService, Task, TaskStatus
 from lithos.edge_store import EdgeStore
 from lithos.errors import SearchBackendError
 from lithos.events import (
@@ -67,6 +67,32 @@ logger = logging.getLogger(__name__)
 # matches from a single FTS query would already be degenerate; at that
 # point the caller should tighten the query, not ask for more results.
 _CONTENT_QUERY_FTS_CAP = 1_000_000
+
+
+def _serialize_task_record(task: Task | TaskStatus) -> dict[str, Any]:
+    """Render a Task or TaskStatus as the MCP wire-shape task dict.
+
+    Used by both ``lithos_task_get`` (which serialises a ``Task``) and
+    ``lithos_task_status`` (which serialises the task-shaped subset of a
+    ``TaskStatus``, then layers ``claims`` on top). Centralising the field
+    set + datetime formatting here stops the two responses drifting on
+    additions or ISO serialisation choices.
+
+    Claims are deliberately excluded — ``lithos_task_status`` adds them
+    alongside this dict; ``lithos_task_get`` does not return them.
+    """
+    return {
+        "id": task.id,
+        "title": task.title,
+        "description": task.description,
+        "status": task.status,
+        "created_by": task.created_by,
+        "created_at": task.created_at.isoformat() if task.created_at else None,
+        "resolved_at": task.resolved_at.isoformat() if task.resolved_at else None,
+        "tags": task.tags,
+        "metadata": task.metadata,
+        "outcome": task.outcome,
+    }
 
 
 class LithosServer:
@@ -2812,16 +2838,7 @@ class LithosServer:
                 return {
                     "tasks": [
                         {
-                            "id": s.id,
-                            "title": s.title,
-                            "description": s.description,
-                            "status": s.status,
-                            "created_by": s.created_by,
-                            "created_at": s.created_at.isoformat() if s.created_at else None,
-                            "resolved_at": s.resolved_at.isoformat() if s.resolved_at else None,
-                            "tags": s.tags,
-                            "metadata": s.metadata,
-                            "outcome": s.outcome,
+                            **_serialize_task_record(s),
                             "claims": [
                                 {
                                     "agent": c.agent,
@@ -2871,20 +2888,7 @@ class LithosServer:
                         "message": f"Task '{task_id}' not found.",
                     }
 
-                return {
-                    "task": {
-                        "id": task.id,
-                        "title": task.title,
-                        "description": task.description,
-                        "status": task.status,
-                        "created_by": task.created_by,
-                        "created_at": task.created_at.isoformat() if task.created_at else None,
-                        "resolved_at": (task.resolved_at.isoformat() if task.resolved_at else None),
-                        "tags": task.tags,
-                        "metadata": task.metadata,
-                        "outcome": task.outcome,
-                    }
-                }
+                return {"task": _serialize_task_record(task)}
 
         @self.mcp.tool()
         @tool_metrics()

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2753,8 +2753,8 @@ class LithosServer:
 
             Returns:
                 Dict with tasks list containing id, title, description, status,
-                created_by, created_at, resolved_at, tags, metadata, and
-                (when with_claims) claims.
+                created_by, created_at, resolved_at, tags, metadata, outcome,
+                and (when with_claims) claims.
             """
             logger.info(
                 "lithos_task_list agent=%s status=%s tags=%s since=%s resolved_since=%s "
@@ -2790,13 +2790,16 @@ class LithosServer:
         async def lithos_task_status(
             task_id: str,
         ) -> dict[str, list[dict[str, Any]]]:
-            """Get status of a specific task with its active claims.
+            """Get the full record of a specific task with its active claims.
 
             Args:
                 task_id: Task ID to look up
 
             Returns:
-                Dict with tasks list containing id, title, status, claims
+                Dict with tasks list containing id, title, description, status,
+                created_by, created_at, resolved_at, tags, metadata, outcome,
+                and claims. Returns an empty tasks list if the task does not
+                exist (mirrors the historical behaviour).
             """
             logger.info("lithos_task_status task_id=%s", task_id)
             tracer = get_tracer()
@@ -2811,8 +2814,14 @@ class LithosServer:
                         {
                             "id": s.id,
                             "title": s.title,
+                            "description": s.description,
                             "status": s.status,
+                            "created_by": s.created_by,
+                            "created_at": s.created_at.isoformat() if s.created_at else None,
+                            "resolved_at": s.resolved_at.isoformat() if s.resolved_at else None,
+                            "tags": s.tags,
                             "metadata": s.metadata,
+                            "outcome": s.outcome,
                             "claims": [
                                 {
                                     "agent": c.agent,
@@ -2824,6 +2833,57 @@ class LithosServer:
                         }
                         for s in statuses
                     ]
+                }
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_get(
+            task_id: str,
+        ) -> dict[str, Any]:
+            """Get the full record of a single task by ID.
+
+            Returns the task on its own (not wrapped in a list) so callers
+            that already know the ID don't have to unwrap a one-element
+            response. Does not include claims — use ``lithos_task_status``
+            when you need claims alongside the task fields.
+
+            Args:
+                task_id: Task ID to look up
+
+            Returns:
+                Dict with task fields (id, title, description, status,
+                created_by, created_at, resolved_at, tags, metadata, outcome).
+                Returns the standard error envelope
+                ``{status: "error", code: "task_not_found", message: ...}``
+                when no task matches.
+            """
+            logger.info("lithos_task_get task_id=%s", task_id)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_get") as span:
+                span.set_attribute("lithos.tool", "lithos_task_get")
+                span.set_attribute("lithos.task_id", task_id)
+
+                task = await self.coordination.get_task(task_id)
+                if task is None:
+                    return {
+                        "status": "error",
+                        "code": "task_not_found",
+                        "message": f"Task '{task_id}' not found.",
+                    }
+
+                return {
+                    "task": {
+                        "id": task.id,
+                        "title": task.title,
+                        "description": task.description,
+                        "status": task.status,
+                        "created_by": task.created_by,
+                        "created_at": task.created_at.isoformat() if task.created_at else None,
+                        "resolved_at": (task.resolved_at.isoformat() if task.resolved_at else None),
+                        "tags": task.tags,
+                        "metadata": task.metadata,
+                        "outcome": task.outcome,
+                    }
                 }
 
         @self.mcp.tool()

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -850,6 +850,24 @@ class TestListTasks:
         assert task["created_by"] == "agent"
         assert "tag1" in task["tags"]
         assert task["created_at"] is not None
+        # Open tasks have no outcome yet but the key is present so consumers
+        # don't have to do an existence-check on every row.
+        assert task["outcome"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_surfaces_outcome_after_completion(
+        self, coordination_service: CoordinationService
+    ):
+        """Completed tasks expose the persisted outcome via list_tasks."""
+        task_id = await coordination_service.create_task(
+            title="Outcome Task",
+            agent="agent",
+        )
+        await coordination_service.complete_task(task_id, "agent", outcome="ship it")
+
+        tasks = await coordination_service.list_tasks(status="completed")
+        task = next(t for t in tasks if t["id"] == task_id)
+        assert task["outcome"] == "ship it"
 
     @pytest.mark.asyncio
     async def test_list_tasks_without_with_claims_omits_claims_field(
@@ -1478,6 +1496,39 @@ class TestTaskMetadata:
         statuses = await coordination_service.get_task_status(task_id)
         assert len(statuses) == 1
         assert statuses[0].metadata == meta
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_includes_all_task_fields(
+        self, coordination_service: CoordinationService
+    ):
+        """get_task_status surfaces description, tags, created_by, created_at,
+        resolved_at, outcome — fields that earlier dropped silently."""
+        meta = {"priority": "high"}
+        task_id = await coordination_service.create_task(
+            title="Full Status",
+            agent="creator-agent",
+            description="A full description",
+            tags=["loom", "demo"],
+            metadata=meta,
+        )
+
+        # Open task: outcome and resolved_at are None, the rest are populated.
+        [open_status] = await coordination_service.get_task_status(task_id)
+        assert open_status.description == "A full description"
+        assert open_status.created_by == "creator-agent"
+        assert open_status.created_at is not None
+        assert open_status.tags == ["loom", "demo"]
+        assert open_status.metadata == meta
+        assert open_status.outcome is None
+        assert open_status.resolved_at is None
+
+        # Completed task: outcome and resolved_at are populated.
+        await coordination_service.complete_task(task_id, "creator-agent", outcome="shipped")
+        [done_status] = await coordination_service.get_task_status(task_id)
+        assert done_status.outcome == "shipped"
+        assert done_status.resolved_at is not None
+        assert done_status.tags == ["loom", "demo"]
+        assert done_status.metadata == meta
 
     @pytest.mark.asyncio
     async def test_migration_adds_metadata_column(self, tmp_path):

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -949,6 +949,48 @@ class TestAgentAndCoordinationMCPTools:
         assert "definitely-not-a-real-id" in got["message"]
 
     @pytest.mark.asyncio
+    async def test_integration_mcp_task_get_and_status_share_task_record(
+        self, server: LithosServer
+    ):
+        """Contract: lithos_task_get and lithos_task_status return the same
+        task fields. Guards the regularisation goal so the two responses
+        can't drift on field set or datetime formatting as fields are added.
+        """
+        created = await _call_tool(
+            server,
+            "lithos_task_create",
+            {
+                "title": "Shared Shape",
+                "agent": "shared-agent",
+                "description": "Same shape on both surfaces.",
+                "tags": ["x"],
+                "metadata": {"k": "v"},
+            },
+        )
+        task_id = created["task_id"]
+        # Add a claim so the status view actually carries one — it must still
+        # be a strict superset of the task_get shape (no missing/extra task
+        # fields), just with the claims array layered on top.
+        await _call_tool(
+            server,
+            "lithos_task_claim",
+            {
+                "task_id": task_id,
+                "aspect": "verification",
+                "agent": "shared-agent",
+                "ttl_minutes": 10,
+            },
+        )
+
+        got = (await _call_tool(server, "lithos_task_get", {"task_id": task_id}))["task"]
+        status_task = (await _call_tool(server, "lithos_task_status", {"task_id": task_id}))[
+            "tasks"
+        ][0]
+
+        status_minus_claims = {k: v for k, v in status_task.items() if k != "claims"}
+        assert got == status_minus_claims
+
+    @pytest.mark.asyncio
     async def test_integration_mcp_task_list_includes_outcome(self, server: LithosServer):
         """lithos_task_list dicts carry the persisted outcome field."""
         created = await _call_tool(

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -865,6 +865,110 @@ class TestAgentAndCoordinationMCPTools:
         assert status["tasks"][0]["claims"] == []
 
     @pytest.mark.asyncio
+    async def test_integration_mcp_task_status_surfaces_full_task_record(
+        self, server: LithosServer
+    ):
+        """lithos_task_status returns the full task row, not just id/title/status."""
+        created = await _call_tool(
+            server,
+            "lithos_task_create",
+            {
+                "title": "Full Status Roundtrip",
+                "agent": "status-agent",
+                "description": "Full record exercise.",
+                "tags": ["loom", "demo"],
+                "metadata": {"priority": "high"},
+            },
+        )
+        task_id = created["task_id"]
+
+        status = await _call_tool(server, "lithos_task_status", {"task_id": task_id})
+        assert len(status["tasks"]) == 1
+        task = status["tasks"][0]
+        assert task["id"] == task_id
+        assert task["title"] == "Full Status Roundtrip"
+        assert task["description"] == "Full record exercise."
+        assert task["created_by"] == "status-agent"
+        assert task["created_at"] is not None
+        assert task["resolved_at"] is None
+        assert task["tags"] == ["loom", "demo"]
+        assert task["metadata"] == {"priority": "high"}
+        assert task["outcome"] is None
+        assert task["claims"] == []
+
+        # After completion, outcome and resolved_at populate.
+        await _call_tool(
+            server,
+            "lithos_task_complete",
+            {"task_id": task_id, "agent": "status-agent", "outcome": "shipped"},
+        )
+        done_status = await _call_tool(server, "lithos_task_status", {"task_id": task_id})
+        done = done_status["tasks"][0]
+        assert done["status"] == "completed"
+        assert done["outcome"] == "shipped"
+        assert done["resolved_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_integration_mcp_task_get_returns_full_record(self, server: LithosServer):
+        """lithos_task_get returns a single task by ID with all persisted fields."""
+        created = await _call_tool(
+            server,
+            "lithos_task_create",
+            {
+                "title": "Get Roundtrip",
+                "agent": "get-agent",
+                "description": "Single-record fetch.",
+                "tags": ["a", "b"],
+                "metadata": {"k": "v"},
+            },
+        )
+        task_id = created["task_id"]
+
+        got = await _call_tool(server, "lithos_task_get", {"task_id": task_id})
+        assert "task" in got
+        task = got["task"]
+        assert task["id"] == task_id
+        assert task["title"] == "Get Roundtrip"
+        assert task["description"] == "Single-record fetch."
+        assert task["created_by"] == "get-agent"
+        assert task["created_at"] is not None
+        assert task["resolved_at"] is None
+        assert task["tags"] == ["a", "b"]
+        assert task["metadata"] == {"k": "v"}
+        assert task["outcome"] is None
+        assert task["status"] == "open"
+
+    @pytest.mark.asyncio
+    async def test_integration_mcp_task_get_unknown_returns_error_envelope(
+        self, server: LithosServer
+    ):
+        """lithos_task_get returns the standard error envelope for unknown ids."""
+        got = await _call_tool(server, "lithos_task_get", {"task_id": "definitely-not-a-real-id"})
+        assert got["status"] == "error"
+        assert got["code"] == "task_not_found"
+        assert "definitely-not-a-real-id" in got["message"]
+
+    @pytest.mark.asyncio
+    async def test_integration_mcp_task_list_includes_outcome(self, server: LithosServer):
+        """lithos_task_list dicts carry the persisted outcome field."""
+        created = await _call_tool(
+            server,
+            "lithos_task_create",
+            {"title": "Outcome List Task", "agent": "outcome-agent"},
+        )
+        task_id = created["task_id"]
+        await _call_tool(
+            server,
+            "lithos_task_complete",
+            {"task_id": task_id, "agent": "outcome-agent", "outcome": "the answer"},
+        )
+
+        listing = await _call_tool(server, "lithos_task_list", {"status": "completed"})
+        match = next((t for t in listing["tasks"] if t["id"] == task_id), None)
+        assert match is not None
+        assert match["outcome"] == "the answer"
+
+    @pytest.mark.asyncio
     async def test_integration_mcp_findings_with_since_filter(self, server: LithosServer):
         task = await _call_tool(
             server,


### PR DESCRIPTION
## Summary

- `lithos_task_status` now returns the full task record (description, created_by, created_at, tags, outcome, resolved_at) alongside the claims it already exposed. Earlier, consumers had to re-call `lithos_task_list` just to recover the missing fields.
- New `lithos_task_get(task_id)` tool returns a single task without the list wrapper or claims, with the standard `{status: "error", code: "task_not_found", message: ...}` envelope on miss.
- `lithos_task_list` response now includes `outcome` (already in `SELECT *`, was being dropped from the payload).
- No schema changes, no new persisted fields, no event payload changes.

## Why

Surveying the task tools surface against the coordination store turned up five gaps where fields the DB already has were being silently dropped from MCP responses. lithos-loom and other downstream consumers were doing N+1 re-fetches as a workaround. This PR addresses the cheapest three (no schema impact); the other two are queued as #292 (event payload enrichment) and #293 (findings tags + metadata).

## Spec updates

- `docs/SPECIFICATION.md` response-shape rows for `lithos_task_status` and `lithos_task_list` updated.
- New `lithos_task_get` section added next to `lithos_task_status`.
- Error envelope listing + scenarios table extended to mention `lithos_task_get` / `task_not_found`.

## Test plan

- [x] `make test` — 1195 passed
- [x] `make test-integration` — 358 passed
- [x] `make check` (ruff lint + format + pyright) — clean
- [x] New unit coverage: `test_get_task_status_includes_all_task_fields`, `test_list_tasks_surfaces_outcome_after_completion` in `tests/test_coordination.py`
- [x] New MCP integration coverage in `tests/test_integration_conformance.py`: `test_integration_mcp_task_status_surfaces_full_task_record`, `test_integration_mcp_task_get_returns_full_record`, `test_integration_mcp_task_get_unknown_returns_error_envelope`, `test_integration_mcp_task_list_includes_outcome`

## Related

- #292 — event payload enrichment (next, depends on agreeing the event-payload conventions)
- #293 — findings tags + metadata (after #292)
- #290 — task per-key metadata merge (precedent for additive updates)