### PR TITLE
feat(write): add writable document metadata param (closes #305)

### DIFF
--- a/docs/plans/unified-write-contract.md
+++ b/docs/plans/unified-write-contract.md
@@ -32,6 +32,7 @@ Required update fields:
 Optional shared fields (create/update as applicable):
 
 - Core: `tags`, `confidence`, `path`, `source_task`
+- Free-form metadata: `metadata` (key/value dict persisted to frontmatter via `KnowledgeMetadata.extra`)
 - Provenance and dedup: `source_url`, `derived_from_ids`
 - Freshness: `ttl_hours`, `expires_at`
 - LCMA metadata: `note_type`, `namespace`, `access_scope`, `entities`, `status`, `schema_version`
@@ -66,6 +67,15 @@ Update requests must distinguish omitted values from explicit clears.
 - `expires_at`: parse and store as UTC instant
 - omitted: preserve existing `expires_at` on update
 - explicit `expires_at: null`: clear expiry
+
+`metadata` (free-form key/value, #305):
+
+- omitted / `null`: preserve existing metadata
+- `{}`: clear all metadata
+- non-empty dict: additive per-key merge into existing metadata. A key whose
+  value is `null` deletes that key; other keys are set; absent keys are
+  preserved. This mirrors task metadata merge semantics (shared
+  `lithos._merge.merge_metadata`).
 
 Other optional fields follow standard patch semantics:
 
@@ -111,6 +121,25 @@ Authority rule:
 - Enums must be validated (`note_type`, `access_scope`, `status`).
 - Defaults applied when absent.
 - Before LCMA metadata support ships, these fields may be rejected as `invalid_input`/`unsupported_feature`.
+
+### Free-form Metadata (#305)
+
+- `metadata` must be an object with string keys; non-dict input or non-string
+  keys are rejected as `invalid_input`.
+- Keys must not collide with reserved frontmatter fields
+  (`KnowledgeMetadata` known keys such as `title`, `tags`, `version`,
+  `source_url`, …). Colliding keys would be silently dropped by frontmatter
+  serialization, so they are rejected as `invalid_input` instead.
+- Persisted into `KnowledgeMetadata.extra`, which serializes as **top-level**
+  frontmatter keys (Obsidian-compatible) and round-trips on read.
+- `expected_version` optimistic locking applies to metadata writes unchanged.
+
+## Read and List Return Shapes
+
+- `lithos_read` returns the free-form metadata as an isolated dict under
+  `metadata.extra`, alongside the full frontmatter `metadata` envelope.
+- `lithos_list` includes the free-form metadata dict on each item under the
+  `metadata` key.
 
 ## Canonical Write Outcome Envelope
 
@@ -221,7 +250,7 @@ Phase 8 is scoped to **option 2**. Rationale:
 The canonical taxonomy used in docs and the `lithos_write` docstring is:
 
 - **Core (required):** `title`, `content`, `agent`
-- **Identity & metadata:** `id`, `tags`, `confidence`, `path`
+- **Identity & metadata:** `id`, `tags`, `metadata`, `confidence`, `path`
 - **Provenance:** `source_url`, `derived_from_ids`, `source_task`
 - **Freshness:** `ttl_hours`, `expires_at`
 - **Concurrency:** `expected_version`, and the batch-only `if_match_updated_at` / `if_match_hash`

--- a/src/lithos/_merge.py
+++ b/src/lithos/_merge.py
@@ -1,0 +1,30 @@
+"""Shared pure helpers for additive metadata merges.
+
+Both task coordination (#290) and document metadata (#305) need the same
+read-merge-write semantics for free-form key/value dicts. Keeping the merge
+in one place guarantees tasks and notes behave identically.
+"""
+
+from typing import Any
+
+
+def merge_metadata(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    """Apply an additive per-key patch to a metadata dict.
+
+    Keys in ``patch`` whose value is ``None`` are removed from the result
+    (silently if absent). Keys with any other value overwrite the existing
+    entry. Keys present in ``existing`` but absent from ``patch`` are
+    preserved. ``patch == {}`` is a no-op that returns a fresh copy of
+    ``existing``.
+
+    Pure: returns a new dict; neither argument is mutated. Callers relying
+    on a multi-writer guarantee (#290) must invoke this inside an atomic
+    read-merge-write section so the cycle cannot interleave.
+    """
+    merged = dict(existing)
+    for key, value in patch.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    return merged

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 
 import aiosqlite
 
+from lithos._merge import merge_metadata
 from lithos.config import LithosConfig, get_config
 from lithos.telemetry import lithos_metrics, traced
 
@@ -244,28 +245,6 @@ def _decode_metadata(raw: Any) -> dict[str, Any]:
         )
         return {}
     return decoded
-
-
-def _merge_metadata(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
-    """Apply an additive per-key patch to a metadata dict.
-
-    Keys in ``patch`` whose value is ``None`` are removed from the result
-    (silently if absent). Keys with any other value overwrite the existing
-    entry. Keys present in ``existing`` but absent from ``patch`` are
-    preserved. ``patch == {}`` is a no-op that returns a fresh copy of
-    ``existing``.
-
-    Pure: returns a new dict; neither argument is mutated. The
-    multi-writer guarantee in #290 depends on this being called inside a
-    BEGIN IMMEDIATE transaction so the read-merge-write cycle is atomic.
-    """
-    merged = dict(existing)
-    for key, value in patch.items():
-        if value is None:
-            merged.pop(key, None)
-        else:
-            merged[key] = value
-    return merged
 
 
 class CoordinationService:
@@ -810,7 +789,7 @@ class CoordinationService:
                     return False
 
                 existing = _decode_metadata(row[0])
-                merged = _merge_metadata(existing, metadata_patch)
+                merged = merge_metadata(existing, metadata_patch)
                 merged_json = json.dumps(merged)
 
                 sets = [*non_metadata_sets, "metadata = ?"]

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -102,6 +102,7 @@ class WriteRequest:
     note_type: str | None | _UnsetType = _UNSET
     lcma_status: str | None | _UnsetType = _UNSET
     summaries: dict | None | _UnsetType = _UNSET
+    metadata: dict | _UnsetType = _UNSET
 
 
 @dataclass(frozen=True)
@@ -308,6 +309,9 @@ class CorpusIntake:
                     create_summaries = (
                         None if isinstance(request.summaries, _UnsetType) else request.summaries
                     )
+                    create_metadata = (
+                        None if isinstance(request.metadata, _UnsetType) else request.metadata
+                    )
                     result = await self._knowledge.create(
                         title=request.title,
                         content=request.content,
@@ -325,6 +329,7 @@ class CorpusIntake:
                         note_type=create_note,
                         lcma_status=create_status,
                         summaries=create_summaries,
+                        extra=create_metadata,
                     )
                 else:
                     result = await self._knowledge.update(
@@ -345,6 +350,7 @@ class CorpusIntake:
                         note_type=request.note_type,
                         lcma_status=request.lcma_status,
                         summaries=request.summaries,
+                        extra=request.metadata,
                     )
             except SlugCollisionError as exc:
                 logger.info(

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import frontmatter
 
+from lithos._merge import merge_metadata
 from lithos.config import LithosConfig
 from lithos.errors import SlugCollisionError
 from lithos.telemetry import lithos_metrics, timed_write, traced
@@ -971,8 +972,12 @@ class KnowledgeManager:
         note_type: str | None = None,
         lcma_status: str | None = None,
         summaries: dict | None = None,
+        extra: dict | None = None,
     ) -> WriteResult:
         """Create a new knowledge document.
+
+        ``extra`` is free-form key/value metadata persisted into the
+        document's frontmatter via ``KnowledgeMetadata.extra`` (#305).
 
         Returns WriteResult with status 'created', 'duplicate', or 'error'.
         """
@@ -1047,6 +1052,7 @@ class KnowledgeManager:
                 note_type=note_type if note_type is not None else "observation",
                 status=lcma_status if lcma_status is not None else "active",
                 summaries=summaries,
+                extra=dict(extra) if extra else {},
             )
 
             # Determine file path.
@@ -1296,6 +1302,7 @@ class KnowledgeManager:
         summaries: dict | None | _UnsetType = _UNSET,
         supersedes: str | None | _UnsetType = _UNSET,
         entities: list[str] | None | _UnsetType = _UNSET,
+        extra: dict | _UnsetType = _UNSET,
     ) -> WriteResult:
         """Update an existing document.
 
@@ -1322,6 +1329,12 @@ class KnowledgeManager:
         - _UNSET (default): preserve existing expires_at
         - None: clear existing expires_at
         - datetime: set new value
+
+        extra semantics (#305) — free-form key/value metadata:
+        - _UNSET (default): preserve existing metadata
+        - {}: clear all metadata
+        - non-empty dict: additive per-key merge (a key whose value is None
+          deletes that key; other keys are set; absent keys are preserved)
 
         Note: version is incremented on every call, even when no fields actually change.
         This is intentional — simplicity over precision. Callers should not rely on
@@ -1506,6 +1519,12 @@ class KnowledgeManager:
                 doc.metadata.summaries = summaries
             if not isinstance(entities, _UnsetType):
                 doc.metadata.entities = entities if entities is not None else []
+            if not isinstance(extra, _UnsetType):
+                # {} clears all metadata; a non-empty dict is an additive
+                # per-key merge into the existing extra (mirrors task metadata).
+                doc.metadata.extra = (
+                    {} if extra == {} else merge_metadata(doc.metadata.extra, extra)
+                )
 
             # Update fields
             if content is not None:

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -119,6 +119,32 @@ _KNOWN_METADATA_KEYS = frozenset(
     }
 )
 
+
+def validate_extra_metadata(extra: dict) -> None:
+    """Validate free-form document metadata before it is stored in ``extra`` (#305).
+
+    The ``extra`` dict serializes as top-level frontmatter keys, and
+    ``KnowledgeMetadata.to_dict`` lets known keys win on collision. A key that
+    shadows a reserved field would therefore be silently dropped on the next
+    write. Enforcing this in the storage layer keeps the invariant true for
+    every caller, not just the MCP boundary.
+
+    Raises:
+        ValueError: if ``extra`` is not a dict, has non-string keys, or uses a
+            key reserved by known frontmatter fields.
+    """
+    if not isinstance(extra, dict):
+        raise ValueError("metadata must be an object of string keys.")
+    if any(not isinstance(k, str) for k in extra):
+        raise ValueError("metadata keys must be strings.")
+    reserved = sorted(set(extra) & _KNOWN_METADATA_KEYS)
+    if reserved:
+        raise ValueError(
+            f"metadata keys collide with reserved frontmatter fields: {reserved}. "
+            "Choose different keys."
+        )
+
+
 # Valid LCMA enum values
 VALID_ACCESS_SCOPES = frozenset({"shared", "task", "agent_private"})
 VALID_NOTE_TYPES = frozenset(
@@ -1030,6 +1056,13 @@ class KnowledgeManager:
                         message=str(e),
                     )
 
+            # Guard free-form metadata against reserved-key collisions (#305).
+            if extra:
+                try:
+                    validate_extra_metadata(extra)
+                except ValueError as e:
+                    return WriteResult(status="invalid_input", message=str(e))
+
             doc_id = str(uuid.uuid4())
             now = datetime.now(timezone.utc)
 
@@ -1343,6 +1376,14 @@ class KnowledgeManager:
         async with self._write_lock:
             lithos_metrics.knowledge_ops.add(1, {"op": "update"})
             doc, _ = await self.read(id=id)
+
+            # Guard free-form metadata against reserved-key collisions (#305).
+            # {} (clear) has no keys to check; _UNSET means preserve.
+            if not isinstance(extra, _UnsetType) and extra:
+                try:
+                    validate_extra_metadata(extra)
+                except ValueError as e:
+                    return WriteResult(status="invalid_input", message=str(e))
 
             # Validate task-scope invariant under the write lock so the
             # source-existence check is atomic with the write. See

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -37,7 +37,6 @@ from lithos.events import (
 from lithos.graph import KnowledgeGraph
 from lithos.intake import CorpusIntake, DeleteRequest, WriteRequest
 from lithos.knowledge import (
-    _KNOWN_METADATA_KEYS,
     _UNSET,
     VALID_ACCESS_SCOPES,
     VALID_NOTE_TYPES,
@@ -45,6 +44,7 @@ from lithos.knowledge import (
     KnowledgeManager,
     _normalize_datetime,
     _UnsetType,
+    validate_extra_metadata,
 )
 from lithos.provenance import ProvenanceProjection
 from lithos.search import Healthy, SearchEngine
@@ -1165,30 +1165,16 @@ class LithosServer:
                                 "warnings": [],
                             }
 
-                # Validate metadata shape. metadata persists into the document's
-                # frontmatter via KnowledgeMetadata.extra; reject non-dict inputs,
-                # non-string keys, and keys that would collide with (and be
-                # silently dropped by) reserved frontmatter fields.
+                # Validate metadata shape at the boundary for a fast, clean
+                # envelope. The same rule is enforced in the storage layer
+                # (KnowledgeManager) so the invariant holds for every caller.
                 if metadata is not None:
-                    if not isinstance(metadata, dict):
+                    try:
+                        validate_extra_metadata(metadata)
+                    except ValueError as e:
                         return {
                             "status": "invalid_input",
-                            "message": "metadata must be an object of string keys.",
-                            "warnings": [],
-                        }
-                    non_string_keys = [k for k in metadata if not isinstance(k, str)]
-                    if non_string_keys:
-                        return {
-                            "status": "invalid_input",
-                            "message": "metadata keys must be strings.",
-                            "warnings": [],
-                        }
-                    reserved = sorted(set(metadata.keys()) & _KNOWN_METADATA_KEYS)
-                    if reserved:
-                        return {
-                            "status": "invalid_input",
-                            "message": f"metadata keys collide with reserved "
-                            f"frontmatter fields: {reserved}. Choose different keys.",
+                            "message": str(e),
                             "warnings": [],
                         }
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -37,6 +37,7 @@ from lithos.events import (
 from lithos.graph import KnowledgeGraph
 from lithos.intake import CorpusIntake, DeleteRequest, WriteRequest
 from lithos.knowledge import (
+    _KNOWN_METADATA_KEYS,
     _UNSET,
     VALID_ACCESS_SCOPES,
     VALID_NOTE_TYPES,
@@ -1015,6 +1016,7 @@ class LithosServer:
             note_type: str | None = None,
             status: str | None = None,
             summaries: dict | None = None,
+            metadata: dict | None = None,
         ) -> dict[str, Any]:
             """Create or update a knowledge file.
 
@@ -1032,6 +1034,12 @@ class LithosServer:
                 id: UUID to update existing; omit to create new.
                 tags: List of tags. On update: null/omit preserves existing; [] clears
                     all tags; non-empty list replaces.
+                metadata: Free-form key/value dict persisted into the document's
+                    frontmatter. On update: null/omit preserves existing; {} clears
+                    all metadata; a non-empty dict is an additive per-key merge (a
+                    key whose value is null deletes it). Keys must be strings and
+                    must not collide with reserved frontmatter fields (e.g. title,
+                    tags, version) — such writes are rejected as invalid_input.
                 confidence: Confidence score 0-1 (default: 1.0 on create). On update:
                     null/omit preserves existing; float sets new value.
                 path: Where to store the note. Two accepted forms:
@@ -1157,6 +1165,33 @@ class LithosServer:
                                 "warnings": [],
                             }
 
+                # Validate metadata shape. metadata persists into the document's
+                # frontmatter via KnowledgeMetadata.extra; reject non-dict inputs,
+                # non-string keys, and keys that would collide with (and be
+                # silently dropped by) reserved frontmatter fields.
+                if metadata is not None:
+                    if not isinstance(metadata, dict):
+                        return {
+                            "status": "invalid_input",
+                            "message": "metadata must be an object of string keys.",
+                            "warnings": [],
+                        }
+                    non_string_keys = [k for k in metadata if not isinstance(k, str)]
+                    if non_string_keys:
+                        return {
+                            "status": "invalid_input",
+                            "message": "metadata keys must be strings.",
+                            "warnings": [],
+                        }
+                    reserved = sorted(set(metadata.keys()) & _KNOWN_METADATA_KEYS)
+                    if reserved:
+                        return {
+                            "status": "invalid_input",
+                            "message": f"metadata keys collide with reserved "
+                            f"frontmatter fields: {reserved}. Choose different keys.",
+                            "warnings": [],
+                        }
+
                 # Validate task-scope create-time invariant. The update-time
                 # case is enforced under ``_write_lock`` inside
                 # ``KnowledgeManager.update`` to avoid the TOCTOU window
@@ -1246,6 +1281,7 @@ class LithosServer:
                     nt_arg: str | None | _UnsetType = _UNSET if note_type is None else note_type
                     st_arg: str | None | _UnsetType = _UNSET if status is None else status
                     sum_arg: dict | None | _UnsetType = _UNSET if summaries is None else summaries
+                    meta_arg: dict | _UnsetType = _UNSET if metadata is None else metadata
                 else:
                     # Create path forwards raw values; KnowledgeManager.create
                     # applies its own defaults.
@@ -1260,6 +1296,7 @@ class LithosServer:
                     nt_arg = note_type
                     st_arg = status
                     sum_arg = summaries
+                    meta_arg = metadata if metadata is not None else _UNSET
 
                 request = WriteRequest(
                     title=title,
@@ -1279,6 +1316,7 @@ class LithosServer:
                     note_type=nt_arg,
                     lcma_status=st_arg,
                     summaries=sum_arg,
+                    metadata=meta_arg,
                 )
 
                 outcome = await self.intake.write(agent, request)
@@ -1407,6 +1445,10 @@ class LithosServer:
                 meta = doc.metadata.to_dict()
                 meta["source_url"] = doc.metadata.source_url  # null when None
                 meta.setdefault("derived_from_ids", [])
+                # Free-form key/value metadata (#305) as an isolated dict, so
+                # callers can read back exactly what they wrote via the
+                # lithos_write `metadata` param without sifting reserved fields.
+                meta["extra"] = dict(doc.metadata.extra)
                 return {
                     "id": doc.id,
                     "title": doc.title,
@@ -2017,6 +2059,7 @@ class LithosServer:
                             "tags": d.metadata.tags,
                             "source_url": d.metadata.source_url or "",
                             "derived_from_ids": self.knowledge.get_doc_sources(d.id),
+                            "metadata": dict(d.metadata.extra),
                         }
                         for d in docs
                     ],

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1576,41 +1576,41 @@ class TestTaskMetadata:
 
 
 class TestMergeMetadataHelper:
-    """Tests for the module-level _merge_metadata pure helper (#290)."""
+    """Tests for the shared merge_metadata pure helper (#290, #305)."""
 
     def test_empty_patch_returns_copy_of_existing(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
         existing = {"a": 1, "b": 2}
-        result = _merge_metadata(existing, {})
+        result = merge_metadata(existing, {})
         assert result == {"a": 1, "b": 2}
         # Pure function: must not mutate inputs and must return a new dict.
         assert result is not existing
 
     def test_set_new_key(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
-        assert _merge_metadata({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+        assert merge_metadata({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
 
     def test_overwrite_existing_key(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
-        assert _merge_metadata({"a": 1, "b": 2}, {"a": 99}) == {"a": 99, "b": 2}
+        assert merge_metadata({"a": 1, "b": 2}, {"a": 99}) == {"a": 99, "b": 2}
 
     def test_null_deletes_key(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
-        assert _merge_metadata({"a": 1, "b": 2}, {"a": None}) == {"b": 2}
+        assert merge_metadata({"a": 1, "b": 2}, {"a": None}) == {"b": 2}
 
     def test_null_for_absent_key_is_silent_noop(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
-        assert _merge_metadata({"a": 1}, {"absent": None}) == {"a": 1}
+        assert merge_metadata({"a": 1}, {"absent": None}) == {"a": 1}
 
     def test_combined_set_and_delete(self):
-        from lithos.coordination import _merge_metadata
+        from lithos._merge import merge_metadata
 
-        assert _merge_metadata({"a": 1, "b": 2}, {"a": None, "c": 3}) == {"b": 2, "c": 3}
+        assert merge_metadata({"a": 1, "b": 2}, {"a": None, "c": 3}) == {"b": 2, "c": 3}
 
 
 class TestTaskUpdateMetadataMerge:

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -717,6 +717,69 @@ class TestUpdateSemantics:
         read_after = await _call_tool(server, "lithos_read", {"id": doc_id})
         assert read_after["metadata"]["confidence"] == 0.5
 
+    @pytest.mark.asyncio
+    async def test_metadata_omit_clear_and_merge_distinguishable(self, server: LithosServer):
+        """Through the real MCP boundary, omit (preserve), {} (clear), and a
+        non-empty dict (per-key merge) are distinguishable for metadata (#305)."""
+        write_payload = await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Metadata Semantics Doc",
+                "content": "Original content.",
+                "agent": "semantics-agent",
+                "metadata": {"a": 1, "b": 2},
+            },
+        )
+        doc_id = write_payload["id"]
+
+        read = await _call_tool(server, "lithos_read", {"id": doc_id})
+        assert read["metadata"]["extra"] == {"a": 1, "b": 2}
+
+        # Omit metadata → preserve.
+        await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "id": doc_id,
+                "title": "Metadata Semantics Doc",
+                "content": "Updated content.",
+                "agent": "semantics-agent",
+            },
+        )
+        read = await _call_tool(server, "lithos_read", {"id": doc_id})
+        assert read["metadata"]["extra"] == {"a": 1, "b": 2}
+
+        # Non-empty dict → additive per-key merge.
+        await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "id": doc_id,
+                "title": "Metadata Semantics Doc",
+                "content": "Updated content.",
+                "agent": "semantics-agent",
+                "metadata": {"c": 3},
+            },
+        )
+        read = await _call_tool(server, "lithos_read", {"id": doc_id})
+        assert read["metadata"]["extra"] == {"a": 1, "b": 2, "c": 3}
+
+        # Empty dict → clear all.
+        await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "id": doc_id,
+                "title": "Metadata Semantics Doc",
+                "content": "Updated content.",
+                "agent": "semantics-agent",
+                "metadata": {},
+            },
+        )
+        read = await _call_tool(server, "lithos_read", {"id": doc_id})
+        assert read["metadata"]["extra"] == {}
+
 
 class TestGraphEdgeConsistency:
     """Tests for graph edge correctness through the MCP write pipeline."""

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -765,6 +765,21 @@ class TestUpdateSemantics:
         read = await _call_tool(server, "lithos_read", {"id": doc_id})
         assert read["metadata"]["extra"] == {"a": 1, "b": 2, "c": 3}
 
+        # Per-key null → delete just that key, preserving the rest.
+        await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "id": doc_id,
+                "title": "Metadata Semantics Doc",
+                "content": "Updated content.",
+                "agent": "semantics-agent",
+                "metadata": {"a": None},
+            },
+        )
+        read = await _call_tool(server, "lithos_read", {"id": doc_id})
+        assert read["metadata"]["extra"] == {"b": 2, "c": 3}
+
         # Empty dict → clear all.
         await _call_tool(
             server,

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -753,6 +753,167 @@ class TestCachedMetaAccessors:
         list(pairs)
 
 
+class TestDocumentMetadata:
+    """Tests for free-form document metadata persisted via extra (#305)."""
+
+    @pytest.mark.asyncio
+    async def test_create_with_metadata_persists_to_extra(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """create(metadata=...) stores keys in KnowledgeMetadata.extra."""
+        doc = (
+            await knowledge_manager.create(
+                title="Configured Doc",
+                content="Body.",
+                agent="agent",
+                extra={"github_repo": "owner/name", "github_watch_enabled": True},
+            )
+        ).document
+        assert doc.metadata.extra == {
+            "github_repo": "owner/name",
+            "github_watch_enabled": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_metadata_round_trips_through_frontmatter(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """Metadata survives a write-read cycle via a fresh manager."""
+        created = (
+            await knowledge_manager.create(
+                title="Round Trip",
+                content="Body.",
+                agent="agent",
+                extra={"k": "v", "n": 3},
+            )
+        ).document
+
+        new_manager = KnowledgeManager(knowledge_manager.config)
+        doc, _ = await new_manager.read(id=created.id)
+        assert doc.metadata.extra == {"k": "v", "n": 3}
+
+    @pytest.mark.asyncio
+    async def test_create_no_metadata_yields_empty_extra(self, knowledge_manager: KnowledgeManager):
+        """Omitting metadata on create leaves extra == {}."""
+        doc = (
+            await knowledge_manager.create(
+                title="Bare Doc",
+                content="Body.",
+                agent="agent",
+            )
+        ).document
+        assert doc.metadata.extra == {}
+
+    @pytest.mark.asyncio
+    async def test_update_metadata_merges_per_key(self, knowledge_manager: KnowledgeManager):
+        """Updating with a new key merges additively without clobbering others."""
+        created = (
+            await knowledge_manager.create(
+                title="Mergeable",
+                content="Body.",
+                agent="agent",
+                extra={"a": 1},
+            )
+        ).document
+
+        await knowledge_manager.update(
+            id=created.id,
+            agent="editor",
+            extra={"b": 2},
+        )
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {"a": 1, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_update_metadata_overwrites_existing_key(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """A repeated key is overwritten by the patch value."""
+        created = (
+            await knowledge_manager.create(
+                title="Overwrite",
+                content="Body.",
+                agent="agent",
+                extra={"a": 1, "b": 2},
+            )
+        ).document
+
+        await knowledge_manager.update(id=created.id, agent="editor", extra={"a": 99})
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {"a": 99, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_update_metadata_null_value_deletes_key(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """A per-key None value deletes that key (consistent with task metadata)."""
+        created = (
+            await knowledge_manager.create(
+                title="Deletable",
+                content="Body.",
+                agent="agent",
+                extra={"a": 1, "b": 2},
+            )
+        ).document
+
+        await knowledge_manager.update(id=created.id, agent="editor", extra={"a": None})
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {"b": 2}
+
+    @pytest.mark.asyncio
+    async def test_update_omitting_metadata_preserves(self, knowledge_manager: KnowledgeManager):
+        """Omitting metadata on update (default _UNSET) preserves existing."""
+        created = (
+            await knowledge_manager.create(
+                title="Preserve",
+                content="Body.",
+                agent="agent",
+                extra={"keep": "this"},
+            )
+        ).document
+
+        await knowledge_manager.update(id=created.id, agent="editor", content="New body.")
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {"keep": "this"}
+
+    @pytest.mark.asyncio
+    async def test_update_empty_dict_clears_metadata(self, knowledge_manager: KnowledgeManager):
+        """Passing metadata={} clears all metadata."""
+        created = (
+            await knowledge_manager.create(
+                title="Clearable",
+                content="Body.",
+                agent="agent",
+                extra={"a": 1, "b": 2},
+            )
+        ).document
+
+        await knowledge_manager.update(id=created.id, agent="editor", extra={})
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {}
+
+    @pytest.mark.asyncio
+    async def test_metadata_keys_serialized_top_level_in_frontmatter(
+        self, knowledge_manager: KnowledgeManager, test_config
+    ):
+        """Metadata keys land as top-level frontmatter (Obsidian-compatible)."""
+        import yaml
+
+        created = (
+            await knowledge_manager.create(
+                title="Frontmatter Check",
+                content="Body.",
+                agent="agent",
+                extra={"github_repo": "owner/name"},
+            )
+        ).document
+
+        file_path = test_config.storage.knowledge_path / created.path
+        raw = file_path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw.split("---", 2)[1])
+        assert parsed["github_repo"] == "owner/name"
+
+
 class TestDocumentPersistence:
     """Tests for document file persistence."""
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -893,6 +893,42 @@ class TestDocumentMetadata:
         assert doc.metadata.extra == {}
 
     @pytest.mark.asyncio
+    async def test_create_reserved_metadata_key_rejected_at_storage_layer(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """The reserved-key invariant is enforced in the manager, not just MCP."""
+        result = await knowledge_manager.create(
+            title="Reserved Create",
+            content="Body.",
+            agent="agent",
+            extra={"title": "shadow"},
+        )
+        assert result.status == "invalid_input"
+        assert "reserved" in result.message
+
+    @pytest.mark.asyncio
+    async def test_update_reserved_metadata_key_rejected_at_storage_layer(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """update() rejects reserved metadata keys before mutating the doc."""
+        created = (
+            await knowledge_manager.create(
+                title="Reserved Update",
+                content="Body.",
+                agent="agent",
+                extra={"ok": 1},
+            )
+        ).document
+
+        result = await knowledge_manager.update(
+            id=created.id, agent="editor", extra={"version": 99}
+        )
+        assert result.status == "invalid_input"
+        # Original metadata untouched.
+        doc, _ = await knowledge_manager.read(id=created.id)
+        assert doc.metadata.extra == {"ok": 1}
+
+    @pytest.mark.asyncio
     async def test_metadata_keys_serialized_top_level_in_frontmatter(
         self, knowledge_manager: KnowledgeManager, test_config
     ):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2481,6 +2481,147 @@ class TestHealthEndpoint:
         assert response.status_code == 503
 
 
+class TestDocumentMetadataTool:
+    """Tests for the metadata param on lithos_write and its surfacing on
+    lithos_read / lithos_list (#305)."""
+
+    async def _call_write(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_write")
+        return await tool.fn(**kwargs)
+
+    async def _call_read(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_read")
+        return await tool.fn(**kwargs)
+
+    async def _call_list(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_list")
+        return await tool.fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_write_metadata_persists_and_read_returns_it(self, server: LithosServer):
+        """lithos_write(metadata=...) persists; lithos_read returns it under metadata.extra."""
+        meta = {"github_repo": "owner/name", "github_watch_enabled": True}
+        result = await self._call_write(
+            server,
+            title="Loom Project",
+            content="Project context.",
+            agent="agent",
+            metadata=meta,
+        )
+        assert result["status"] == "created"
+
+        read = await self._call_read(server, id=result["id"])
+        assert read["metadata"]["extra"] == meta
+
+    @pytest.mark.asyncio
+    async def test_list_includes_metadata(self, server: LithosServer):
+        """lithos_list items include the free-form metadata dict."""
+        result = await self._call_write(
+            server,
+            title="Listed Doc",
+            content="Body.",
+            agent="agent",
+            path="projects",
+            metadata={"github_repo": "a/b"},
+        )
+        assert result["status"] == "created"
+
+        listing = await self._call_list(server, path_prefix="projects")
+        item = next(i for i in listing["items"] if i["id"] == result["id"])
+        assert item["metadata"] == {"github_repo": "a/b"}
+
+    @pytest.mark.asyncio
+    async def test_update_merge_then_clear(self, server: LithosServer):
+        """Merge semantics through the tool: {a:1} then {b:2} -> both; {} clears."""
+        created = await self._call_write(
+            server,
+            title="Merge Doc",
+            content="Body.",
+            agent="agent",
+            metadata={"a": 1},
+        )
+        doc_id = created["id"]
+
+        await self._call_write(
+            server, id=doc_id, title="Merge Doc", content="Body.", agent="ed", metadata={"b": 2}
+        )
+        read = await self._call_read(server, id=doc_id)
+        assert read["metadata"]["extra"] == {"a": 1, "b": 2}
+
+        await self._call_write(
+            server, id=doc_id, title="Merge Doc", content="Body.", agent="ed", metadata={}
+        )
+        read = await self._call_read(server, id=doc_id)
+        assert read["metadata"]["extra"] == {}
+
+    @pytest.mark.asyncio
+    async def test_update_omit_metadata_preserves(self, server: LithosServer):
+        """Omitting metadata on update preserves existing."""
+        created = await self._call_write(
+            server,
+            title="Preserve Doc",
+            content="Body.",
+            agent="agent",
+            metadata={"keep": "this"},
+        )
+        await self._call_write(
+            server,
+            id=created["id"],
+            title="Preserve Doc",
+            content="Changed.",
+            agent="ed",
+            # metadata omitted
+        )
+        read = await self._call_read(server, id=created["id"])
+        assert read["metadata"]["extra"] == {"keep": "this"}
+
+    @pytest.mark.asyncio
+    async def test_metadata_reserved_key_collision_rejected(self, server: LithosServer):
+        """Keys colliding with reserved frontmatter fields are rejected."""
+        result = await self._call_write(
+            server,
+            title="Bad Keys",
+            content="Body.",
+            agent="agent",
+            metadata={"title": "shadow"},
+        )
+        assert result["status"] == "invalid_input"
+        assert "reserved" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_metadata_non_dict_rejected(self, server: LithosServer):
+        """A non-object metadata value is rejected."""
+        result = await self._call_write(
+            server,
+            title="Bad Type",
+            content="Body.",
+            agent="agent",
+            metadata=["not", "a", "dict"],
+        )
+        assert result["status"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_expected_version_conflict_unchanged_with_metadata(self, server: LithosServer):
+        """A stale expected_version still yields version_conflict when metadata is supplied."""
+        created = await self._call_write(
+            server,
+            title="Locked Doc",
+            content="Body.",
+            agent="agent",
+            metadata={"a": 1},
+        )
+        result = await self._call_write(
+            server,
+            id=created["id"],
+            title="Locked Doc",
+            content="Body.",
+            agent="ed",
+            metadata={"b": 2},
+            expected_version=999,
+        )
+        assert result["status"] == "version_conflict"
+
+
 class TestTaskMetadataTool:
     """Tests for metadata field in lithos_task_create, lithos_task_update, lithos_task_list, lithos_task_status (#215)."""
 


### PR DESCRIPTION
## Summary

Adds a writable + readable free-form `metadata` key/value field to the document write surface (Part A of #305). Previously only `tags` was writable on `lithos_write`, forcing consumers (e.g. `lithos-loom`) to smuggle structured config into tags as prefixed strings. Tasks already have `metadata`; this closes the asymmetry for documents.

The gap was purely the API surface — `KnowledgeMetadata.extra` already round-trips through YAML frontmatter. This change lets callers **write** it and **read it back cleanly**.

## What changed

- **`lithos_write`** gains a `metadata: dict | None` param.
  - Update semantics mirror `tags`: `null`/omit preserves, `{}` clears, a non-empty dict is an **additive per-key merge** (per-key `null` deletes a key).
  - Persisted via `KnowledgeMetadata.extra` (top-level frontmatter keys, Obsidian-compatible) — no data-model change.
  - Reserved-key collisions (`title`, `tags`, `version`, …), non-dict input, and non-string keys are rejected as `invalid_input`.
  - `expected_version` optimistic locking applies unchanged.
- **`lithos_read`** returns the free-form metadata as an isolated dict under `metadata.extra`.
- **`lithos_list`** includes the metadata dict per item under `metadata`.
- The per-key merge helper is **extracted** from `coordination.py` into shared `lithos._merge.merge_metadata`, so documents and tasks share one source of truth.
- `docs/plans/unified-write-contract.md` updated.

## Scope

Part A only. **Part B** (metadata-equality filtering on `lithos_list` / `lithos_task_list`) is deferred to #306.

## Test plan

- [x] Knowledge-layer unit tests: create→read round-trip, merge `{a:1}`+`{b:2}`→both, overwrite, per-key `null` delete, `{}` clears, omit preserves, top-level frontmatter serialization.
- [x] Tool-layer tests: `lithos_write` metadata, `lithos_read` returns `metadata.extra`, `lithos_list` items include `metadata`, reserved-key + non-dict rejection, `expected_version` conflict still fires with metadata.
- [x] MCP-boundary conformance test: omit vs `{}` vs non-empty dict are distinguishable end-to-end.
- [x] `make check` (lint + pyright 0 errors + 1214 unit tests) green.
- [x] `make test-integration` (373 tests) green.

Closes #305.
