### PR TITLE
fix: heal non-numeric confidence on read, validate on write (closes #312)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -252,9 +252,10 @@ tags:                             # Optional: List of tags
   - <tag1>
   - <tag2>
 confidence: <float 0-1>           # Optional: Confidence score (default: 1.0).
-                                  # Normalized on read: non-numeric values
-                                  # (null, strings, bool) fall back to 1.0;
-                                  # out-of-range numbers clamp to [0.0, 1.0].
+                                  # Normalized on read: non-numeric (null,
+                                  # strings, bool) and non-finite (.nan/.inf)
+                                  # values fall back to 1.0; out-of-range
+                                  # finite numbers clamp to [0.0, 1.0].
 aliases:                          # Optional: Alternative names (Obsidian compatible)
   - <alias1>
 source: <string>                  # Optional: Task ID or provenance note
@@ -414,7 +415,7 @@ Parameters are flat at the MCP boundary but grouped below by role to aid discove
 | `id` | string | No | UUID to update existing; omit to create new |
 | `tags` | string[] | No | List of tags |
 | `metadata` | object | No | Free-form key/value metadata persisted to frontmatter (#305). Values may be arbitrary JSON-compatible values. On update: omit/`null` preserves; `{}` clears; a non-empty dict is an additive per-key merge (a key whose value is `null` deletes it). Keys must be strings and must not collide with reserved frontmatter fields, else `status="invalid_input"`. Returned by `lithos_read` (as `metadata.extra`) and `lithos_list` (as each item's `metadata`), and filterable via `lithos_list(metadata_match=...)`. |
-| `confidence` | float | No | Confidence score 0-1 (default: 1.0). Integers are accepted and coerced to float; non-numeric or out-of-range values return `status="invalid_input"`. |
+| `confidence` | float | No | Confidence score 0-1 (default: 1.0). Integers are accepted and coerced to float; anything else that is not a finite number in [0.0, 1.0] — non-numeric values, bool, NaN/inf, or out-of-range numbers — returns `status="invalid_input"`. |
 | `path` | string | No | Either a subdirectory (e.g. `"procedures"`) under which the filename is derived from `title` (slugified) and `.md` appended, OR a full relative file path ending in `.md` (e.g. `"procedures/my-doc.md"`) used verbatim as the filename. Intermediate path segments may not end in `.md` — such inputs return `status="invalid_input"`. Paths that resolve to an already-owned file return `status="path_collision"`. |
 
 *Provenance:*

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -251,7 +251,10 @@ contributors:                     # Optional: List of agents who edited
 tags:                             # Optional: List of tags
   - <tag1>
   - <tag2>
-confidence: <float 0-1>           # Optional: Confidence score (default: 1.0)
+confidence: <float 0-1>           # Optional: Confidence score (default: 1.0).
+                                  # Normalized on read: non-numeric values
+                                  # (null, strings, bool) fall back to 1.0;
+                                  # out-of-range numbers clamp to [0.0, 1.0].
 aliases:                          # Optional: Alternative names (Obsidian compatible)
   - <alias1>
 source: <string>                  # Optional: Task ID or provenance note
@@ -411,7 +414,7 @@ Parameters are flat at the MCP boundary but grouped below by role to aid discove
 | `id` | string | No | UUID to update existing; omit to create new |
 | `tags` | string[] | No | List of tags |
 | `metadata` | object | No | Free-form key/value metadata persisted to frontmatter (#305). Values may be arbitrary JSON-compatible values. On update: omit/`null` preserves; `{}` clears; a non-empty dict is an additive per-key merge (a key whose value is `null` deletes it). Keys must be strings and must not collide with reserved frontmatter fields, else `status="invalid_input"`. Returned by `lithos_read` (as `metadata.extra`) and `lithos_list` (as each item's `metadata`), and filterable via `lithos_list(metadata_match=...)`. |
-| `confidence` | float | No | Confidence score 0-1 (default: 1.0) |
+| `confidence` | float | No | Confidence score 0-1 (default: 1.0). Integers are accepted and coerced to float; non-numeric or out-of-range values return `status="invalid_input"`. |
 | `path` | string | No | Either a subdirectory (e.g. `"procedures"`) under which the filename is derived from `title` (slugified) and `.md` appended, OR a full relative file path ending in `.md` (e.g. `"procedures/my-doc.md"`) used verbatim as the filename. Intermediate path segments may not end in `.md` — such inputs return `status="invalid_input"`. Paths that resolve to an already-owned file return `status="path_collision"`. |
 
 *Provenance:*

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import re
 import tempfile
@@ -72,6 +73,46 @@ def _parse_version(value: object) -> int:
             parsed,
         )
         return 1
+    return parsed
+
+
+def _parse_confidence(value: object) -> float:
+    """Parse a confidence value from frontmatter, falling back to 1.0 on bad input (#312).
+
+    ``dict.get("confidence", 1.0)`` only applies the default when the key is
+    absent; a key present with ``null`` (or a string) would otherwise load as-is
+    and crash numeric comparisons downstream (e.g. ``cache_lookup``).
+    """
+    # bool is an int subclass: float(False) would silently become 0.0 and
+    # filter the doc out of every lookup, so treat it as non-numeric noise.
+    if isinstance(value, bool):
+        logger.warning(
+            "_parse_confidence: non-numeric confidence value %r in frontmatter; defaulting to 1.0",
+            value,
+        )
+        return 1.0
+    try:
+        parsed = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning(
+            "_parse_confidence: non-numeric confidence value %r in frontmatter; defaulting to 1.0",
+            value,
+        )
+        return 1.0
+    if math.isnan(parsed) or math.isinf(parsed):
+        logger.warning(
+            "_parse_confidence: non-finite confidence value %r in frontmatter; defaulting to 1.0",
+            value,
+        )
+        return 1.0
+    if not 0.0 <= parsed <= 1.0:
+        clamped = min(max(parsed, 0.0), 1.0)
+        logger.warning(
+            "_parse_confidence: out-of-range confidence value %r in frontmatter; clamping to %s",
+            parsed,
+            clamped,
+        )
+        return clamped
     return parsed
 
 
@@ -144,6 +185,25 @@ def validate_extra_metadata(extra: dict) -> None:
             f"metadata keys collide with reserved frontmatter fields: {reserved}. "
             "Choose different keys."
         )
+
+
+def validate_confidence(value: object) -> float:
+    """Validate a confidence value at the write boundary (#312).
+
+    Stricter than the read-side ``_parse_confidence``: writes fail fast with
+    ``ValueError`` instead of healing, so ``null``/string values can never be
+    persisted again. Integers are accepted and coerced (integer JSON over the
+    MCP wire); bool is rejected because it is an ``int`` subclass, not a score.
+
+    Raises:
+        ValueError: if ``value`` is not a finite number in [0.0, 1.0].
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"confidence must be a number between 0.0 and 1.0, got {value!r}")
+    parsed = float(value)
+    if math.isnan(parsed) or math.isinf(parsed) or not 0.0 <= parsed <= 1.0:
+        raise ValueError(f"confidence must be a number between 0.0 and 1.0, got {value!r}")
+    return parsed
 
 
 # Scalar JSON types accepted as metadata_match *query* values (#306).
@@ -460,7 +520,7 @@ class KnowledgeMetadata:
             updated_at=updated_at,
             tags=data.get("tags", []),
             aliases=data.get("aliases", []),
-            confidence=data.get("confidence", 1.0),
+            confidence=_parse_confidence(data.get("confidence", 1.0)),
             contributors=data.get("contributors", []),
             source=data.get("source"),
             source_url=data.get("source_url"),
@@ -1142,7 +1202,7 @@ class KnowledgeManager:
         content: str,
         agent: str,
         tags: list[str] | None = None,
-        confidence: float = 1.0,
+        confidence: float | None = None,
         path: str | None = None,
         source: str | None = None,
         source_url: str | None = None,
@@ -1158,6 +1218,12 @@ class KnowledgeManager:
     ) -> WriteResult:
         """Create a new knowledge document.
 
+        ``confidence=None`` means "not provided" and applies the default 1.0 —
+        MCP callers omit the field as ``null``. Anything else must be a finite
+        number in [0.0, 1.0] or the write is rejected (#312); previously a
+        ``None`` here was persisted as ``confidence: null`` in frontmatter,
+        which poisoned every later read.
+
         ``extra`` is free-form key/value metadata persisted into the
         document's frontmatter via ``KnowledgeMetadata.extra`` (#305).
 
@@ -1165,6 +1231,12 @@ class KnowledgeManager:
         """
         async with self._write_lock:
             lithos_metrics.knowledge_ops.add(1, {"op": "create"})
+
+            # Reject invalid confidence before anything is persisted (#312).
+            try:
+                confidence = 1.0 if confidence is None else validate_confidence(confidence)
+            except ValueError as e:
+                return WriteResult(status="invalid_input", message=str(e))
 
             # Validate and normalize source_url
             norm_url: str | None = None
@@ -1542,6 +1614,15 @@ class KnowledgeManager:
             if not isinstance(extra, _UnsetType) and extra:
                 try:
                     validate_extra_metadata(extra)
+                except ValueError as e:
+                    return WriteResult(status="invalid_input", message=str(e))
+
+            # Reject invalid confidence before any in-memory metadata mutation —
+            # update() mutates the cached doc, so a late rejection would leave a
+            # poisoned in-memory document (#312).
+            if not isinstance(confidence, _UnsetType):
+                try:
+                    confidence = validate_confidence(confidence)
                 except ValueError as e:
                     return WriteResult(status="invalid_input", message=str(e))
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1043,8 +1043,9 @@ class LithosServer:
                     tags, version) — such writes are rejected as invalid_input.
                 confidence: Confidence score 0-1 (default: 1.0 on create). On update:
                     null/omit preserves existing; float sets new value. Integers
-                    are coerced to float; non-numeric or out-of-range values are
-                    rejected as invalid_input.
+                    are coerced to float; anything else that is not a finite
+                    number in [0.0, 1.0] (non-numeric, bool, NaN/inf, or
+                    out-of-range) is rejected as invalid_input.
                 path: Where to store the note. Two accepted forms:
                     - Subdirectory (e.g., "procedures") — the filename is derived
                       from the title (slugified) and ".md" is appended.

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1042,7 +1042,9 @@ class LithosServer:
                     must not collide with reserved frontmatter fields (e.g. title,
                     tags, version) — such writes are rejected as invalid_input.
                 confidence: Confidence score 0-1 (default: 1.0 on create). On update:
-                    null/omit preserves existing; float sets new value.
+                    null/omit preserves existing; float sets new value. Integers
+                    are coerced to float; non-numeric or out-of-range values are
+                    rejected as invalid_input.
                 path: Where to store the note. Two accepted forms:
                     - Subdirectory (e.g., "procedures") — the filename is derived
                       from the title (slugified) and ".md" is appended.

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -1170,6 +1170,62 @@ class TestCacheLookupHitPath:
         assert result["hit"] is True
         assert result["document"]["id"] == doc.id
 
+    async def _write_poisoned_doc(
+        self,
+        real_memory: CognitiveMemory,
+        test_config: LithosConfig,
+        *,
+        confidence_yaml: str,
+    ) -> None:
+        """Write a raw .md with a poisoned confidence value, then load + index it.
+
+        Simulates a legacy doc persisted before write-side validation existed
+        (#312) — write validation cannot prevent these, so reads must heal them.
+        """
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        raw = textwrap.dedent(f"""\
+            ---
+            id: poisoned-doc
+            title: Quantum Computing Notes
+            author: lithos-enrich
+            created_at: '{now}'
+            updated_at: '{now}'
+            tags: [research]
+            confidence: {confidence_yaml}
+            ---
+
+            # Quantum Computing Notes
+
+            Information about quantum computing.
+            """)
+        path = Path("poisoned-doc.md")
+        (test_config.storage.knowledge_path / path).write_text(raw)
+        doc = await real_memory._knowledge.sync_from_disk(path)
+        real_memory._search.index(KnowledgeManager.to_indexable(doc))
+
+    async def test_null_confidence_frontmatter_does_not_crash_lookup(
+        self, real_memory: CognitiveMemory, test_config: LithosConfig
+    ) -> None:
+        """Regression for #312: a candidate doc with ``confidence: null`` must not
+        abort the lookup with TypeError; it heals to the default 1.0."""
+        await self._write_poisoned_doc(real_memory, test_config, confidence_yaml="null")
+
+        result = await real_memory.cache_lookup(query="quantum computing")
+        assert result["hit"] is True
+        assert result["document"]["confidence"] == 1.0
+
+    async def test_string_confidence_frontmatter_does_not_crash_lookup(
+        self, real_memory: CognitiveMemory, test_config: LithosConfig
+    ) -> None:
+        """Regression for #312: a non-numeric string confidence heals to 1.0."""
+        await self._write_poisoned_doc(real_memory, test_config, confidence_yaml="medium")
+
+        result = await real_memory.cache_lookup(query="quantum computing")
+        assert result["hit"] is True
+        assert result["document"]["confidence"] == 1.0
+
 
 class TestConflictResolve:
     """Routing and persistence checks for the migrated ``conflict_resolve``."""

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -2000,6 +2000,194 @@ class TestUpdateTagsConfidenceSentinel:
         assert result.document.metadata.confidence == pytest.approx(0.9)
 
 
+class TestConfidenceParsing:
+    """Tests for issue #312: from_dict() heals missing/null/non-numeric confidence."""
+
+    def _meta(self, **extra_fields) -> KnowledgeMetadata:
+        data = {"id": "test-id", "title": "Test", "author": "agent", **extra_fields}
+        return KnowledgeMetadata.from_dict(data)
+
+    def test_from_dict_missing_confidence_defaults_to_one(self):
+        """Absent confidence key defaults to 1.0."""
+        meta = self._meta()
+        assert meta.confidence == 1.0
+
+    def test_from_dict_null_confidence_defaults_to_one(self):
+        """Present-but-null confidence (confidence: null in YAML) defaults to 1.0 (#312)."""
+        meta = self._meta(confidence=None)
+        assert meta.confidence == 1.0
+
+    def test_from_dict_string_confidence_defaults_to_one(self, caplog):
+        """Non-numeric string confidence falls back to 1.0 with a warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="lithos.knowledge"):
+            meta = self._meta(confidence="medium")
+        assert meta.confidence == 1.0
+        assert "confidence" in caplog.text
+
+    def test_from_dict_numeric_string_confidence_parses(self):
+        """Numeric string confidence parses to its float value."""
+        meta = self._meta(confidence="0.8")
+        assert meta.confidence == pytest.approx(0.8)
+
+    def test_from_dict_int_confidence_coerces_to_float(self):
+        """Integer confidence coerces to float."""
+        meta = self._meta(confidence=1)
+        assert meta.confidence == 1.0
+        assert isinstance(meta.confidence, float)
+
+    def test_from_dict_bool_confidence_defaults_to_one(self):
+        """Bool confidence is invalid, not coerced (False would silently become 0.0)."""
+        meta = self._meta(confidence=False)
+        assert meta.confidence == 1.0
+
+    def test_from_dict_out_of_range_confidence_clamped(self):
+        """Out-of-range finite floats clamp into [0.0, 1.0]."""
+        assert self._meta(confidence=1.5).confidence == 1.0
+        assert self._meta(confidence=-0.2).confidence == 0.0
+
+    def test_from_dict_nan_confidence_defaults_to_one(self):
+        """NaN confidence falls back to 1.0 (clamping cannot fix NaN)."""
+        meta = self._meta(confidence=float("nan"))
+        assert meta.confidence == 1.0
+
+
+class TestConfidenceWriteValidation:
+    """Tests for issue #312: create()/update() reject invalid confidence values."""
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_out_of_range_confidence(
+        self, knowledge_manager: KnowledgeManager, test_config
+    ):
+        """create() with out-of-range confidence returns invalid_input, writes nothing."""
+        result = await knowledge_manager.create(
+            title="Bad Confidence",
+            content="Content.",
+            agent="agent",
+            confidence=1.5,
+        )
+        assert result.status == "invalid_input"
+        assert "confidence" in result.message
+        assert not list(test_config.storage.knowledge_path.rglob("*.md"))
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_string_confidence(self, knowledge_manager: KnowledgeManager):
+        """create() with a string confidence returns invalid_input."""
+        result = await knowledge_manager.create(
+            title="String Confidence",
+            content="Content.",
+            agent="agent",
+            confidence="high",  # type: ignore[arg-type]
+        )
+        assert result.status == "invalid_input"
+        assert "confidence" in result.message
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_bool_confidence(self, knowledge_manager: KnowledgeManager):
+        """create() with a bool confidence returns invalid_input (bool is not a number here)."""
+        result = await knowledge_manager.create(
+            title="Bool Confidence",
+            content="Content.",
+            agent="agent",
+            confidence=True,
+        )
+        assert result.status == "invalid_input"
+        assert "confidence" in result.message
+
+    @pytest.mark.asyncio
+    async def test_create_accepts_int_confidence(
+        self, knowledge_manager: KnowledgeManager, test_config
+    ):
+        """create() accepts integer confidence and coerces it to float."""
+        import yaml
+
+        result = await knowledge_manager.create(
+            title="Int Confidence",
+            content="Content.",
+            agent="agent",
+            confidence=1,
+        )
+        assert result.status == "created"
+        assert result.document is not None
+        assert result.document.metadata.confidence == 1.0
+        assert isinstance(result.document.metadata.confidence, float)
+
+        # Raw frontmatter on disk serializes a number
+        file_path = test_config.storage.knowledge_path / result.document.path
+        parts = file_path.read_text().split("---", 2)
+        frontmatter_data = yaml.safe_load(parts[1])
+        assert isinstance(frontmatter_data["confidence"], (int, float))
+        assert not isinstance(frontmatter_data["confidence"], bool)
+
+    @pytest.mark.asyncio
+    async def test_create_none_confidence_applies_default(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """create() treats confidence=None as "not provided" → default 1.0.
+
+        MCP callers omit the field as null; before #312 the None was persisted
+        as ``confidence: null`` in frontmatter — the write-side origin of the
+        poisoned docs.
+        """
+        result = await knowledge_manager.create(
+            title="Omitted Confidence",
+            content="Content.",
+            agent="agent",
+            confidence=None,
+        )
+        assert result.status == "created"
+        assert result.document is not None
+        assert result.document.metadata.confidence == 1.0
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_none_confidence(self, knowledge_manager: KnowledgeManager):
+        """update() with confidence=None returns invalid_input (the historical poisoning path)."""
+        doc = (
+            await knowledge_manager.create(
+                title="Doc", content="Content.", agent="agent", confidence=0.7
+            )
+        ).document
+        result = await knowledge_manager.update(
+            id=doc.id,
+            agent="editor",
+            confidence=None,  # type: ignore[arg-type]
+        )
+        assert result.status == "invalid_input"
+        assert "confidence" in result.message
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_out_of_range_confidence(
+        self, knowledge_manager: KnowledgeManager
+    ):
+        """update() with out-of-range confidence rejects without mutating the doc."""
+        doc = (
+            await knowledge_manager.create(
+                title="Doc 2", content="Content.", agent="agent", confidence=0.7
+            )
+        ).document
+        result = await knowledge_manager.update(id=doc.id, agent="editor", confidence=2.0)
+        assert result.status == "invalid_input"
+
+        reread, _ = await knowledge_manager.read(id=doc.id)
+        assert reread.metadata.confidence == pytest.approx(0.7)
+        assert reread.metadata.version == doc.metadata.version
+
+    @pytest.mark.asyncio
+    async def test_update_accepts_int_confidence(self, knowledge_manager: KnowledgeManager):
+        """update() accepts integer confidence and coerces it to float."""
+        doc = (
+            await knowledge_manager.create(
+                title="Doc 3", content="Content.", agent="agent", confidence=0.5
+            )
+        ).document
+        result = await knowledge_manager.update(id=doc.id, agent="editor", confidence=1)
+        assert result.status == "updated"
+        assert result.document is not None
+        assert result.document.metadata.confidence == 1.0
+        assert isinstance(result.document.metadata.confidence, float)
+
+
 class TestDeleteRemovesUrl:
     """Tests for US-007: delete() cleans up dedup map."""
 


### PR DESCRIPTION
## Summary

Fixes #312 — `lithos_cache_lookup` raised an uncaught `TypeError: '<' not supported between instances of 'NoneType' and 'float'` whenever any candidate doc had a non-numeric `confidence` (notably `confidence: null`) in its frontmatter, aborting the entire lookup (took down 4 of 5 Influx profiles on 2026-06-07).

Two layers, per the issue's proposed fix:

### Read-side healing (`KnowledgeMetadata.from_dict`)
- New `_parse_confidence()` helper (mirrors the existing `_parse_version` defensive-parsing precedent): `None` / non-numeric strings / bool → fall back to the default `1.0` with a warning; out-of-range finite numbers clamp to `[0.0, 1.0]`; NaN/inf → `1.0`.
- All reads go through `from_dict`, so the 19 existing poisoned docs heal on next read everywhere — no migration needed, and `cache_lookup` needs no defensive guard.

### Write-side validation (`KnowledgeManager.create` / `update`)
- New `validate_confidence()` raises `ValueError` for non-numeric / non-finite / out-of-range values; `create()`/`update()` return `WriteResult(status="invalid_input")` (the established envelope convention), before any in-memory metadata mutation. The envelope propagates verbatim through intake and the MCP layer — no changes needed there.
- Integers are accepted and coerced to float (integer JSON over the MCP wire); bool is rejected (it's an `int` subclass, and `float(False)` would silently become `0.0`).

### Root cause of the poisoning (found during this work)
The issue asked "why those writers emit `confidence: null` in the first place" — answer: `lithos_write`'s **create** path forwards `confidence=None` when the MCP caller omits the field, and `KnowledgeManager.create()` persisted that `None` straight into frontmatter as `confidence: null`. Every MCP create that omitted `confidence` wrote a poisoned doc. `create()` now treats `None` as "not provided" and applies the documented default `1.0`, so this path can never poison docs again.

## Test plan

- [x] `TestConfidenceParsing` (8 tests): missing / null / string / numeric-string / int / bool / out-of-range / NaN frontmatter values
- [x] `TestConfidenceWriteValidation` (8 tests): create/update rejection envelopes, no-mutation-on-reject, int coercion, `create(confidence=None)` → default 1.0
- [x] End-to-end regression in `TestCacheLookupHitPath`: raw `.md` with `confidence: null` / `confidence: medium` frontmatter → `cache_lookup` returns a hit with `confidence == 1.0` instead of crashing (the exact #312 repro)
- [x] `make check` green (ruff, pyright, 1255 unit tests)
- [x] `make test-integration` green (380 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)