### PR TITLE
feat(list): add metadata_match filtering to lithos_list and lithos_task_list (closes #306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Free-form metadata on knowledge notes (#305).** `lithos_write` accepts a `metadata` object of arbitrary key/value pairs (scalars or lists), persisted to YAML frontmatter via `KnowledgeMetadata.extra`. `lithos_read` returns it as `metadata.extra`; `lithos_list` includes it on each item. Update semantics mirror `tags`: omit/`null` preserves, `{}` clears, a non-empty dict is an additive per-key merge (per-key `null` deletes). Keys that collide with reserved frontmatter fields are rejected with `status="invalid_input"`.
+- **`metadata_match` filter on `lithos_list` and `lithos_task_list` (#306).** Filter by free-form metadata: AND across keys, where each `key: q` matches records whose stored value equals `q` or is a list containing `q` (e.g. `github_repos: ["org/a","org/b"]` matches `{"github_repos": "org/a"}`). Query values are scalars; matching is type-sensitive. `lithos_list` resolves it through an in-memory inverted index (no full scan); `lithos_task_list` pushes it into SQLite via `json_extract`/`json_each`. As part of this, `lithos_list`'s existing equality filters (`tags`, `author`) are now index-backed too.
 - **`lithos_task_list` `with_claims` flag.** When set to `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`, so existing payloads are unchanged. Lets list views avoid an N+1 of `lithos_task_status` calls. Implementation issues a single batched `WHERE task_id IN (...)` query rather than one per task.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Just as Alation coined the term "Knowledge Layer" for enterprise data governance
 - **🧠 Research cache**: One-call freshness check so agents skip redundant research — returns hit/miss/stale with update guidance
 - **🔗 URL deduplication**: Automatic detection and prevention of duplicate notes from the same source URL
 - **🧬 Provenance tracking**: Declare which notes a synthesis is derived from and query lineage across the knowledge base
-- **🏷️ Free-form metadata**: Attach arbitrary key/value metadata (scalars or lists) to notes and tasks, then filter by it — `lithos_list`/`lithos_task_list` `metadata_match` (e.g. find the project doc whose `github_repos` contains a repo), index-backed so it never scans the whole base
+- **🏷️ Free-form metadata**: Attach arbitrary key/value metadata (scalars or lists) to notes and tasks, then filter by it — `lithos_list`/`lithos_task_list` `metadata_match` (e.g. find the project doc whose `github_repos` contains a repo). Notes are filtered through an in-memory inverted index (no full scan); task filtering is evaluated inside SQLite (no Python post-scan, composes with other indexed filters)
 - **🔌 MCP interface**: Works with any MCP-compatible agent or tool
 - **🏠 Local & private**: No cloud dependencies, you own your data
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Just as Alation coined the term "Knowledge Layer" for enterprise data governance
 - **🧠 Research cache**: One-call freshness check so agents skip redundant research — returns hit/miss/stale with update guidance
 - **🔗 URL deduplication**: Automatic detection and prevention of duplicate notes from the same source URL
 - **🧬 Provenance tracking**: Declare which notes a synthesis is derived from and query lineage across the knowledge base
+- **🏷️ Free-form metadata**: Attach arbitrary key/value metadata (scalars or lists) to notes and tasks, then filter by it — `lithos_list`/`lithos_task_list` `metadata_match` (e.g. find the project doc whose `github_repos` contains a repo), index-backed so it never scans the whole base
 - **🔌 MCP interface**: Works with any MCP-compatible agent or tool
 - **🏠 Local & private**: No cloud dependencies, you own your data
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -283,6 +283,15 @@ summaries:                        # Optional: nested object with short/long summ
 entities:                         # Optional: extracted entity strings (advisory)
   - <entity-1>                    # Reserved for the lithos-enrich worker;
   - <entity-2>                    # may be empty or absent on agent-written notes.
+# --- Free-form metadata (#305) ---
+# Any frontmatter key NOT listed above is preserved as free-form metadata,
+# settable via lithos_write(metadata={...}) and returned by lithos_read /
+# lithos_list. Keys must not collide with the reserved fields above. Values may
+# be scalars or lists; list values are matched element-wise by metadata_match.
+github_repos:                     # Example free-form key (arbitrary name)
+  - <owner/repo-1>
+  - <owner/repo-2>
+github_watch_enabled: <bool>      # Example scalar free-form value
 ---
 
 # Title
@@ -399,6 +408,7 @@ Parameters are flat at the MCP boundary but grouped below by role to aid discove
 |------|------|----------|-------------|
 | `id` | string | No | UUID to update existing; omit to create new |
 | `tags` | string[] | No | List of tags |
+| `metadata` | object | No | Free-form key/value metadata persisted to frontmatter (#305). Values may be scalars or lists. On update: omit/`null` preserves; `{}` clears; a non-empty dict is an additive per-key merge (a key whose value is `null` deletes it). Keys must be strings and must not collide with reserved frontmatter fields, else `status="invalid_input"`. Returned by `lithos_read` (as `metadata.extra`) and `lithos_list` (as each item's `metadata`), and filterable via `lithos_list(metadata_match=...)`. |
 | `confidence` | float | No | Confidence score 0-1 (default: 1.0) |
 | `path` | string | No | Either a subdirectory (e.g. `"procedures"`) under which the filename is derived from `title` (slugified) and `.md` appended, OR a full relative file path ending in `.md` (e.g. `"procedures/my-doc.md"`) used verbatim as the filename. Intermediate path segments may not end in `.md` — such inputs return `status="invalid_input"`. Paths that resolve to an already-owned file return `status="path_collision"`. |
 
@@ -592,12 +602,20 @@ List knowledge items with filters.
 | `offset` | int | No | Pagination offset |
 | `title_contains` | string | No | Case-insensitive substring match on title |
 | `content_query` | string | No | Tantivy full-text query applied after the base filters |
+| `metadata_match` | object | No | Filter by free-form metadata (see Filter semantics) |
 
-**Returns:** `{ items: [{ id, title, path, updated, tags, source_url, derived_from_ids }], total: int }`
+**Returns:** `{ items: [{ id, title, path, updated, tags, source_url, derived_from_ids, metadata }], total: int }`
+(`metadata` is the document's free-form key/value dict.)
 
 **Behavior:**
 - When `title_contains` or `content_query` is present, Lithos fetches the full base-filtered set first, then applies post-filters before pagination. This keeps `items` and `total` correct across pages.
 - `content_query` backend failures return `{ status: "error", code: "search_backend_error", message }`.
+- `metadata_match` is resolved through an in-memory inverted index, so a metadata-filtered list never scans the whole knowledge base.
+
+**Filter semantics (`metadata_match`, #306):**
+- AND across keys: a document must match every `key: q` pair.
+- Per key, a document matches when its stored value **equals `q`** or **is a list containing `q`** (e.g. a note with `github_repos: ["org/a","org/b"]` matches `{"github_repos": "org/a"}`).
+- Query values must be JSON scalars (string/number/boolean); `null`/list/dict query values return `{ status: "invalid_input" }`. Matching is type-sensitive (`"1"` ≠ `1`).
 
 ### 5.2 Graph Operations
 
@@ -812,6 +830,7 @@ List tasks with optional filters.
 | `since` | string | No | Filter by `created_at >= since` (ISO datetime) |
 | `resolved_since` | string | No | Filter by `resolved_at >= resolved_since` (ISO datetime). `resolved_at` is set on both terminal transitions (`complete` and `cancel`), so this surfaces tasks resolved in either way within the window. Open tasks and historical cancellations whose `resolved_at` is `NULL` are excluded automatically. |
 | `with_claims` | boolean | No | When `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`. Use to avoid an N+1 of `lithos_task_status` calls when rendering a list view. |
+| `metadata_match` | object | No | Filter by task metadata. Same semantics as `lithos_list.metadata_match` (AND across keys; stored value equals the query or is a list containing it; scalar query values; type-sensitive). Pushed into SQLite via `json_extract`/`json_each`, so it is engine-evaluated rather than a Python post-scan. |
 
 **Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). `outcome` is `null` until the task is completed with an outcome. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
 

--- a/docs/plans/unified-write-contract.md
+++ b/docs/plans/unified-write-contract.md
@@ -140,6 +140,12 @@ Authority rule:
   `metadata.extra`, alongside the full frontmatter `metadata` envelope.
 - `lithos_list` includes the free-form metadata dict on each item under the
   `metadata` key.
+- Both `lithos_list` and `lithos_task_list` accept `metadata_match` (#306) to
+  filter by free-form metadata: AND across keys, where each `key: q` matches a
+  record whose stored value equals `q` or is a list containing `q`. Query values
+  are scalars; matching is type-sensitive. `lithos_list` is backed by an
+  in-memory inverted index; `lithos_task_list` pushes the predicate into SQLite
+  (`json_extract`/`json_each`). Neither performs a full scan.
 
 ## Canonical Write Outcome Envelope
 

--- a/docs/plans/unified-write-contract.md
+++ b/docs/plans/unified-write-contract.md
@@ -144,8 +144,12 @@ Authority rule:
   filter by free-form metadata: AND across keys, where each `key: q` matches a
   record whose stored value equals `q` or is a list containing `q`. Query values
   are scalars; matching is type-sensitive. `lithos_list` is backed by an
-  in-memory inverted index; `lithos_task_list` pushes the predicate into SQLite
-  (`json_extract`/`json_each`). Neither performs a full scan.
+  in-memory inverted index, so a metadata-filtered list never scans the whole
+  knowledge base. `lithos_task_list` pushes the predicate into SQLite
+  (`json_extract`/`json_each`), so it is engine-evaluated (no Python post-scan)
+  and composes with indexed filters such as `status`; a metadata-only query can
+  still scan the `tasks` table until an expression index on the queried key is
+  added (a documented future optimization).
 
 ## Canonical Write Outcome Envelope
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -220,6 +220,22 @@ def _json_path_for_key(key: str) -> str:
     return f'$."{escaped}"'
 
 
+def _json_type_label(value: object) -> str:
+    """Map a Python scalar to the ``json_type()`` label SQLite reports (#306).
+
+    Used to make ``metadata_match`` type-sensitive: SQLite stores JSON booleans
+    as 1/0, so without this a query value of ``1`` would match a stored ``true``.
+    ``bool`` is checked before ``int`` because ``bool`` is an ``int`` subclass.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "real"
+    return "text"
+
+
 def _decode_metadata(raw: Any) -> dict[str, Any]:
     """Decode a stored ``tasks.metadata`` JSON column into a dict, safely.
 
@@ -988,17 +1004,23 @@ class CoordinationService:
 
         # Metadata equality/contains filter (#306), pushed into SQL so the
         # engine evaluates it (no full-table load into Python). For each key the
-        # task matches when the stored value equals the query OR is a JSON array
-        # containing it. The JSON path and value are bound parameters, so keys
-        # from the caller cannot inject SQL.
+        # task matches when the stored value equals the query OR is an element of
+        # a JSON *array* at that key. Matching is type-sensitive to mirror the
+        # knowledge side: ``json_type`` is checked so a JSON boolean (stored as
+        # 1/0 by SQLite) never matches an integer query, and the array branch is
+        # gated on ``json_type(...) = 'array'`` so JSON objects are not iterated.
+        # The JSON path and value are bound parameters, so caller keys cannot
+        # inject SQL.
         if metadata_match:
             for key, value in metadata_match.items():
                 path = _json_path_for_key(key)
+                jtype = _json_type_label(value)
                 query += (
-                    " AND ( json_extract(metadata, ?) = ?"
-                    " OR EXISTS (SELECT 1 FROM json_each(metadata, ?) WHERE value = ?) )"
+                    " AND ( (json_type(metadata, ?) = ? AND json_extract(metadata, ?) = ?)"
+                    " OR (json_type(metadata, ?) = 'array' AND EXISTS"
+                    " (SELECT 1 FROM json_each(metadata, ?) WHERE type = ? AND value = ?)) )"
                 )
-                params.extend([path, value, path, value])
+                params.extend([path, jtype, path, value, path, path, jtype, value])
 
         query += " ORDER BY created_at DESC"
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -208,6 +208,18 @@ def _format_datetime(dt: datetime) -> str:
     return dt.isoformat()
 
 
+def _json_path_for_key(key: str) -> str:
+    """Build a SQLite JSON path addressing a top-level metadata ``key`` (#306).
+
+    Always uses the quoted-label form ``$."key"`` (valid for keys with dots,
+    spaces, etc.), escaping embedded backslashes and quotes. The result is
+    passed to ``json_extract``/``json_each`` as a *bound parameter*, so it
+    cannot inject SQL — this only ensures the path addresses the right key.
+    """
+    escaped = key.replace("\\", "\\\\").replace('"', '\\"')
+    return f'$."{escaped}"'
+
+
 def _decode_metadata(raw: Any) -> dict[str, Any]:
     """Decode a stored ``tasks.metadata`` JSON column into a dict, safely.
 
@@ -923,6 +935,7 @@ class CoordinationService:
         since: str | None = None,
         resolved_since: str | None = None,
         with_claims: bool = False,
+        metadata_match: dict | None = None,
     ) -> list[dict[str, Any]]:
         """List tasks with optional filters.
 
@@ -930,6 +943,11 @@ class CoordinationService:
             agent: Filter by created_by agent
             status: Filter by status (open/completed/cancelled), or None for all
             tags: Filter by tags (task must have all specified tags)
+            metadata_match: Filter by metadata (AND across keys). For each
+                ``key: q`` a task matches when its stored metadata value equals
+                ``q`` or is a list containing ``q``. Pushed into SQL via
+                ``json_extract``/``json_each`` (engine-evaluated, not a Python
+                post-scan). Query values must be scalars.
             since: Filter by created_at >= this ISO datetime string
             resolved_since: Filter by resolved_at >= this ISO datetime string.
                 ``resolved_at`` is set on both terminal transitions (complete
@@ -967,6 +985,20 @@ class CoordinationService:
         if resolved_since:
             query += " AND resolved_at >= ?"
             params.append(resolved_since)
+
+        # Metadata equality/contains filter (#306), pushed into SQL so the
+        # engine evaluates it (no full-table load into Python). For each key the
+        # task matches when the stored value equals the query OR is a JSON array
+        # containing it. The JSON path and value are bound parameters, so keys
+        # from the caller cannot inject SQL.
+        if metadata_match:
+            for key, value in metadata_match.items():
+                path = _json_path_for_key(key)
+                query += (
+                    " AND ( json_extract(metadata, ?) = ?"
+                    " OR EXISTS (SELECT 1 FROM json_each(metadata, ?) WHERE value = ?) )"
+                )
+                params.extend([path, value, path, value])
 
         query += " ORDER BY created_at DESC"
 

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import re
@@ -143,6 +144,51 @@ def validate_extra_metadata(extra: dict) -> None:
             f"metadata keys collide with reserved frontmatter fields: {reserved}. "
             "Choose different keys."
         )
+
+
+# Scalar JSON types accepted as metadata_match *query* values (#306).
+_METADATA_MATCH_SCALARS = (str, int, float, bool)
+
+
+def validate_metadata_match(metadata_match: dict) -> None:
+    """Validate a ``metadata_match`` filter (#306).
+
+    Used by both ``lithos_list`` and ``lithos_task_list`` so the two surfaces
+    share one ``invalid_input`` contract. Query values must be JSON scalars;
+    a stored value that is a *list* is matched element-wise downstream, but the
+    query value itself stays scalar (list/dict/null query values are rejected).
+
+    Raises:
+        ValueError: if ``metadata_match`` is not a dict, has a non-string or
+            empty key, or a non-scalar value.
+    """
+    if not isinstance(metadata_match, dict):
+        raise ValueError("metadata_match must be an object of string keys.")
+    for key, value in metadata_match.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("metadata_match keys must be non-empty strings.")
+        # bool is a subclass of int — both are allowed scalars; reject only
+        # null, lists and dicts.
+        if not isinstance(value, _METADATA_MATCH_SCALARS):
+            raise ValueError(f"metadata_match[{key!r}] must be a string, number, or boolean.")
+
+
+def extract_extra(frontmatter_meta: dict) -> dict:
+    """Return the free-form metadata: keys not recognised as known fields.
+
+    Single source of truth for "what counts as ``extra``", shared by
+    ``KnowledgeMetadata.from_dict`` and the startup scan.
+    """
+    return {k: v for k, v in frontmatter_meta.items() if k not in _KNOWN_METADATA_KEYS}
+
+
+def canonical_metadata_value(value: object) -> str:
+    """Canonical, hashable bucket key for a metadata value (#306).
+
+    JSON-equal values map to the same string, so equality matching is correct
+    across types and across dict key orderings.
+    """
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
 # Valid LCMA enum values
@@ -390,7 +436,7 @@ class KnowledgeMetadata:
         elif not isinstance(expires_at, datetime):
             expires_at = None
 
-        extra = {k: v for k, v in data.items() if k not in _KNOWN_METADATA_KEYS}
+        extra = extract_extra(data)
 
         # Parse LCMA fields — only unpack what is present; defaults applied by caller
         schema_version_raw = data.get("schema_version")
@@ -648,6 +694,12 @@ class _CachedMeta:
     note_type: str | None = None
     status: str | None = None
     source_url: str | None = None
+    # Free-form key/value metadata (#305) — kept here so equality filtering and
+    # the inverted index (#306) work without a disk read.
+    extra: dict = field(default_factory=dict)
+    # Insertion ordinal — reproduces _meta_cache ordering in the index path so
+    # list pagination stays stable (#306).
+    seq: int = 0
 
 
 class _UnsetType:
@@ -799,7 +851,102 @@ class KnowledgeManager:
         self._unresolved_provenance: dict[str, set[str]] = {}
         self._id_to_title: dict[str, str] = {}
         self._meta_cache: dict[str, _CachedMeta] = {}
+        # Inverted indexes for sub-linear equality filtering (#306). All map a
+        # value to the set of doc ids carrying it; maintained beside _meta_cache.
+        self._author_index: dict[str, set[str]] = {}
+        self._status_index: dict[str, set[str]] = {}
+        self._tag_index: dict[str, set[str]] = {}
+        self._metadata_index: dict[str, dict[str, set[str]]] = {}
+        self._meta_seq: int = 0
         self._scan_existing()
+
+    def _next_seq(self) -> int:
+        self._meta_seq += 1
+        return self._meta_seq
+
+    def _index_doc(self, doc_id: str, cached: _CachedMeta) -> None:
+        """Add a doc's equality-filter contributions to the inverted indexes."""
+        if cached.author:
+            self._author_index.setdefault(cached.author, set()).add(doc_id)
+        if cached.status:
+            self._status_index.setdefault(cached.status, set()).add(doc_id)
+        for tag in cached.tags:
+            self._tag_index.setdefault(tag, set()).add(doc_id)
+        for key, value in cached.extra.items():
+            buckets = self._metadata_index.setdefault(key, {})
+            # A list value is matched element-wise (contains); a scalar by value.
+            elements = value if isinstance(value, list) else [value]
+            for element in elements:
+                buckets.setdefault(canonical_metadata_value(element), set()).add(doc_id)
+
+    def _deindex_doc(self, doc_id: str, cached: _CachedMeta) -> None:
+        """Remove a doc's contributions (using its *previous* cached meta)."""
+
+        def _discard(index: dict[str, set[str]], value: str | None) -> None:
+            if value is None:
+                return
+            bucket = index.get(value)
+            if bucket is not None:
+                bucket.discard(doc_id)
+                if not bucket:
+                    del index[value]
+
+        _discard(self._author_index, cached.author or None)
+        _discard(self._status_index, cached.status or None)
+        for tag in cached.tags:
+            _discard(self._tag_index, tag)
+        for key, value in cached.extra.items():
+            buckets = self._metadata_index.get(key)
+            if buckets is None:
+                continue
+            elements = value if isinstance(value, list) else [value]
+            for element in elements:
+                _discard(buckets, canonical_metadata_value(element))
+            if not buckets:
+                del self._metadata_index[key]
+
+    def _candidate_ids(
+        self,
+        *,
+        tags: list[str] | None,
+        author: str | None,
+        metadata_match: dict | None,
+        exclude_status: list[str] | None,
+    ) -> set[str] | None:
+        """Resolve equality filters to a candidate id set via the inverted index.
+
+        Returns ``None`` when no equality/AND filter is supplied, signalling the
+        caller to use the existing full-scan path (correct for unfiltered /
+        prefix-only / since-only / exclude-only queries). Otherwise returns the
+        (possibly empty) intersected candidate set — never iterating all docs.
+        """
+        seed_sets: list[set[str]] = []
+        if author:
+            seed_sets.append(self._author_index.get(author, set()))
+        if tags:
+            for tag in tags:
+                seed_sets.append(self._tag_index.get(tag, set()))
+        if metadata_match:
+            for key, value in metadata_match.items():
+                bucket = self._metadata_index.get(key, {})
+                seed_sets.append(bucket.get(canonical_metadata_value(value), set()))
+
+        if not seed_sets:
+            return None
+
+        # Intersect smallest-first; any empty seed short-circuits to empty.
+        seed_sets.sort(key=len)
+        candidates = set(seed_sets[0])
+        for s in seed_sets[1:]:
+            candidates &= s
+            if not candidates:
+                break
+
+        if candidates and exclude_status:
+            for status in exclude_status:
+                candidates -= self._status_index.get(status, set())
+
+        return candidates
 
     def _scan_existing(self) -> None:
         """Scan existing documents and build indices.
@@ -818,6 +965,11 @@ class KnowledgeManager:
         self._unresolved_provenance.clear()
         self._id_to_title.clear()
         self._meta_cache.clear()
+        self._author_index.clear()
+        self._status_index.clear()
+        self._tag_index.clear()
+        self._metadata_index.clear()
+        self._meta_seq = 0
         self.duplicate_url_count = 0
 
         if not self.knowledge_path.exists():
@@ -890,7 +1042,7 @@ class KnowledgeManager:
                         if isinstance(raw_namespace, str) and raw_namespace
                         else derive_namespace(rel_path)
                     )
-                    self._meta_cache[doc_id] = _CachedMeta(
+                    cached = _CachedMeta(
                         title=title,
                         author=raw_author if isinstance(raw_author, str) else "",
                         tags=raw_tags if isinstance(raw_tags, list) else [],
@@ -905,7 +1057,11 @@ class KnowledgeManager:
                         note_type=raw_note_type if isinstance(raw_note_type, str) else None,
                         status=raw_status if isinstance(raw_status, str) else None,
                         source_url=raw_source_url if isinstance(raw_source_url, str) else None,
+                        extra=extract_extra(post.metadata),
+                        seq=self._next_seq(),
                     )
+                    self._meta_cache[doc_id] = cached
+                    self._index_doc(doc_id, cached)
 
                     # Populate source_url -> id map
                     raw_url: str | None = post.metadata.get("source_url")  # type: ignore[assignment]
@@ -1202,7 +1358,7 @@ class KnowledgeManager:
             # from path (matches apply_lcma_defaults at read time).
             cached_namespace = metadata.namespace or derive_namespace(file_path)
 
-            self._meta_cache[doc_id] = _CachedMeta(
+            cached = _CachedMeta(
                 title=title,
                 author=metadata.author,
                 tags=list(metadata.tags),
@@ -1215,7 +1371,11 @@ class KnowledgeManager:
                 note_type=metadata.note_type,
                 status=metadata.status,
                 source_url=metadata.source_url,
+                extra=dict(metadata.extra),
+                seq=self._next_seq(),
             )
+            self._meta_cache[doc_id] = cached
+            self._index_doc(doc_id, cached)
 
             logger.info(
                 "Document created: doc_id=%s title=%.60s agent=%s",
@@ -1604,9 +1764,14 @@ class KnowledgeManager:
             if title is not None:
                 self._id_to_title[id] = title
 
-            # Update metadata cache
+            # Update metadata cache + inverted index. Deindex the previous entry
+            # first, then index the new one; preserve the insertion ordinal so
+            # list ordering/pagination is unchanged by an update.
             cached_namespace = doc.metadata.namespace or derive_namespace(doc.path)
-            self._meta_cache[id] = _CachedMeta(
+            old_cached = self._meta_cache.get(id)
+            if old_cached is not None:
+                self._deindex_doc(id, old_cached)
+            cached = _CachedMeta(
                 title=doc.metadata.title,
                 author=doc.metadata.author,
                 tags=list(doc.metadata.tags),
@@ -1619,7 +1784,11 @@ class KnowledgeManager:
                 note_type=doc.metadata.note_type,
                 status=doc.metadata.status,
                 source_url=doc.metadata.source_url,
+                extra=dict(doc.metadata.extra),
+                seq=old_cached.seq if old_cached is not None else self._next_seq(),
             )
+            self._meta_cache[id] = cached
+            self._index_doc(id, cached)
 
             if logger.isEnabledFor(logging.INFO):
                 changed: list[str] = []
@@ -1683,9 +1852,11 @@ class KnowledgeManager:
             derived_docs = self._source_to_derived.pop(id, set())
             if derived_docs:
                 self._unresolved_provenance[id] = derived_docs
-            # 4. Remove from title and metadata caches
+            # 4. Remove from title and metadata caches + inverted index
             self._id_to_title.pop(id, None)
-            self._meta_cache.pop(id, None)
+            removed = self._meta_cache.pop(id, None)
+            if removed is not None:
+                self._deindex_doc(id, removed)
 
             logger.info("Document deleted: doc_id=%s path=%s", id, file_path)
             return True, str(file_path)
@@ -1700,6 +1871,7 @@ class KnowledgeManager:
         tags: list[str] | None = None,
         author: str | None = None,
         exclude_status: list[str] | None = None,
+        metadata_match: dict | None = None,
     ) -> tuple[list[KnowledgeDocument], int]:
         """List all documents with optional filtering.
 
@@ -1708,24 +1880,52 @@ class KnowledgeManager:
 
         ``exclude_status`` filters out documents whose cached status is in
         the given list (e.g. ``['quarantined']``).
-        """
-        matching_ids: list[str] = []
-        normalized_since = _normalize_datetime(since) if since else None
 
-        for doc_id, cached in self._meta_cache.items():
-            if exclude_status and cached.status in exclude_status:
-                continue
-            if path_prefix and not str(cached.path).startswith(path_prefix):
-                continue
-            if tags and not all(t in cached.tags for t in tags):
-                continue
-            if author and cached.author != author:
-                continue
-            if normalized_since:
-                doc_updated = _normalize_datetime(cached.updated_at)
-                if doc_updated < normalized_since:
+        ``metadata_match`` filters by free-form metadata (#306): each ``key: q``
+        matches docs whose stored value equals ``q`` or is a list containing it.
+
+        Equality filters (``tags``, ``author``, ``metadata_match``) are resolved
+        through inverted indexes to a candidate set, so a filtered query never
+        scans the whole cache; ``path_prefix``/``since`` then refine only those
+        candidates. With no equality filter, falls back to a full scan (which is
+        unavoidable for unfiltered / prefix-only / since-only listings).
+        """
+        normalized_since = _normalize_datetime(since) if since else None
+        candidate_ids = self._candidate_ids(
+            tags=tags,
+            author=author,
+            metadata_match=metadata_match,
+            exclude_status=exclude_status,
+        )
+
+        if candidate_ids is None:
+            # No equality filter — full scan (existing behaviour + ordering).
+            matching_ids: list[str] = []
+            for doc_id, cached in self._meta_cache.items():
+                if exclude_status and cached.status in exclude_status:
                     continue
-            matching_ids.append(doc_id)
+                if path_prefix and not str(cached.path).startswith(path_prefix):
+                    continue
+                if normalized_since and _normalize_datetime(cached.updated_at) < normalized_since:
+                    continue
+                matching_ids.append(doc_id)
+        else:
+            # Index path — refine the (small) candidate set, then restore the
+            # _meta_cache insertion order via the stored seq for stable paging.
+            refined: list[_CachedMeta] = []
+            refined_ids: list[str] = []
+            for doc_id in candidate_ids:
+                cached = self._meta_cache.get(doc_id)
+                if cached is None:
+                    continue
+                if path_prefix and not str(cached.path).startswith(path_prefix):
+                    continue
+                if normalized_since and _normalize_datetime(cached.updated_at) < normalized_since:
+                    continue
+                refined.append(cached)
+                refined_ids.append(doc_id)
+            order = sorted(range(len(refined_ids)), key=lambda i: refined[i].seq)
+            matching_ids = [refined_ids[i] for i in order]
 
         total = len(matching_ids)
         docs = []
@@ -1745,6 +1945,20 @@ class KnowledgeManager:
             extra={"total": total, "returned": len(docs), "offset": offset, "limit": limit},
         )
         return docs, total
+
+    def metadata_candidate_ids(self, metadata_match: dict | None) -> set[str] | None:
+        """Public wrapper: candidate ids for a ``metadata_match`` filter (#306).
+
+        Returns ``None`` when ``metadata_match`` is empty/None (no filtering),
+        otherwise the set of doc ids matching every key (sub-linear, index-based).
+        Used by the content-query path of ``lithos_list`` to intersect with
+        full-text hits without scanning the cache.
+        """
+        if not metadata_match:
+            return None
+        return self._candidate_ids(
+            tags=None, author=None, metadata_match=metadata_match, exclude_status=None
+        )
 
     async def get_all_tags(self) -> dict[str, int]:
         """Get all tags with document counts (from in-memory cache)."""
@@ -1916,9 +2130,13 @@ class KnowledgeManager:
                     self._source_to_derived[doc_id] = set()
                 self._source_to_derived[doc_id].update(resolved_docs)
 
-        # Update metadata cache
+        # Update metadata cache + inverted index (deindex prior entry first;
+        # preserve insertion ordinal so list ordering stays stable).
         cached_namespace = metadata.namespace or derive_namespace(file_path)
-        self._meta_cache[doc_id] = _CachedMeta(
+        old_cached = self._meta_cache.get(doc_id)
+        if old_cached is not None:
+            self._deindex_doc(doc_id, old_cached)
+        cached = _CachedMeta(
             title=title,
             author=metadata.author,
             tags=list(metadata.tags),
@@ -1931,7 +2149,11 @@ class KnowledgeManager:
             note_type=metadata.note_type,
             status=metadata.status,
             source_url=metadata.source_url,
+            extra=dict(metadata.extra),
+            seq=old_cached.seq if old_cached is not None else self._next_seq(),
         )
+        self._meta_cache[doc_id] = cached
+        self._index_doc(doc_id, cached)
 
         return doc
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -45,6 +45,7 @@ from lithos.knowledge import (
     _normalize_datetime,
     _UnsetType,
     validate_extra_metadata,
+    validate_metadata_match,
 )
 from lithos.provenance import ProvenanceProjection
 from lithos.search import Healthy, SearchEngine
@@ -1913,6 +1914,7 @@ class LithosServer:
             offset: int = 0,
             title_contains: str | None = None,
             content_query: str | None = None,
+            metadata_match: dict | None = None,
         ) -> dict[str, Any]:
             """List knowledge documents with filters.
 
@@ -1924,6 +1926,13 @@ class LithosServer:
                 limit: Max results (default: 50)
                 offset: Pagination offset
                 title_contains: Filter by case-insensitive substring match on title
+                metadata_match: Filter by free-form metadata (AND across keys). For
+                    each ``key: q`` a document matches when its stored metadata
+                    value equals ``q`` or is a list containing ``q`` (so a note with
+                    ``github_repos: ["org/a","org/b"]`` matches
+                    ``{"github_repos": "org/a"}``). Query values must be scalars
+                    (string/number/boolean); type-sensitive. Resolved via an
+                    inverted index (no full scan).
                 content_query: Filter by full-text search query (Tantivy).
                     Tantivy-native filters (``tags``, ``author``,
                     ``path_prefix``) are pushed down into the search query so
@@ -1944,6 +1953,12 @@ class LithosServer:
                 since_dt = None
                 if since:
                     since_dt = datetime.fromisoformat(since)
+
+                if metadata_match is not None:
+                    try:
+                        validate_metadata_match(metadata_match)
+                    except ValueError as e:
+                        return {"status": "invalid_input", "message": str(e), "warnings": []}
 
                 if content_query is not None:
                     # Push the Tantivy-native filters into the search call so
@@ -1967,11 +1982,16 @@ class LithosServer:
                             "message": f"Full-text search failed: {exc}",
                         }
 
-                    # Apply the filters Tantivy doesn't handle: ``since`` and
-                    # ``title_contains``. Consult the metadata cache so we
-                    # don't incur a disk read per candidate.
+                    # Apply the filters Tantivy doesn't handle: ``since``,
+                    # ``title_contains`` and ``metadata_match``. Consult the
+                    # metadata cache / inverted index so we don't incur a disk
+                    # read per candidate. ``meta_candidates`` is None when no
+                    # metadata filter is requested.
+                    meta_candidates = self.knowledge.metadata_candidate_ids(metadata_match)
                     matching_ids: list[str] = []
                     for r in fts_results:
+                        if meta_candidates is not None and r.id not in meta_candidates:
+                            continue
                         cached = self.knowledge.get_cached_meta(r.id)
                         if cached is None:
                             continue
@@ -2006,6 +2026,7 @@ class LithosServer:
                         tags=tags,
                         author=author,
                         since=since_dt,
+                        metadata_match=metadata_match,
                         limit=0,
                         offset=0,
                     )
@@ -2015,6 +2036,7 @@ class LithosServer:
                             tags=tags,
                             author=author,
                             since=since_dt,
+                            metadata_match=metadata_match,
                             limit=total_base,
                             offset=0,
                         )
@@ -2029,6 +2051,7 @@ class LithosServer:
                         tags=tags,
                         author=author,
                         since=since_dt,
+                        metadata_match=metadata_match,
                         limit=limit,
                         offset=offset,
                     )
@@ -2803,6 +2826,7 @@ class LithosServer:
             since: str | None = None,
             resolved_since: str | None = None,
             with_claims: bool = False,
+            metadata_match: dict | None = None,
         ) -> dict[str, list[dict[str, Any]]]:
             """List tasks with optional filters.
 
@@ -2810,6 +2834,10 @@ class LithosServer:
                 agent: Filter by creating agent
                 status: Filter by status: "open", "completed", or "cancelled" (None = all)
                 tags: Filter by tags (task must have all specified tags)
+                metadata_match: Filter by metadata (AND across keys). For each
+                    ``key: q`` a task matches when its stored metadata value
+                    equals ``q`` or is a list containing ``q``. Query values must
+                    be scalars (string/number/boolean); type-sensitive.
                 since: Filter by created_at >= this ISO datetime string (e.g. "2024-01-01T00:00:00Z")
                 resolved_since: Filter by resolved_at >= this ISO datetime string.
                     ``resolved_at`` is set on both terminal transitions (complete
@@ -2847,6 +2875,12 @@ class LithosServer:
                     span.set_attribute("lithos.status", status)
                 span.set_attribute("lithos.with_claims", with_claims)
 
+                if metadata_match is not None:
+                    try:
+                        validate_metadata_match(metadata_match)
+                    except ValueError as e:
+                        return {"status": "invalid_input", "message": str(e), "warnings": []}  # type: ignore[return-value]
+
                 tasks = await self.coordination.list_tasks(
                     agent=agent,
                     status=status,
@@ -2854,6 +2888,7 @@ class LithosServer:
                     since=since,
                     resolved_since=resolved_since,
                     with_claims=with_claims,
+                    metadata_match=metadata_match,
                 )
                 return {"tasks": tasks}
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1987,6 +1987,14 @@ class LithosServer:
                     # metadata cache / inverted index so we don't incur a disk
                     # read per candidate. ``meta_candidates`` is None when no
                     # metadata filter is requested.
+                    #
+                    # Like ``since``/``title_contains``, ``metadata_match`` is a
+                    # post-rank filter here: metadata isn't a Tantivy field, so
+                    # it can't be pushed into the query the way tags/author/
+                    # path_prefix are (#194). It runs against the full ranked
+                    # window (cap = _CONTENT_QUERY_FTS_CAP = 1e6), so a match is
+                    # only ever dropped if >1e6 docs match content_query — the
+                    # same bound the other two post-filters already accept.
                     meta_candidates = self.knowledge.metadata_candidate_ids(metadata_match)
                     matching_ids: list[str] = []
                     for r in fts_results:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -752,6 +752,78 @@ class TestFindings:
         assert findings[0].summary == "New finding"
 
 
+class TestListTasksMetadataMatch:
+    """Tests for list_tasks metadata_match filtering via SQL pushdown (#306)."""
+
+    @pytest.mark.asyncio
+    async def test_scalar_match(self, coordination_service: CoordinationService):
+        t1 = await coordination_service.create_task(
+            title="A", agent="agent", metadata={"priority": "high"}
+        )
+        await coordination_service.create_task(
+            title="B", agent="agent", metadata={"priority": "low"}
+        )
+        tasks = await coordination_service.list_tasks(metadata_match={"priority": "high"})
+        assert [t["id"] for t in tasks] == [t1]
+
+    @pytest.mark.asyncio
+    async def test_no_match(self, coordination_service: CoordinationService):
+        await coordination_service.create_task(title="A", agent="agent", metadata={"k": "v"})
+        assert await coordination_service.list_tasks(metadata_match={"k": "other"}) == []
+        assert await coordination_service.list_tasks(metadata_match={"missing": "x"}) == []
+
+    @pytest.mark.asyncio
+    async def test_multi_key_and(self, coordination_service: CoordinationService):
+        t1 = await coordination_service.create_task(
+            title="A", agent="agent", metadata={"repo": "x", "watch": True}
+        )
+        await coordination_service.create_task(
+            title="B", agent="agent", metadata={"repo": "x", "watch": False}
+        )
+        tasks = await coordination_service.list_tasks(metadata_match={"repo": "x", "watch": True})
+        assert [t["id"] for t in tasks] == [t1]
+
+    @pytest.mark.asyncio
+    async def test_type_fidelity(self, coordination_service: CoordinationService):
+        await coordination_service.create_task(title="A", agent="agent", metadata={"n": 3})
+        assert len(await coordination_service.list_tasks(metadata_match={"n": 3})) == 1
+        assert await coordination_service.list_tasks(metadata_match={"n": "3"}) == []
+
+    @pytest.mark.asyncio
+    async def test_list_contains(self, coordination_service: CoordinationService):
+        t1 = await coordination_service.create_task(
+            title="A", agent="agent", metadata={"github_repos": ["org/a", "org/b"]}
+        )
+        await coordination_service.create_task(
+            title="B", agent="agent", metadata={"github_repos": ["org/c"]}
+        )
+        hit = await coordination_service.list_tasks(metadata_match={"github_repos": "org/a"})
+        assert [t["id"] for t in hit] == [t1]
+        assert await coordination_service.list_tasks(metadata_match={"github_repos": "org/z"}) == []
+
+    @pytest.mark.asyncio
+    async def test_composes_with_status_filter(self, coordination_service: CoordinationService):
+        t1 = await coordination_service.create_task(
+            title="A", agent="agent", metadata={"team": "x"}
+        )
+        t2 = await coordination_service.create_task(
+            title="B", agent="agent", metadata={"team": "x"}
+        )
+        await coordination_service.complete_task(t2, agent="agent", outcome="done")
+        tasks = await coordination_service.list_tasks(status="open", metadata_match={"team": "x"})
+        assert [t["id"] for t in tasks] == [t1]
+
+    @pytest.mark.asyncio
+    async def test_injection_style_key_is_inert(self, coordination_service: CoordinationService):
+        await coordination_service.create_task(title="A", agent="agent", metadata={"k": "v"})
+        # A key crafted to look like SQL/JSON-path injection is bound as a
+        # parameter, so it simply addresses a (nonexistent) key → no match,
+        # and the table is intact afterwards.
+        evil = '") = 1 OR "1"=("1'
+        assert await coordination_service.list_tasks(metadata_match={evil: "v"}) == []
+        assert len(await coordination_service.list_tasks()) == 1
+
+
 class TestListTasks:
     """Tests for list_tasks filtering."""
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -802,6 +802,32 @@ class TestListTasksMetadataMatch:
         assert await coordination_service.list_tasks(metadata_match={"github_repos": "org/z"}) == []
 
     @pytest.mark.asyncio
+    async def test_bool_not_matched_by_int(self, coordination_service: CoordinationService):
+        """Type-sensitive: a stored JSON bool must not match an int query (and
+        vice versa), even though SQLite stores booleans as 1/0."""
+        bool_task = await coordination_service.create_task(
+            title="bool", agent="agent", metadata={"watch": True}
+        )
+        int_task = await coordination_service.create_task(
+            title="int", agent="agent", metadata={"watch": 1}
+        )
+        by_true = await coordination_service.list_tasks(metadata_match={"watch": True})
+        by_one = await coordination_service.list_tasks(metadata_match={"watch": 1})
+        assert [t["id"] for t in by_true] == [bool_task]
+        assert [t["id"] for t in by_one] == [int_task]
+
+    @pytest.mark.asyncio
+    async def test_object_value_not_matched_by_contains(
+        self, coordination_service: CoordinationService
+    ):
+        """A stored JSON object must not be treated as a 'contains' collection —
+        only arrays are iterated."""
+        await coordination_service.create_task(
+            title="obj", agent="agent", metadata={"repos": {"nested": "org/a"}}
+        )
+        assert await coordination_service.list_tasks(metadata_match={"repos": "org/a"}) == []
+
+    @pytest.mark.asyncio
     async def test_composes_with_status_filter(self, coordination_service: CoordinationService):
         t1 = await coordination_service.create_task(
             title="A", agent="agent", metadata={"team": "x"}

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -796,6 +796,60 @@ class TestUpdateSemantics:
         assert read["metadata"]["extra"] == {}
 
 
+class TestMetadataMatchFilterConformance:
+    """metadata_match filtering round-trips across the real MCP boundary (#306)."""
+
+    @pytest.mark.asyncio
+    async def test_list_filter_scalar_and_list_contains(self, server: LithosServer):
+        multi = await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Kindred Code",
+                "content": "Project context.",
+                "agent": "a",
+                "path": "projects",
+                "metadata": {"github_repos": ["org/a", "org/b"], "watch": True},
+            },
+        )
+        await _call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Other Project",
+                "content": "ctx",
+                "agent": "a",
+                "path": "projects",
+                "metadata": {"github_repos": ["org/c"], "watch": False},
+            },
+        )
+
+        # list-contains by a single repo
+        res = await _call_tool(server, "lithos_list", {"metadata_match": {"github_repos": "org/a"}})
+        assert [i["id"] for i in res["items"]] == [multi["id"]]
+
+        # multi-key AND (list-contains + scalar bool)
+        res = await _call_tool(
+            server, "lithos_list", {"metadata_match": {"github_repos": "org/b", "watch": True}}
+        )
+        assert [i["id"] for i in res["items"]] == [multi["id"]]
+
+        # no match
+        res = await _call_tool(server, "lithos_list", {"metadata_match": {"github_repos": "org/z"}})
+        assert res["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_task_list_filter(self, server: LithosServer):
+        t = await _call_tool(
+            server, "lithos_task_create", {"title": "A", "agent": "a", "metadata": {"team": "x"}}
+        )
+        await _call_tool(
+            server, "lithos_task_create", {"title": "B", "agent": "a", "metadata": {"team": "y"}}
+        )
+        res = await _call_tool(server, "lithos_task_list", {"metadata_match": {"team": "x"}})
+        assert [task["id"] for task in res["tasks"]] == [t["task_id"]]
+
+
 class TestGraphEdgeConsistency:
     """Tests for graph edge correctness through the MCP write pipeline."""
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -950,6 +950,154 @@ class TestDocumentMetadata:
         assert parsed["github_repo"] == "owner/name"
 
 
+class _CountingDict(dict):
+    """dict that counts full iterations, to prove the index path avoids a scan."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.iter_count = 0
+
+    def items(self):  # type: ignore[override]
+        self.iter_count += 1
+        return super().items()
+
+    def __iter__(self):
+        self.iter_count += 1
+        return super().__iter__()
+
+
+class TestMetadataFiltering:
+    """Tests for metadata_match filtering on list_all via the inverted index (#306)."""
+
+    async def _mk(self, km: KnowledgeManager, title: str, **kw) -> str:
+        return (await km.create(title=title, content="Body.", agent="agent", **kw)).document.id
+
+    @pytest.mark.asyncio
+    async def test_scalar_equality_match(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", extra={"github_repo": "org/a"})
+        await self._mk(knowledge_manager, "B", extra={"github_repo": "org/b"})
+        docs, total = await knowledge_manager.list_all(metadata_match={"github_repo": "org/a"})
+        assert total == 1
+        assert [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, knowledge_manager: KnowledgeManager):
+        await self._mk(knowledge_manager, "A", extra={"k": "v"})
+        docs, total = await knowledge_manager.list_all(metadata_match={"k": "other"})
+        assert total == 0
+        assert docs == []
+        # Absent key also yields empty (short-circuit).
+        _, total2 = await knowledge_manager.list_all(metadata_match={"missing": "x"})
+        assert total2 == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_key_and(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", extra={"repo": "x", "watch": True})
+        await self._mk(knowledge_manager, "B", extra={"repo": "x", "watch": False})
+        docs, total = await knowledge_manager.list_all(metadata_match={"repo": "x", "watch": True})
+        assert total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_type_sensitive(self, knowledge_manager: KnowledgeManager):
+        await self._mk(knowledge_manager, "A", extra={"n": 3})
+        # int 3 matches; string "3" does not.
+        _, hit = await knowledge_manager.list_all(metadata_match={"n": 3})
+        _, miss = await knowledge_manager.list_all(metadata_match={"n": "3"})
+        assert hit == 1 and miss == 0
+
+    @pytest.mark.asyncio
+    async def test_list_valued_contains(self, knowledge_manager: KnowledgeManager):
+        multi = await self._mk(
+            knowledge_manager, "Multi", extra={"github_repos": ["org/a", "org/b"]}
+        )
+        scalar = await self._mk(knowledge_manager, "Scalar", extra={"github_repos": "org/a"})
+        # "org/a" matches both the list-containing doc and the scalar doc.
+        docs, total = await knowledge_manager.list_all(metadata_match={"github_repos": "org/a"})
+        assert total == 2 and {d.id for d in docs} == {multi, scalar}
+        # "org/b" matches only the list doc; "org/c" matches nothing.
+        _, only_b = await knowledge_manager.list_all(metadata_match={"github_repos": "org/b"})
+        _, none = await knowledge_manager.list_all(metadata_match={"github_repos": "org/c"})
+        assert only_b == 1 and none == 0
+
+    @pytest.mark.asyncio
+    async def test_combined_with_path_prefix(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", path="projects", extra={"k": "v"})
+        await self._mk(knowledge_manager, "B", path="other", extra={"k": "v"})
+        docs, total = await knowledge_manager.list_all(
+            metadata_match={"k": "v"}, path_prefix="projects"
+        )
+        assert total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_update_rebuckets_value(self, knowledge_manager: KnowledgeManager):
+        doc_id = await self._mk(knowledge_manager, "A", extra={"repo": "x"})
+        await knowledge_manager.update(id=doc_id, agent="ed", extra={"repo": "y"})
+        _, old = await knowledge_manager.list_all(metadata_match={"repo": "x"})
+        _, new = await knowledge_manager.list_all(metadata_match={"repo": "y"})
+        assert old == 0 and new == 1
+
+    @pytest.mark.asyncio
+    async def test_update_list_add_remove_element(self, knowledge_manager: KnowledgeManager):
+        doc_id = await self._mk(knowledge_manager, "A", extra={"repos": ["a", "b"]})
+        await knowledge_manager.update(id=doc_id, agent="ed", extra={"repos": ["b", "c"]})
+        _, gone = await knowledge_manager.list_all(metadata_match={"repos": "a"})
+        _, kept = await knowledge_manager.list_all(metadata_match={"repos": "b"})
+        _, added = await knowledge_manager.list_all(metadata_match={"repos": "c"})
+        assert gone == 0 and kept == 1 and added == 1
+
+    @pytest.mark.asyncio
+    async def test_clear_and_delete_deindex(self, knowledge_manager: KnowledgeManager):
+        clear_id = await self._mk(knowledge_manager, "Clear", extra={"k": "v"})
+        del_id = await self._mk(knowledge_manager, "Del", extra={"k": "v"})
+        await knowledge_manager.update(id=clear_id, agent="ed", extra={})
+        await knowledge_manager.delete(del_id)
+        _, total = await knowledge_manager.list_all(metadata_match={"k": "v"})
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_index_correct_after_rescan(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", extra={"github_repos": ["a", "b"]})
+        # Rebuild all in-memory indexes from disk.
+        knowledge_manager.rescan()
+        docs, total = await knowledge_manager.list_all(metadata_match={"github_repos": "a"})
+        assert total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_pagination_stable_and_ordered(self, knowledge_manager: KnowledgeManager):
+        ids = [await self._mk(knowledge_manager, f"D{i}", extra={"k": "v"}) for i in range(5)]
+        page1, total = await knowledge_manager.list_all(
+            metadata_match={"k": "v"}, limit=2, offset=0
+        )
+        page2, _ = await knowledge_manager.list_all(metadata_match={"k": "v"}, limit=2, offset=2)
+        page3, _ = await knowledge_manager.list_all(metadata_match={"k": "v"}, limit=2, offset=4)
+        assert total == 5
+        got = [d.id for d in page1] + [d.id for d in page2] + [d.id for d in page3]
+        assert got == ids  # insertion order, disjoint, complete
+
+    @pytest.mark.asyncio
+    async def test_filtered_query_does_not_scan_cache(self, knowledge_manager: KnowledgeManager):
+        """Efficiency proof: an equality-filtered list_all never iterates _meta_cache."""
+        for i in range(10):
+            await self._mk(knowledge_manager, f"D{i}", extra={"k": "v" if i == 0 else "w"})
+        counting = _CountingDict(knowledge_manager._meta_cache)
+        knowledge_manager._meta_cache = counting
+
+        counting.iter_count = 0
+        _, total = await knowledge_manager.list_all(metadata_match={"k": "v"})
+        assert total == 1
+        assert counting.iter_count == 0  # resolved via index, no full scan
+
+        # A tag filter is also index-backed.
+        counting.iter_count = 0
+        await knowledge_manager.list_all(tags=["nonexistent"])
+        assert counting.iter_count == 0
+
+        # An unfiltered list legitimately scans (sanity check the probe works).
+        counting.iter_count = 0
+        await knowledge_manager.list_all()
+        assert counting.iter_count >= 1
+
+
 class TestDocumentPersistence:
     """Tests for document file persistence."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2622,6 +2622,69 @@ class TestDocumentMetadataTool:
         assert result["status"] == "version_conflict"
 
 
+class TestMetadataMatchFilterTool:
+    """Tool-layer tests for metadata_match on lithos_list and lithos_task_list (#306)."""
+
+    async def _write(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_write")).fn(**kwargs)
+
+    async def _list(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_list")).fn(**kwargs)
+
+    async def _task_create(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_task_create")).fn(**kwargs)
+
+    async def _task_list(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_task_list")).fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_list_metadata_match_scalar_and_list(self, server: LithosServer):
+        m = await self._write(
+            server,
+            title="Multi",
+            content="b",
+            agent="a",
+            path="projects",
+            metadata={"github_repos": ["org/a", "org/b"]},
+        )
+        await self._write(
+            server,
+            title="Other",
+            content="b",
+            agent="a",
+            path="projects",
+            metadata={"github_repos": ["org/c"]},
+        )
+        res = await self._list(server, metadata_match={"github_repos": "org/a"})
+        assert [i["id"] for i in res["items"]] == [m["id"]]
+        assert res["items"][0]["metadata"] == {"github_repos": ["org/a", "org/b"]}
+        # no match
+        res2 = await self._list(server, metadata_match={"github_repos": "org/z"})
+        assert res2["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_invalid_metadata_match(self, server: LithosServer):
+        assert (await self._list(server, metadata_match=["not", "dict"]))["status"] == (
+            "invalid_input"
+        )
+        assert (await self._list(server, metadata_match={"k": ["list", "val"]}))["status"] == (
+            "invalid_input"
+        )
+        assert (await self._list(server, metadata_match={"": "v"}))["status"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_task_list_metadata_match(self, server: LithosServer):
+        t = await self._task_create(server, title="A", agent="a", metadata={"team": "x"})
+        await self._task_create(server, title="B", agent="a", metadata={"team": "y"})
+        res = await self._task_list(server, metadata_match={"team": "x"})
+        assert [t2["id"] for t2 in res["tasks"]] == [t["task_id"]]
+
+    @pytest.mark.asyncio
+    async def test_task_list_invalid_metadata_match(self, server: LithosServer):
+        res = await self._task_list(server, metadata_match={"k": None})
+        assert res["status"] == "invalid_input"
+
+
 class TestTaskMetadataTool:
     """Tests for metadata field in lithos_task_create, lithos_task_update, lithos_task_list, lithos_task_status (#215)."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2663,6 +2663,34 @@ class TestMetadataMatchFilterTool:
         assert res2["total"] == 0
 
     @pytest.mark.asyncio
+    async def test_content_query_combined_with_metadata_match(self, server: LithosServer):
+        """content_query + metadata_match: the metadata candidate set is
+        intersected with the FTS hits, so only docs matching both survive.
+        Mirrors the since/title_contains post-filter on this path (#306)."""
+        keep = (
+            await server.knowledge.create(
+                title="Keep", content="payload", agent="agent", extra={"team": "x"}
+            )
+        ).document
+        drop = (
+            await server.knowledge.create(
+                title="Drop", content="payload", agent="agent", extra={"team": "y"}
+            )
+        ).document
+
+        # Both rank for the content query; metadata_match must drop "Drop".
+        hits = [SimpleNamespace(id=keep.id), SimpleNamespace(id=drop.id)]
+        tool = await server.mcp.get_tool("lithos_list")
+        with patch.object(server.search, "full_text_search", return_value=hits):
+            r = await tool.fn(content_query="payload", metadata_match={"team": "x"})
+        assert {i["id"] for i in r["items"]} == {keep.id}
+
+        # No metadata match → empty, even though both are FTS hits.
+        with patch.object(server.search, "full_text_search", return_value=hits):
+            r = await tool.fn(content_query="payload", metadata_match={"team": "z"})
+        assert r["total"] == 0
+
+    @pytest.mark.asyncio
     async def test_list_invalid_metadata_match(self, server: LithosServer):
         assert (await self._list(server, metadata_match=["not", "dict"]))["status"] == (
             "invalid_input"


### PR DESCRIPTION
## Summary

Part B of #305: adds a symmetric `metadata_match: dict` filter to **`lithos_list`** and **`lithos_task_list`**, so consumers can query the free-form metadata that Part A (#307) made writable. Closes #306.

Per the efficiency requirement, **neither surface scans the whole database** — the filter is index-backed on both.

## Filter semantics (identical on both surfaces)

- AND across keys: a record must match every `key: q`.
- Per key, a record matches when its stored value **equals `q`** or **is a list containing `q`** — so list-valued metadata is supported from day one (a project doc with `github_repos: ["org/a","org/b"]` is found by `metadata_match={"github_repos": "org/a"}`).
- Query values must be JSON scalars (string/number/boolean); `null`/list/dict query values → `invalid_input`. Matching is type-sensitive (`"1"` ≠ `1`).

## How it stays efficient

**Knowledge (`lithos_list`)** — in-memory inverted indexes maintained beside `_meta_cache` (the metadata is already in RAM, feeding hot LCMA retrieval; SQLite would be a parallel store). Equality filters (`tags`/`author`/`metadata_match`) resolve to a candidate set via hash lookup + smallest-first intersection; `path_prefix`/`since` then refine only those candidates. Falls back to the existing scan only when no equality filter is supplied — which also makes the pre-existing `tags`/`author` filters sub-linear. `_CachedMeta` gained `extra` (no disk read to filter) and `seq` (insertion ordinal → stable ordering/pagination in the index path).

**Tasks (`lithos_task_list`)** — pushes the predicate into SQLite: `json_extract(metadata, ?) = ? OR EXISTS (SELECT 1 FROM json_each(metadata, ?) WHERE value = ?)`. Engine-evaluated (no Python post-scan), composes with `idx_tasks_status`. The JSON path and value are **bound parameters**, so caller keys can't inject SQL.

## Design decisions (agreed before implementation)

- In-memory inverted index for knowledge (not SQLite) — fits the in-RAM knowledge layer; SQLite stays right for SQL-native tasks. The symmetry is the filter *shape*.
- Generalized the index to also de-O(N) the existing `tags`/`author` equality filters.
- List-valued metadata (contains-or-equals) supported from the start.

## Docs

- `docs/SPECIFICATION.md`: free-form `metadata` in the frontmatter format, `metadata` param on `lithos_write` (backfilling #307), and `metadata_match` + filter semantics on both list tools.
- `CHANGELOG.md` (both the #305 set capability and the #306 filter), `README.md` feature bullet, `docs/plans/unified-write-contract.md`.

## Test plan

- [x] **Knowledge filtering** (12): scalar/list-contains/multi-key-AND/no-match/type-sensitivity/path_prefix combo/update re-bucketing/clear+delete de-index/rescan correctness/pagination stability.
- [x] **Efficiency proof** (white-box): wraps `_meta_cache` in a counter; asserts a `metadata_match` (and `tags`) query performs **zero** full iterations, while an unfiltered list does iterate.
- [x] **Task SQL filter** (7): scalar/multi-key/type-fidelity/list-contains/status composition/`with_claims`/injection-inert.
- [x] **Tool-layer** (4) + **MCP-boundary conformance** (2) for both surfaces, incl. `invalid_input`.
- [x] `make check` (ruff + pyright 0 errors + **1235 unit**) and `make test-integration` (**379**) green.

Closes #306.
