### PR TITLE
fix(watcher): emit canonical note.created/updated payload (closes #297)

### DIFF
--- a/src/lithos/watch_intake.py
+++ b/src/lithos/watch_intake.py
@@ -163,7 +163,12 @@ class WatchIntake:
                         LithosEvent(
                             type=NOTE_CREATED if is_new else NOTE_UPDATED,
                             agent=WATCHER_AGENT,
-                            payload={"path": str(relative_path)},
+                            payload={
+                                "id": doc.id,
+                                "title": doc.title,
+                                "path": str(doc.path),
+                            },
+                            tags=list(doc.metadata.tags),
                         )
                     )
                 except Exception as e:

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -104,6 +104,41 @@ class TestFileWatcherEventEmission:
         assert event.agent == WATCHER_AGENT
         assert set(event.tags) == {"alpha", "beta"}
 
+    async def test_tag_filtered_subscriber_receives_watcher_event(
+        self, server: LithosServer
+    ) -> None:
+        """End-to-end pin for #297's downstream concern: a subscriber with
+        ``tags=["alpha"]`` actually receives a watcher-originated
+        ``NOTE_UPDATED`` for a doc carrying that tag, not just that
+        ``event.tags`` is populated. ``EventBus._matches`` filters on
+        ``event.tags`` (events.py:265-269), so this test exercises the full
+        delivery path that tag-filtered consumers depend on.
+        """
+        doc = (
+            await server.knowledge.create(
+                title="Tag-filtered Watcher Doc",
+                content="Body for tag-filter delivery test.",
+                agent="test-agent",
+                tags=["alpha", "beta"],
+                path="watched",
+            )
+        ).document
+        server.search.index(KnowledgeManager.to_indexable(doc))
+        server.graph.add_document(doc)
+
+        queue = server.event_bus.subscribe(
+            event_types=[NOTE_UPDATED],
+            tags=["alpha"],
+        )
+
+        file_path = server.config.storage.knowledge_path / doc.path
+        await server.watch_intake.upsert_from_disk(file_path)
+
+        event = queue.get_nowait()
+        assert event.type == NOTE_UPDATED
+        assert event.agent == WATCHER_AGENT
+        assert "alpha" in event.tags
+
     async def test_file_delete_emits_note_deleted(self, server: LithosServer) -> None:
         """A file deletion triggers note.deleted event with agent="watcher"."""
         doc = (

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -23,9 +23,11 @@ class TestFileWatcherEventEmission:
         Pins the create-side attribution: an externally-written file that
         is not yet in ``KnowledgeManager._id_to_path`` produces
         ``NOTE_CREATED`` (not ``NOTE_UPDATED``), and the event carries the
-        watcher sentinel. The branch is otherwise only exercised by the
-        telemetry counter test (``TestFileWatcherEventsCounter``), which
-        does not subscribe to the event.
+        watcher sentinel.
+
+        Also pins the canonical payload shape — ``{id, title, path}`` — that
+        ``CorpusIntake.write`` emits, so subscribers (e.g. lithos-loom's
+        ``LithosNoteStream``) can resolve the note from either producer.
         """
         queue = server.event_bus.subscribe(event_types=[NOTE_CREATED])
 
@@ -34,13 +36,23 @@ class TestFileWatcherEventEmission:
 
         await server.watch_intake.upsert_from_disk(new_file)
 
+        expected_id = server.knowledge.get_id_by_path(Path("brand-new-watcher.md"))
+        assert expected_id is not None
+
         event = queue.get_nowait()
         assert event.type == NOTE_CREATED
         assert event.agent == WATCHER_AGENT
+        assert event.payload["id"] == expected_id
+        assert event.payload["title"] == "Brand New Watcher Doc"
         assert event.payload["path"] == "brand-new-watcher.md"
+        assert event.tags == []
 
     async def test_file_modify_emits_note_updated(self, server: LithosServer) -> None:
-        """A file create/modify triggers note.updated event with agent="watcher"."""
+        """A file create/modify triggers note.updated event with agent="watcher".
+
+        Pins the canonical ``{id, title, path}`` payload shape so the watcher
+        emit cannot drift from ``CorpusIntake.write``'s contract again.
+        """
         doc = (
             await server.knowledge.create(
                 title="Watcher Event Doc",
@@ -60,7 +72,37 @@ class TestFileWatcherEventEmission:
         event = queue.get_nowait()
         assert event.type == NOTE_UPDATED
         assert event.agent == WATCHER_AGENT
+        assert event.payload["id"] == doc.id
+        assert event.payload["title"] == doc.title
         assert event.payload["path"] == str(doc.path)
+        assert event.tags == list(doc.metadata.tags)
+
+    async def test_file_modify_propagates_tags_to_event(self, server: LithosServer) -> None:
+        """WatchIntake mirrors CorpusIntake.write by setting event.tags
+        from the document's frontmatter, so tag-filtered EventBus
+        subscribers receive watcher-originated events.
+        """
+        doc = (
+            await server.knowledge.create(
+                title="Tagged Watcher Doc",
+                content="Tagged content for the watcher tag-propagation test.",
+                agent="test-agent",
+                tags=["alpha", "beta"],
+                path="watched",
+            )
+        ).document
+        server.search.index(KnowledgeManager.to_indexable(doc))
+        server.graph.add_document(doc)
+
+        queue = server.event_bus.subscribe(event_types=[NOTE_UPDATED])
+
+        file_path = server.config.storage.knowledge_path / doc.path
+        await server.watch_intake.upsert_from_disk(file_path)
+
+        event = queue.get_nowait()
+        assert event.type == NOTE_UPDATED
+        assert event.agent == WATCHER_AGENT
+        assert set(event.tags) == {"alpha", "beta"}
 
     async def test_file_delete_emits_note_deleted(self, server: LithosServer) -> None:
         """A file deletion triggers note.deleted event with agent="watcher"."""


### PR DESCRIPTION
## Summary

`WatchIntake.upsert_from_disk` (`src/lithos/watch_intake.py:162-172`) was emitting `NOTE_CREATED` / `NOTE_UPDATED` events with payload `{"path": ...}` only, diverging from `CorpusIntake.write` (`src/lithos/intake.py:395-402`) which emits the canonical `{"id", "title", "path"}` payload and sets `tags=list(doc.metadata.tags)` on the event.

Both producers feed the same event type into the same `EventBus`, so subscribers cannot distinguish them at the type level. Downstream impact:

- **lithos-loom's `LithosNoteStream`** matches on `payload["id"]` to resolve the note, so watcher-originated events were silently dropped — meaning external file changes (Obsidian, `mv`, `git checkout`) never reached the loom consumer.
- **Tag-filtered EventBus subscribers** (`event_bus.subscribe(tags=[...])`) drop events whose `event.tags` is empty, so the watcher leg was invisible to any tag-filtered consumer.

Closes #297.

## What changed

`src/lithos/watch_intake.py` — the upsert emit block now mirrors `CorpusIntake.write`:

```python
LithosEvent(
    type=NOTE_CREATED if is_new else NOTE_UPDATED,
    agent=WATCHER_AGENT,
    payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
    tags=list(doc.metadata.tags),
)
```

`doc` is already in scope (return value of `sync_from_disk` at line 154), so this is a zero-cost change — no extra disk read or DB lookup.

`tests/test_file_watcher_events.py`:
- Extended `test_file_create_emits_note_created` to pin `payload["id"]`, `payload["title"]`, and `event.tags`.
- Extended `test_file_modify_emits_note_updated` likewise.
- Added `test_file_modify_propagates_tags_to_event` — creates a doc with `tags=["alpha", "beta"]`, calls `upsert_from_disk`, asserts the emitted event carries those tags.

The pre-existing `test_delete_emits_after_knowledge_delete_completes` already pins `payload["id"]` on the delete path; the delete payload shape is **unchanged** (deliberately omits `title`).

## Precedent in the same file

The fix is purely about restoring consistency with patterns already established in `watch_intake.py`:

| Method | Payload shape today |
|--------|---------------------|
| `delete_from_disk` (line 210-216) | `{"id": doc_id, "path": str(relative_path)}` |
| `rename_on_disk` (line 281-291) | `{"id": doc_id or doc.id, "src_path": ..., "dest_path": ...}` |
| `upsert_from_disk` (this PR) | `{"id": doc.id, "title": doc.title, "path": str(doc.path)}` + `tags` |

## Test plan

- [x] `make check` — green (1195 unit tests, lint, typecheck — exit 0)
- [x] `pytest tests/test_file_watcher_events.py -v` — 12/12 passed in ~43s, including:
  - The 3 extended assertion tests
  - The new `test_file_modify_propagates_tags_to_event` test
- [ ] CI `Lint` green
- [ ] CI `Test` green
- [ ] CI `Integration Test` green