### PR TITLE
docs(task): document metadata argument on lithos_task_create (closes #295)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -707,6 +707,7 @@ Create a coordination task.
 | `description` | string | No | Task description |
 | `tags` | string[] | No | Task tags |
 | `agent` | string | Yes | Creating agent identifier |
+| `metadata` | object | No | Arbitrary JSON metadata dict persisted on the task row at insert time. Omitted (or `null`) creates a task with empty metadata. This is an **initial set**, not a merge — the row does not yet exist, so there is nothing to merge into. Subsequent mutations go through `lithos_task_update`, which applies an additive per-key merge (see that tool's **Behavior** for the contract). |
 
 **Returns:** `{ task_id: string }`
 


### PR DESCRIPTION
## Summary

Single-row addition to `docs/SPECIFICATION.md` documenting the existing `metadata` argument on `lithos_task_create`. Closes #295.

The implementation has been in tree since #215 (April 2026) — only the spec arguments table was missing the field, leaving the public contract under-documented.

## Why this is docs-only

Round-trip coverage already exists at three layers:

- **Coordination layer**: `tests/test_coordination.py::TestTaskMetadata::test_create_task_with_metadata` (+ the `_defaults_empty` companion)
- **MCP-unit layer (via `tool.fn()`)**: `tests/test_server.py::TestTaskMetadataTool::test_task_create_with_metadata`
- **MCP-integration layer (via `_call_tool`)**: three tests in `tests/test_integration_conformance.py` added in #294 — they call `lithos_task_create(metadata={...})` and assert round-trip through `task_status` / `task_get`.

No code path is touched by this PR; no new tests are needed.

## The new row

Mirrors the row format of `lithos_task_update`'s `metadata` argument (line ~724) but flags the key semantic difference for create-time: it's an **initial set**, not the additive per-key merge contract `lithos_task_update` uses, since the row doesn't yet exist at insert time. Cross-references `lithos_task_update` for the post-create mutation contract.

## Test plan

- [x] `make check` (ruff + pyright) — clean
- [ ] CI green (Lint / Test / Integration Test) — relying on CI; docs-only so unit/integration suites cannot regress
- [x] Visual diff: the new row is consistent in tone, type vocabulary, and grammar with `title`/`description`/`tags`/`agent` neighbours and with the cross-referenced `lithos_task_update` `metadata` row

## Related

- #215 — added the metadata implementation (April 2026)
- #290 — task per-key metadata merge on `lithos_task_update`
- #294 — task status / get plumb-through + MCP integration tests covering `lithos_task_create(metadata=...)`