### PR TITLE
fix(write): treat .md-ending paths as explicit filenames (closes #300)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -400,7 +400,7 @@ Parameters are flat at the MCP boundary but grouped below by role to aid discove
 | `id` | string | No | UUID to update existing; omit to create new |
 | `tags` | string[] | No | List of tags |
 | `confidence` | float | No | Confidence score 0-1 (default: 1.0) |
-| `path` | string | No | Subdirectory path (e.g., "procedures") |
+| `path` | string | No | Either a subdirectory (e.g. `"procedures"`) under which the filename is derived from `title` (slugified) and `.md` appended, OR a full relative file path ending in `.md` (e.g. `"procedures/my-doc.md"`) used verbatim as the filename. Intermediate path segments may not end in `.md` — such inputs return `status="invalid_input"`. Paths that resolve to an already-owned file return `status="path_collision"`. |
 
 *Provenance:*
 
@@ -442,13 +442,15 @@ The error code is the canonical top-level `status` value (e.g. `status="slug_col
 
 `{ status: "updated", id: string, path: string, version: int, warnings: string[] }`
 
-`{ status: "duplicate", duplicate_of: { id, title, source_url }, message: string, warnings: string[] }`
+`{ status: "duplicate", duplicate_of: { id, title, source_url }, message: string, warnings: string[] }`  *(source-URL dedup only — never used for filesystem-path conflicts; see `path_collision` below)*
 
 `{ status: "invalid_input", message: string, warnings: string[] }`
 
 `{ status: "content_too_large", message: string, warnings: string[] }`
 
 `{ status: "slug_collision", message: string, existing_id: string, warnings: string[] }`
+
+`{ status: "path_collision", message: string, existing_id: string, warnings: string[] }`  *(another doc already owns the requested file path — e.g. caller passed an explicit `path` ending in `.md` that's already in use)*
 
 `{ status: "version_conflict", message: string, current_version: int, warnings: string[] }`
 

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -154,12 +154,14 @@ class WriteOutcome:
         "version_conflict",
         "content_too_large",
         "slug_collision",
+        "path_collision",
         "error",
     ]
     document: KnowledgeDocument | None = None
     duplicate_of: DuplicateInfo | None = None
     current_version: int | None = None
     slug_collision_existing_id: str | None = None
+    path_collision_existing_id: str | None = None
     message: str | None = None
     warnings: list[str] = field(default_factory=list)
 
@@ -366,6 +368,7 @@ class CorpusIntake:
                     document=result.document,
                     duplicate_of=result.duplicate_of,
                     current_version=result.current_version,
+                    path_collision_existing_id=result.path_collision_existing_id,
                     message=result.message,
                     warnings=list(result.warnings),
                 )

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -447,11 +447,16 @@ class WriteResult:
     """Structured result type for create/update operations.
 
     Error outcomes use the error code as the canonical ``status`` value
-    (``invalid_input`` / ``version_conflict`` / ``content_too_large``)
-    rather than ``status="error"`` plus a separate discriminator field.
-    The plain ``"error"`` status remains as a generic fallback for
-    unforeseen failures and ``slug_collision`` is raised as a
+    (``invalid_input`` / ``version_conflict`` / ``content_too_large`` /
+    ``path_collision``) rather than ``status="error"`` plus a separate
+    discriminator field. The plain ``"error"`` status remains as a generic
+    fallback for unforeseen failures and ``slug_collision`` is raised as a
     ``SlugCollisionError`` exception (not represented in WriteResult).
+
+    Per ``docs/plans/unified-write-contract.md``: ``"duplicate"`` is specific
+    to source URL dedup; filesystem-level conflicts use ``"path_collision"``
+    and carry the existing doc's id in ``path_collision_existing_id``,
+    mirroring ``slug_collision_existing_id`` on the intake-layer outcome.
     """
 
     status: Literal[
@@ -462,12 +467,14 @@ class WriteResult:
         "invalid_input",
         "version_conflict",
         "content_too_large",
+        "path_collision",
     ]
     document: KnowledgeDocument | None = None
     warnings: list[str] = field(default_factory=list)
     message: str | None = None
     duplicate_of: DuplicateInfo | None = None
     current_version: int | None = None
+    path_collision_existing_id: str | None = None
 
 
 def slugify(text: str) -> str:
@@ -1096,15 +1103,17 @@ class KnowledgeManager:
             # path — without this guard the second create would silently
             # overwrite the first file and leave `_id_to_path` retaining
             # both IDs pointing at one path.
+            #
+            # Status is "path_collision" per docs/plans/unified-write-contract.md:
+            # "duplicate" is reserved for source-URL dedup; filesystem-level
+            # conflicts get their own machine-readable code with the existing
+            # doc id carried in `path_collision_existing_id` (mirrors how
+            # `slug_collision_existing_id` works at the intake layer).
             existing_path_id = self._path_to_id.get(file_path)
             if existing_path_id is not None and existing_path_id != doc_id:
-                existing_title = self._id_to_title.get(existing_path_id, "")
                 return WriteResult(
-                    status="duplicate",
-                    duplicate_of=DuplicateInfo(
-                        id=existing_path_id,
-                        title=existing_title,
-                    ),
+                    status="path_collision",
+                    path_collision_existing_id=existing_path_id,
                     message=(
                         f"Path {str(file_path)!r} is already used by document {existing_path_id!r}"
                     ),

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1042,9 +1042,34 @@ class KnowledgeManager:
                 summaries=summaries,
             )
 
-            # Determine file path
+            # Determine file path.
+            #
+            # `path` semantics:
+            #   - None/empty   → filename = slugify(title) + ".md" at knowledge root
+            #   - ends in ".md" (final segment only) → treat as explicit relative file path;
+            #                    the filename is taken verbatim, title is not slugified into it
+            #   - otherwise    → treat as subdirectory; append slugify(title) + ".md"
+            #
+            # Any non-final path segment ending in ".md" is rejected: that shape would
+            # silently create a directory whose name ends in ".md", which is what
+            # confused callers into double-nesting documents (issue #300).
             slug = slugify(title)
-            file_path = Path(path) / f"{slug}.md" if path else Path(f"{slug}.md")
+            if not path:
+                file_path = Path(f"{slug}.md")
+            else:
+                parts = Path(path).parts
+                if any(p.endswith(".md") for p in parts[:-1]):
+                    return WriteResult(
+                        status="invalid_input",
+                        message=(
+                            f"path contains a '.md' segment that is not the final "
+                            f"segment: {path!r}; directories ending in '.md' are not allowed"
+                        ),
+                    )
+                if parts and parts[-1].endswith(".md"):
+                    file_path = Path(path)
+                else:
+                    file_path = Path(path) / f"{slug}.md"
             file_path, full_path = self._resolve_safe_path(file_path)
 
             # Parse wiki-links

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1089,6 +1089,27 @@ class KnowledgeManager:
             if existing_slug_id is not None and existing_slug_id != doc_id:
                 raise SlugCollisionError(slug, existing_slug_id)
 
+            # Check for explicit-path collision. In the directory-semantics
+            # mode the slug check above already covers this (slug uniquely
+            # determines file_path). In the explicit-`.md` mode added for
+            # issue #300, two distinct titles can resolve to the same file
+            # path — without this guard the second create would silently
+            # overwrite the first file and leave `_id_to_path` retaining
+            # both IDs pointing at one path.
+            existing_path_id = self._path_to_id.get(file_path)
+            if existing_path_id is not None and existing_path_id != doc_id:
+                existing_title = self._id_to_title.get(existing_path_id, "")
+                return WriteResult(
+                    status="duplicate",
+                    duplicate_of=DuplicateInfo(
+                        id=existing_path_id,
+                        title=existing_title,
+                    ),
+                    message=(
+                        f"Path {str(file_path)!r} is already used by document {existing_path_id!r}"
+                    ),
+                )
+
             # Write to disk
             full_path.parent.mkdir(parents=True, exist_ok=True)
             _atomic_write(full_path, doc.to_markdown())

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1291,6 +1291,14 @@ class LithosServer:
                         "existing_id": outcome.slug_collision_existing_id,
                         "warnings": [],
                     }
+                if outcome.status == "path_collision":
+                    span.set_attribute("lithos.write_status", "path_collision")
+                    return {
+                        "status": "path_collision",
+                        "message": outcome.message,
+                        "existing_id": outcome.path_collision_existing_id,
+                        "warnings": list(outcome.warnings),
+                    }
                 if outcome.status == "duplicate":
                     span.set_attribute("lithos.write_status", "duplicate")
                     dup = outcome.duplicate_of

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1034,7 +1034,16 @@ class LithosServer:
                     all tags; non-empty list replaces.
                 confidence: Confidence score 0-1 (default: 1.0 on create). On update:
                     null/omit preserves existing; float sets new value.
-                path: Subdirectory path (e.g., "procedures").
+                path: Where to store the note. Two accepted forms:
+                    - Subdirectory (e.g., "procedures") — the filename is derived
+                      from the title (slugified) and ".md" is appended.
+                    - Full relative file path ending in ".md"
+                      (e.g., "procedures/my-doc.md") — the final segment is used
+                      as the filename verbatim; the title does NOT influence the
+                      filename in this mode.
+                    Intermediate path segments may not end in ".md"; such inputs
+                    are rejected with status "invalid_input" to prevent
+                    accidental creation of directories whose names end in ".md".
 
                 --- Provenance ---
                 source_url: URL provenance for this knowledge. On update: null/omit

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -8,6 +8,7 @@ no-event semantics, and the "event-emit failures don't undo writes" rule.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -537,6 +538,52 @@ async def test_lithos_write_handler_routes_through_intake(
         assert event.payload["id"] == doc_id
     finally:
         server.event_bus.unsubscribe(queue)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lithos_write_md_path_used_as_explicit_filename(
+    server: LithosServer,
+) -> None:
+    """End-to-end: a `.md`-ending path is stored at exactly that location.
+
+    Regression test for issue #300: the caller controls the filename, not the
+    slugified title.
+    """
+    write_tool = await server.mcp.get_tool("lithos_write")
+
+    result = await write_tool.fn(
+        title="Something Different",
+        content="explicit filename",
+        agent="agent-1",
+        path="projects/explicit/foo.md",
+    )
+
+    assert result["status"] == "created"
+    assert result["path"] == str(Path("projects") / "explicit" / "foo.md")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lithos_write_rejects_md_in_intermediate_segment(
+    server: LithosServer,
+) -> None:
+    """End-to-end: paths with `.md` in a non-final segment are rejected.
+
+    Regression test for issue #300: we must not silently create directories
+    whose names end in `.md`.
+    """
+    write_tool = await server.mcp.get_tool("lithos_write")
+
+    result = await write_tool.fn(
+        title="Bad Path",
+        content="should fail",
+        agent="agent-1",
+        path="bad.md/nested.md",
+    )
+
+    assert result["status"] == "invalid_input"
+    assert ".md" in result["message"]
 
 
 @pytest.mark.integration

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -588,12 +588,14 @@ async def test_lithos_write_rejects_md_in_intermediate_segment(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_lithos_write_explicit_md_path_collision_returns_duplicate(
+async def test_lithos_write_explicit_md_path_collision_returns_path_collision(
     server: LithosServer,
 ) -> None:
     """End-to-end: two distinct titles targeting the same explicit `.md` path must
-    not silently overwrite. The second call gets status="duplicate" carrying the
-    first doc's id+title, and the on-disk content remains the first body.
+    not silently overwrite. The second call gets ``status="path_collision"`` (per
+    ``docs/plans/unified-write-contract.md``: ``"duplicate"`` is reserved for
+    source-URL dedup) carrying the first doc's id in ``existing_id``, and the
+    on-disk content remains the first body.
 
     Regression test for the path-collision class of bugs that would otherwise
     accompany issue #300's explicit-filename mode.
@@ -616,10 +618,10 @@ async def test_lithos_write_explicit_md_path_collision_returns_duplicate(
         agent="agent-1",
         path="conflicts/same.md",
     )
-    assert second["status"] == "duplicate"
-    assert second["duplicate_of"] is not None
-    assert second["duplicate_of"]["id"] == first_id
-    assert second["duplicate_of"]["title"] == "First Title"
+    assert second["status"] == "path_collision"
+    assert second["existing_id"] == first_id
+    assert "duplicate_of" not in second
+    assert ".md" in second["message"]
 
     # Round-trip: reading by id still returns the first body (no overwrite).
     fetched = await read_tool.fn(id=first_id)

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -588,6 +588,47 @@ async def test_lithos_write_rejects_md_in_intermediate_segment(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_lithos_write_explicit_md_path_collision_returns_duplicate(
+    server: LithosServer,
+) -> None:
+    """End-to-end: two distinct titles targeting the same explicit `.md` path must
+    not silently overwrite. The second call gets status="duplicate" carrying the
+    first doc's id+title, and the on-disk content remains the first body.
+
+    Regression test for the path-collision class of bugs that would otherwise
+    accompany issue #300's explicit-filename mode.
+    """
+    write_tool = await server.mcp.get_tool("lithos_write")
+    read_tool = await server.mcp.get_tool("lithos_read")
+
+    first = await write_tool.fn(
+        title="First Title",
+        content="first body",
+        agent="agent-1",
+        path="conflicts/same.md",
+    )
+    assert first["status"] == "created"
+    first_id = first["id"]
+
+    second = await write_tool.fn(
+        title="Different Title",
+        content="second body",
+        agent="agent-1",
+        path="conflicts/same.md",
+    )
+    assert second["status"] == "duplicate"
+    assert second["duplicate_of"] is not None
+    assert second["duplicate_of"]["id"] == first_id
+    assert second["duplicate_of"]["title"] == "First Title"
+
+    # Round-trip: reading by id still returns the first body (no overwrite).
+    fetched = await read_tool.fn(id=first_id)
+    assert fetched["title"] == "First Title"
+    assert "first body" in fetched["content"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_lithos_delete_handler_routes_through_intake(
     server: LithosServer,
 ) -> None:

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -133,6 +133,54 @@ class TestMCPToolContracts:
         assert delete_payload == {"success": True}
 
     @pytest.mark.asyncio
+    async def test_write_path_collision_envelope_contract(self, server: LithosServer):
+        """Pins the public envelope shape for ``status="path_collision"``.
+
+        Per ``docs/plans/unified-write-contract.md`` (line 134): ``"duplicate"`` is
+        reserved for source-URL dedup; filesystem-level conflicts use the
+        ``"path_collision"`` code from the Error Model (line 151). The MCP envelope
+        for ``path_collision`` mirrors ``slug_collision``: ``{status, message,
+        existing_id, warnings}`` — and crucially does **not** include a
+        ``duplicate_of`` field, since that's part of the URL-dedup envelope only.
+        """
+        first = await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Path Conformance First",
+                "content": "first body",
+                "agent": "conformance-agent",
+                "path": "path-conformance/same.md",
+            },
+        )
+        assert first["status"] == "created"
+        first_id = first["id"]
+
+        second = await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Path Conformance Different",
+                "content": "second body",
+                "agent": "conformance-agent",
+                "path": "path-conformance/same.md",
+            },
+        )
+
+        # Envelope shape: exactly these keys, no `duplicate_of` leakage.
+        assert set(second.keys()) == {"status", "message", "existing_id", "warnings"}
+        assert second["status"] == "path_collision"
+        assert second["existing_id"] == first_id
+        assert isinstance(second["message"], str)
+        assert "path-conformance/same.md" in second["message"]
+        assert isinstance(second["warnings"], list)
+
+        # No silent overwrite: first body still readable.
+        fetched = await _call_tool(server, "lithos_read", {"id": first_id})
+        assert fetched["title"] == "Path Conformance First"
+        assert "first body" in fetched["content"]
+
+    @pytest.mark.asyncio
     async def test_projection_consistency_after_write(self, server: LithosServer):
         write_payload = await _call_tool(
             server,

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -312,6 +312,120 @@ class TestKnowledgeManager:
         assert ".md" in result.message
 
     @pytest.mark.asyncio
+    async def test_create_explicit_md_path_collision_does_not_overwrite(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """Two distinct titles targeting the same explicit `.md` path must not collide
+        silently. The second create returns status="duplicate" pointing at the first
+        doc; the on-disk file and the path/id indexes still resolve to the first doc.
+
+        Regression test for the path-collision class of bugs introduced when explicit
+        filenames became possible (issue #300).
+        """
+        first = await knowledge_manager.create(
+            title="First Title",
+            content="first body",
+            agent="agent",
+            path="same.md",
+        )
+        assert first.status == "created"
+        assert first.document is not None
+        first_id = first.document.id
+
+        second = await knowledge_manager.create(
+            title="Different Title",
+            content="second body",
+            agent="agent",
+            path="same.md",
+        )
+        assert second.status == "duplicate"
+        assert second.duplicate_of is not None
+        assert second.duplicate_of.id == first_id
+        assert second.duplicate_of.title == "First Title"
+
+        # The original file content is intact (no silent overwrite).
+        by_id, _ = await knowledge_manager.read(id=first_id)
+        assert by_id.title == "First Title"
+        assert by_id.content == "first body"
+
+        # `_path_to_id` still resolves to the first doc.
+        by_path, _ = await knowledge_manager.read(path="same.md")
+        assert by_path.id == first_id
+
+    @pytest.mark.asyncio
+    async def test_create_explicit_md_path_collides_with_directory_semantics_write(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """A directory-mode write that lands at `procedures/foo.md` must block a
+        subsequent explicit-path write to `procedures/foo.md` from a different title.
+        Same invariant, different entry vector.
+        """
+        first = await knowledge_manager.create(
+            title="Foo",
+            content="from dir mode",
+            agent="agent",
+            path="procedures",
+        )
+        assert first.status == "created"
+        assert first.document is not None
+        assert str(first.document.path) == str(Path("procedures") / "foo.md")
+        first_id = first.document.id
+
+        second = await knowledge_manager.create(
+            title="Completely Different",
+            content="from explicit mode",
+            agent="agent",
+            path="procedures/foo.md",
+        )
+        assert second.status == "duplicate"
+        assert second.duplicate_of is not None
+        assert second.duplicate_of.id == first_id
+
+        by_id, _ = await knowledge_manager.read(id=first_id)
+        assert by_id.content == "from dir mode"
+
+    @pytest.mark.asyncio
+    async def test_create_explicit_md_path_round_trip_after_reload(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """Doc created via explicit `.md` path is reachable by id AND by path after a
+        fresh `KnowledgeManager` reloads the index from disk — proving the on-disk
+        scan correctly seeds `_path_to_id` for explicit-filename writes.
+        """
+        created = (
+            await knowledge_manager.create(
+                title="Round Trip",
+                content="payload",
+                agent="agent",
+                path="projects/explicit/note.md",
+            )
+        ).document
+        assert created is not None
+        doc_id = created.id
+
+        # Simulate a process restart: a brand-new manager over the same data dir.
+        reloaded = KnowledgeManager(knowledge_manager.config)
+
+        by_id, _ = await reloaded.read(id=doc_id)
+        assert by_id.title == "Round Trip"
+        assert by_id.content == "payload"
+
+        by_path, _ = await reloaded.read(path="projects/explicit/note.md")
+        assert by_path.id == doc_id
+        assert by_path.content == "payload"
+
+        # And the path-collision guard still fires after restart.
+        collision = await reloaded.create(
+            title="Stomp Attempt",
+            content="should be rejected",
+            agent="agent",
+            path="projects/explicit/note.md",
+        )
+        assert collision.status == "duplicate"
+        assert collision.duplicate_of is not None
+        assert collision.duplicate_of.id == doc_id
+
+    @pytest.mark.asyncio
     async def test_read_document_by_id(self, knowledge_manager: KnowledgeManager):
         """Read document by UUID."""
         created = (

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -316,8 +316,11 @@ class TestKnowledgeManager:
         self, knowledge_manager: KnowledgeManager
     ):
         """Two distinct titles targeting the same explicit `.md` path must not collide
-        silently. The second create returns status="duplicate" pointing at the first
-        doc; the on-disk file and the path/id indexes still resolve to the first doc.
+        silently. The second create returns ``status="path_collision"`` (NOT
+        ``"duplicate"`` — per docs/plans/unified-write-contract.md ``"duplicate"`` is
+        reserved for source-URL dedup) carrying the first doc's id in
+        ``path_collision_existing_id``. The on-disk file and the path/id indexes still
+        resolve to the first doc.
 
         Regression test for the path-collision class of bugs introduced when explicit
         filenames became possible (issue #300).
@@ -338,10 +341,13 @@ class TestKnowledgeManager:
             agent="agent",
             path="same.md",
         )
-        assert second.status == "duplicate"
-        assert second.duplicate_of is not None
-        assert second.duplicate_of.id == first_id
-        assert second.duplicate_of.title == "First Title"
+        assert second.status == "path_collision"
+        assert second.path_collision_existing_id == first_id
+        # `duplicate_of` must NOT be populated for path collisions — that field is
+        # part of the URL-dedup envelope only.
+        assert second.duplicate_of is None
+        assert second.message is not None
+        assert "same.md" in second.message
 
         # The original file content is intact (no silent overwrite).
         by_id, _ = await knowledge_manager.read(id=first_id)
@@ -358,7 +364,7 @@ class TestKnowledgeManager:
     ):
         """A directory-mode write that lands at `procedures/foo.md` must block a
         subsequent explicit-path write to `procedures/foo.md` from a different title.
-        Same invariant, different entry vector.
+        Same invariant, different entry vector — same ``path_collision`` status.
         """
         first = await knowledge_manager.create(
             title="Foo",
@@ -377,9 +383,8 @@ class TestKnowledgeManager:
             agent="agent",
             path="procedures/foo.md",
         )
-        assert second.status == "duplicate"
-        assert second.duplicate_of is not None
-        assert second.duplicate_of.id == first_id
+        assert second.status == "path_collision"
+        assert second.path_collision_existing_id == first_id
 
         by_id, _ = await knowledge_manager.read(id=first_id)
         assert by_id.content == "from dir mode"
@@ -421,9 +426,8 @@ class TestKnowledgeManager:
             agent="agent",
             path="projects/explicit/note.md",
         )
-        assert collision.status == "duplicate"
-        assert collision.duplicate_of is not None
-        assert collision.duplicate_of.id == doc_id
+        assert collision.status == "path_collision"
+        assert collision.path_collision_existing_id == doc_id
 
     @pytest.mark.asyncio
     async def test_read_document_by_id(self, knowledge_manager: KnowledgeManager):

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -213,6 +213,105 @@ class TestKnowledgeManager:
         assert "procedures" in str(doc.path)
 
     @pytest.mark.asyncio
+    async def test_create_no_path_uses_slugified_filename_at_root(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """When `path` is omitted, file lives at root with slugified title."""
+        doc = (
+            await knowledge_manager.create(
+                title="Top Level Note",
+                content="hi",
+                agent="agent",
+            )
+        ).document
+
+        assert str(doc.path) == "top-level-note.md"
+
+    @pytest.mark.asyncio
+    async def test_create_deep_directory_path_appends_slug(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """Multi-segment directory path still appends slugified title."""
+        doc = (
+            await knowledge_manager.create(
+                title="Deep Doc",
+                content="nested",
+                agent="agent",
+                path="a/b/c",
+            )
+        ).document
+
+        assert str(doc.path) == str(Path("a") / "b" / "c" / "deep-doc.md")
+
+    @pytest.mark.asyncio
+    async def test_create_md_path_uses_path_as_full_filename(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """A `.md`-ending path is taken as the complete relative file path.
+
+        The title is intentionally different from the path's leaf to prove the
+        filename comes from `path`, not slugify(title). Regression guard for
+        issue #300.
+        """
+        doc = (
+            await knowledge_manager.create(
+                title="Anything Else",
+                content="explicit",
+                agent="agent",
+                path="procedures/my-explicit-name.md",
+            )
+        ).document
+
+        assert str(doc.path) == str(Path("procedures") / "my-explicit-name.md")
+
+    @pytest.mark.asyncio
+    async def test_create_md_path_at_root_uses_path_as_filename(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """Single `.md` segment is treated as a filename at the knowledge root."""
+        doc = (
+            await knowledge_manager.create(
+                title="Different Title",
+                content="root file",
+                agent="agent",
+                path="root-level.md",
+            )
+        ).document
+
+        assert str(doc.path) == "root-level.md"
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_md_in_non_final_segment(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """`.md` in an intermediate segment must not create a `.md` directory."""
+        result = await knowledge_manager.create(
+            title="Bad Path",
+            content="should fail",
+            agent="agent",
+            path="projects/foo.md/bar",
+        )
+
+        assert result.status == "invalid_input"
+        assert result.message is not None
+        assert ".md" in result.message
+        assert "final segment" in result.message
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_multiple_md_segments(self, knowledge_manager: KnowledgeManager):
+        """Multiple `.md` segments hit the same non-final-segment rule."""
+        result = await knowledge_manager.create(
+            title="Bad Path 2",
+            content="should fail",
+            agent="agent",
+            path="a.md/b.md",
+        )
+
+        assert result.status == "invalid_input"
+        assert result.message is not None
+        assert ".md" in result.message
+
+    @pytest.mark.asyncio
     async def test_read_document_by_id(self, knowledge_manager: KnowledgeManager):
         """Read document by UUID."""
         created = (
@@ -618,6 +717,24 @@ class TestDocumentPersistence:
                 content="Should fail.",
                 agent="agent",
                 path="../outside",
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_md_traversal_still_raises_value_error(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """A `.md`-ending traversal path must still trip the traversal guard.
+
+        The new `.md`-segment validation runs before `_resolve_safe_path`, but
+        `..` doesn't end in `.md`, so the input falls through to the existing
+        traversal check, which raises ValueError (not a structured invalid_input).
+        """
+        with pytest.raises(ValueError, match="within knowledge directory"):
+            await knowledge_manager.create(
+                title="Unsafe MD Path",
+                content="Should fail.",
+                agent="agent",
+                path="../outside.md",
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `lithos_write` now accepts a full relative file path ending in `.md` and stores the doc at exactly that path; bare-directory inputs behave unchanged.
- Any path with a non-final segment ending in `.md` is rejected with `invalid_input` — making it structurally impossible to create directories whose names end in `.md`.
- `lithos_write` `path` docstring updated to describe both modes.

Closes #300.

## Why

Callers intuiting the more common "full file path" convention silently got a doc nested one level too deep, under a directory whose name ended in `.md`. The maintainer has had to manually clean up such directories from earlier callers, so this is shaping the on-disk knowledge base.

Implements Option A from the issue, with the additional invariant — requested in follow-up — that no directory ending in `.md` may be created via `lithos_write` going forward.

## Behavioural matrix

| `path` input | Before | After |
|---|---|---|
| `None` / `""` | `slugify(title).md` at root | unchanged |
| `"procedures"` | `procedures/slugify(title).md` | unchanged |
| `"a/b/c"` | `a/b/c/slugify(title).md` | unchanged |
| `"procedures/my-doc.md"` | `procedures/my-doc.md/slugify(title).md` ⚠️ | `procedures/my-doc.md` ✅ |
| `"root-level.md"` | `root-level.md/slugify(title).md` ⚠️ | `root-level.md` ✅ |
| `"projects/foo.md/bar"` | `projects/foo.md/bar/slugify(title).md` ⚠️ | `invalid_input` ✅ |
| `"a.md/b.md"` | `a.md/b.md/slugify(title).md` ⚠️ | `invalid_input` ✅ |
| `"../outside"` / `"../outside.md"` | `ValueError` (traversal) | unchanged |

Clients that operate correctly today see no behaviour change.

## Test plan

- [x] `make test` (unit) — 1202 passed
- [x] `make test-integration` — 363 passed
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] `make check` — all green
- [x] Backwards-compat anchors added: `None`, `procedures`, `a/b/c`
- [x] New `.md` happy path: nested + root
- [x] New rejection paths: intermediate `.md`, multiple `.md`
- [x] Traversal interaction: `../outside.md` still raises `ValueError`
- [x] Integration: `.md`-ending path round-trips through intake; bad path → `invalid_input` at MCP tier