### PR TITLE
Add lithos and influx-inbox skill content

### DIFF
--- a/agent-skills/plugins/influx-inbox/skills/influx-inbox/SKILL.md
+++ b/agent-skills/plugins/influx-inbox/skills/influx-inbox/SKILL.md
@@ -4,6 +4,100 @@ description: |
   Use when an agent needs to submit a URL or PDF to the Influx inbox for ingestion into the Lithos knowledge base. Covers creating the required influx:inbox task, mandatory metadata fields (kind, url/local_path, submitted_by, source_tag), validation rules, and how to check ingestion results.
 ---
 
-# influx-inbox
+# Influx Inbox
 
-TODO: Add instructions for how the agent should execute this skill.
+The Influx inbox lets agents submit URLs or PDFs for ingestion into the Lithos knowledge base. The interface is a Lithos task with specific tags and metadata — Influx polls for tasks tagged `influx:inbox` and processes them.
+
+## Trigger Conditions
+
+Load this skill when you need to:
+- Submit a URL or article for ingestion into Lithos
+- Submit a local PDF for ingestion into Lithos
+- Check the result of a previously submitted ingestion task
+- Triage or score content against Influx profiles
+
+Do NOT use this skill for general Lithos knowledge or task work — load the `lithos` skill for that.
+
+## Submitting a URL
+
+```
+lithos_task_create(
+    title="Influx inbox: <descriptive title or URL>",
+    agent="<your-agent-id>",
+    tags=["influx:inbox"],
+    metadata={
+        "kind": "url",
+        "url": "https://example.com/interesting-article",
+        "submitted_by": "<your-agent-id>",
+        "title": "Optional title hint",
+        "summary": "Optional pre-fetched summary",
+        "source_tag": "inbox"
+    }
+)
+```
+
+## Submitting a PDF
+
+```
+lithos_task_create(
+    title="Influx inbox: <filename>",
+    agent="<your-agent-id>",
+    tags=["influx:inbox"],
+    metadata={
+        "kind": "pdf",
+        "local_path": "/path/under/pdf_root/research-paper.pdf",
+        "submitted_by": "<your-agent-id>",
+        "source_tag": "papers"
+    }
+)
+```
+
+## Mandatory Fields
+
+| Field | Required | Rules |
+|-------|----------|-------|
+| `tags` | Yes | Must include `"influx:inbox"` — this is how Influx discovers submissions |
+| `metadata.kind` | Yes | `"url"` or `"pdf"` only — anything else is a terminal error |
+| `metadata.url` | If kind=url | Must be `http://` or `https://` scheme |
+| `metadata.local_path` | If kind=pdf | Must resolve inside configured `pdf_root` |
+| `metadata.submitted_by` | Yes | Only `[A-Za-z0-9:._-]` kept, truncated to 64 chars |
+| `metadata.source_tag` | Yes | `^[a-z0-9][a-z0-9-]{0,31}$` — lowercase alphanumeric + hyphens, 1–32 chars |
+
+## Optional Fields
+
+| Field | Purpose |
+|-------|---------|
+| `metadata.title` | Title hint for ingestion |
+| `metadata.summary` | Pre-fetched summary to assist profile scoring |
+
+## Validation Rules
+
+1. `influx:inbox` tag is mandatory — submissions without it are invisible to Influx
+2. `kind` must be `"url"` or `"pdf"` — no other values accepted
+3. URLs must use `http://` or `https://` scheme
+4. PDF paths must resolve inside the configured `pdf_root`
+5. `source_tag` format: `^[a-z0-9][a-z0-9-]{0,31}$`
+6. All submissions must clear each profile's relevance threshold — no bypass
+7. Resubmitting the same URL is safe — deduplication scores only un-ingested profiles
+8. Rate limit: max 20 items processed per 5-minute tick (configurable)
+
+## Checking Ingestion Results
+
+After submission, poll the task until it completes:
+
+```
+lithos_task_get(task_id="<returned-task-id>")
+```
+
+When complete, check:
+- `outcome` — human-readable result string
+- `metadata.inbox_result` — structured JSON with per-profile scores and note IDs
+- The created/updated Lithos document IDs will appear in `inbox_result`
+
+## Pitfalls
+
+- **Missing `influx:inbox` tag** — the single most common mistake. Without it, Influx never sees the task
+- **Wrong `kind` value** — must be exactly `"url"` or `"pdf"`, lowercase. Any other value is a terminal error and the task will not be processed
+- **`source_tag` format** — must match `^[a-z0-9][a-z0-9-]{0,31}$`. Uppercase, underscores, or spaces will fail validation
+- **PDF path outside `pdf_root`** — Influx will reject it. Confirm the path is within the configured root before submitting
+- **Resubmitting is safe** — if you're unsure whether something was ingested, resubmit. Deduplication handles it

--- a/agent-skills/plugins/lithos/skills/lithos/SKILL.md
+++ b/agent-skills/plugins/lithos/skills/lithos/SKILL.md
@@ -4,6 +4,169 @@ description: |
   Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle, project conventions, and tagging.
 ---
 
-# lithos
+# Lithos
 
-TODO: Add instructions for how the agent should execute this skill.
+Lithos is a shared knowledge base and task coordination system for multi-agent workflows. Agents interact with it exclusively through MCP tools prefixed `lithos_`. Think of it as "Obsidian for agents" — structured markdown with full-text and semantic search, task claiming, and provenance tracking.
+
+## Trigger Conditions
+
+Load this skill when you need to:
+- Search for existing knowledge before starting work
+- Read or write knowledge documents
+- Create, claim, complete, or cancel tasks
+- Post findings during task execution
+- Coordinate with other agents (check who's active, what's claimed)
+- Work within a project using `project:<slug>` conventions
+- Submit URLs or PDFs for ingestion (use `influx-inbox` skill instead)
+
+## Required First Steps
+
+Every session, before any significant work:
+
+**1. Register yourself**
+```
+lithos_agent_register(id="<your-agent-id>", name="<display-name>", type="<agent-type>")
+```
+Do this once on first run. Your `agent_id` follows you across sessions — pick a stable, descriptive ID.
+
+**2. Search before you work**
+```
+lithos_search(query="<topic>")
+lithos_retrieve(query="<topic>")
+```
+Do not re-research or re-solve something another agent already documented. If you find relevant prior work, read it with `lithos_read(id=...)`.
+
+**3. Check what others are doing**
+```
+lithos_task_list(status="open", with_claims=True)
+lithos_agent_list()
+```
+Check before starting a task — someone may already be working on it.
+
+## Core Workflows
+
+### Research and Write
+1. `lithos_cache_lookup(source_url="https://...")` — check if knowledge already exists
+2. `lithos_search(query="<topic>")` or `lithos_retrieve(query="<topic>")` — find related docs
+3. Do your research
+4. `lithos_write(...)` — store findings with appropriate `note_type` and tags
+5. `lithos_edge_upsert(...)` — link to source docs if applicable
+
+### Task Execution
+1. `lithos_task_list(status="open", with_claims=True)` — find unclaimed tasks
+2. `lithos_task_claim(task_id=..., aspect="<aspect>", agent="<id>", ttl_minutes=60)` — claim before starting
+3. `lithos_retrieve(query="<topic>", task_id=...)` — retrieve relevant knowledge
+4. Do the work, posting interim results with `lithos_finding_post(...)`
+5. `lithos_task_complete(task_id=..., agent="<id>", outcome="...", cited_nodes=[...])` — complete with feedback
+
+### Create a New Task
+```
+lithos_task_create(
+    title="...",
+    agent="<your-id>",
+    description="...",
+    tags=["project:<slug>"],
+    metadata={"project": "<slug>", "priority": "medium"}
+)
+```
+Always set **both** `tags=["project:<slug>"]` and `metadata={"project": "<slug>"}` — different agents query by each convention.
+
+### Capture a Finding or Idea
+- **Finding** (during a task): `lithos_finding_post(task_id=..., agent="<id>", summary="...")`
+- **Idea** (speculative): `lithos_write(path="ideas/", tags=["idea"], confidence=0.5, note_type="hypothesis", ...)`
+
+## Tool Selection Rules
+
+| Question | Tool |
+|----------|------|
+| Does a doc about X already exist? | `lithos_cache_lookup(query="X")` |
+| Does a doc from this URL exist? | `lithos_cache_lookup(source_url="https://...")` |
+| Find docs about X (exploring) | `lithos_search(query="X")` |
+| Find docs about X in project Y | `lithos_list(content_query="X", tags=["project:Y"])` |
+| Best knowledge for task Z | `lithos_retrieve(query="...", task_id="Z")` |
+| What's related to this doc? | `lithos_related(id="<uuid>")` |
+
+Use `lithos_retrieve` (not `lithos_search`) when quality matters — it runs multi-scout retrieval with reranking. Use `lithos_search` for quick exploration.
+
+## Writing Knowledge: Key Decisions
+
+**What deserves a write:**
+- Non-obvious decisions and reasoning
+- Patterns, APIs, or behaviours discovered during research
+- Bugs found and how they were fixed
+- Research findings that took effort to assemble
+
+**What does NOT:**
+- Routine status updates (use task findings instead)
+- Things already in the knowledge base
+- Trivial facts easily re-discovered from source code or docs
+
+**Note type affects retrieval ranking** — choose deliberately:
+
+| note_type | Use for |
+|-----------|---------|
+| `agent_finding` | Conclusions, distilled insights, actionable findings (ranked highest) |
+| `summary` | Aggregated summaries of multiple sources |
+| `hypothesis` | Speculative ideas, untested theories |
+| `observation` | Raw data points, direct observations |
+| `concept` | Project contexts, definitions, stable reference |
+| `task_record` | Task logs (ranked lowest — noisy by nature) |
+
+## Project Conventions
+
+Lithos has no first-class project entity. Projects are represented through conventions:
+
+- **Project context doc**: `projects/<slug>/<slug>-project-context.md`, tagged `["project-context", "project:<slug>"]`, `note_type="concept"`
+- **Tag format**: `project:<slug>` (colon separator, e.g. `project:influx`)
+- **Metadata**: always also set `metadata={"project": "<slug>"}` on tasks
+
+Query patterns:
+```
+lithos_list(path_prefix="projects/<slug>/")          # all docs
+lithos_task_list(tags=["project:<slug>"])            # tasks (Agent Zero convention)
+lithos_task_list(metadata_match={"project": "<slug>"})  # tasks (Loom convention)
+```
+Run both task queries and union results — no single query covers all agents' conventions.
+
+## Task Lifecycle Rules
+
+- **Claim before acting** — `lithos_task_claim(...)`, then do the work
+- **Renew before expiry** — claims expire (default 60 min, max 480). Use `lithos_task_renew(...)` if work runs long
+- **Terminal states are final** — no reopen primitive. Post `[ReopenRequested]` finding if a task needs revisiting
+- **Always provide feedback on complete** — `cited_nodes` and `misleading_nodes` improve the KB over time
+- **Claim denied = `{success: false}`** — not an error; another agent holds it. Try another task or wait
+
+## Pitfalls
+
+- **Don't skip the search step** — the most common mistake. Always `lithos_cache_lookup` or `lithos_search` before writing new knowledge
+- **Don't use `lithos_search` when quality matters** — it doesn't enforce access scopes or track salience. Use `lithos_retrieve` for actual work
+- **Don't set only tags OR only metadata on tasks** — set both. Loom queries by `metadata.project`; Agent Zero queries by tag
+- **`metadata` reserved keys** — don't use: `id, title, author, created_at, updated_at, tags, confidence, source_url, version, status`. They'll return `invalid_input`
+- **Shell escaping** — if using a CLI wrapper, content with backticks or JSON breaks arg parsing. Write to a temp file instead
+- **Optimistic concurrency** — use `expected_version` on updates when concurrent edits are possible. On conflict, re-read and retry
+
+## Verification
+
+After writing a document:
+```
+lithos_read(id="<returned-id>")   # confirm content and metadata stored correctly
+```
+
+After completing a task:
+```
+lithos_task_get(task_id="...")    # confirm status is "completed" and outcome is set
+```
+
+KB health check:
+```
+lithos_stats()                    # document counts, open tasks, index health
+```
+
+## Reference Files
+
+For deeper detail, load these references on demand:
+
+- `references/search-and-retrieval.md` — full decision matrix, LCMA scout weights, retrieval tuning
+- `references/task-coordination.md` — claim patterns, finding conventions, feedback mechanics
+- `references/project-conventions.md` — project context docs, slug format, idea lifecycle, tagging
+- `references/error-handling.md` — all error codes, collision types, retry patterns

--- a/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
@@ -1,0 +1,116 @@
+# Error Handling Reference
+
+## Knowledge Tool Errors
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `duplicate` | Same `source_url` on another doc | Read `duplicate_of.id`, update it or skip |
+| `slug_collision` | Title slugifies to same filename | Use `existing_id` to update, or pick different title |
+| `path_collision` | Explicit `.md` path already taken | Use `existing_id` or change path |
+| `version_conflict` | Optimistic lock failed | Re-read, get `current_version`, retry |
+| `content_too_large` | Content exceeds 1MB | Trim or split the document |
+| `invalid_input` | Field validation failed | Check error message for specifics |
+| `doc_not_found` | ID doesn't exist | Verify the UUID |
+| `search_backend_error` | Tantivy/ChromaDB down | Retry or fall back to a different search mode |
+| `lcma_disabled` | LCMA not enabled | Fall back to `lithos_search` |
+
+---
+
+## Collision Types — Know the Difference
+
+Three distinct collision types with different handling:
+
+| Status | Cause | What to Do |
+|--------|-------|------------|
+| `duplicate` | Same `source_url` exists on another doc | Read existing doc (`duplicate_of.id`), update or skip |
+| `slug_collision` | Title slugifies to same filename as existing doc | Use `existing_id` to update that doc, or pick a different title |
+| `path_collision` | Explicit `.md` path already taken by a different doc | Same — use `existing_id` or change path |
+
+URL deduplication normalizes before comparison: lowercase scheme/host, strips fragments + tracking params (utm_*, fbclid), sorts query params, removes trailing slashes and default ports.
+
+---
+
+## Stale Cache Pattern
+
+```
+result = lithos_cache_lookup(source_url="https://...", max_age_hours=168)
+
+if result["hit"]:
+    # Fresh knowledge exists — read and use it
+    doc = lithos_read(id=result["document"]["id"])
+
+elif result["stale_exists"]:
+    # Expired knowledge exists — update it rather than create a duplicate
+    lithos_write(id=result["stale_id"], content="...", agent="<id>")
+
+else:
+    # Clean miss — create new
+    lithos_write(title="...", content="...", agent="<id>")
+```
+
+---
+
+## Optimistic Concurrency
+
+Use `expected_version` on updates when concurrent edits are possible:
+
+```
+lithos_write(
+    id="<uuid>",
+    content="...",
+    agent="<id>",
+    expected_version=3   # reject if doc has moved past version 3
+)
+```
+
+On `version_conflict`, the response includes `current_version` — re-read the doc and retry.
+
+---
+
+## Task Tool Responses
+
+| Response | Meaning |
+|----------|---------|
+| `{success: true}` | Operation succeeded |
+| `{success: false}` (on claim) | Another agent holds the claim — not an error |
+| `{success: false}` (on release/renew) | Claim expired or not owned |
+| `{status: "error", code: "task_not_found"}` | Task doesn't exist or is already closed |
+
+---
+
+## Reserved Metadata Keys
+
+Free-form metadata keys must NOT collide with reserved frontmatter fields. Colliding keys return `invalid_input`:
+
+```
+id, title, author, created_at, updated_at, tags, aliases, confidence,
+contributors, source, source_url, supersedes, derived_from_ids,
+expires_at, version, schema_version, namespace, access_scope,
+note_type, status, summaries, entities
+```
+
+---
+
+## Update Field Semantics
+
+These are inconsistent across fields — know them:
+
+| Field | Omit/null | Empty value | Non-empty |
+|-------|-----------|-------------|-----------|
+| `tags` | Preserve existing | `[]` clears all | Replaces entirely |
+| `source_url` | Preserve existing | `""` clears | Sets new value |
+| `derived_from_ids` | Preserve existing | `[]` clears | Replaces entirely |
+| `expires_at` | Preserve existing | `""` clears | Sets new value |
+| `confidence` | Preserve existing | — | Sets new value |
+| `metadata` | Preserve existing | `{}` is a no-op | Per-key merge (null value deletes key) |
+
+---
+
+## Observability
+
+```
+lithos_stats()                    # KB health: doc counts, open tasks, index drift
+lithos_node_stats(node_id="...")  # Per-doc: salience, retrieval_count, cited/misleading counts
+```
+
+A document with ≥3 `misleading` marks is auto-quarantined and excluded from all future search and retrieve results.

--- a/agent-skills/plugins/lithos/skills/lithos/references/project-conventions.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/project-conventions.md
@@ -1,0 +1,112 @@
+# Project Conventions Reference
+
+## Projects in Lithos
+
+Lithos has no first-class project entity. Projects are represented through two conventions applied together: a **project context document** and a **tag + metadata pair** on all related tasks and docs.
+
+---
+
+## Project Context Documents
+
+| Field | Value |
+|-------|-------|
+| Path | `projects/<slug>/<slug>-project-context.md` |
+| Tags | `["project-context", "project:<slug>"]` |
+| note_type | `concept` |
+| Slug format | `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$` |
+
+Create a project context doc when starting a new project:
+```
+lithos_write(
+    title="<Project Name> Project Context",
+    content="...",
+    agent="<id>",
+    path="projects/<slug>/<slug>-project-context.md",
+    tags=["project-context", "project:<slug>"],
+    note_type="concept"
+)
+```
+
+---
+
+## Tag and Metadata Conventions
+
+All tasks and documents belonging to a project should carry **both**:
+
+- **Tag**: `project:<slug>` (colon separator — e.g. `project:lithos-core`, `project:influx`)
+- **Metadata**: `{"project": "<slug>"}` on tasks
+
+**Why both?** Different agents use different conventions:
+- **Agent Zero** queries by `tags: ["project:<slug>"]`
+- **Loom** stores project in `metadata.project` only, with no project tag
+- Setting both ensures discoverability regardless of which agent created the item
+
+---
+
+## Project Query Patterns
+
+| Goal | Tool Call |
+|------|-----------|
+| All docs for a project | `lithos_list(path_prefix="projects/<slug>/")` |
+| All tasks (Agent Zero) | `lithos_task_list(tags=["project:<slug>"])` |
+| All tasks (Loom) | `lithos_task_list(metadata_match={"project": "<slug>"})` |
+| Search within a project | `lithos_search(query="...", path_prefix="projects/<slug>/")` |
+| All project contexts | `lithos_list(path_prefix="projects/", tags=["project-context"])` |
+| Recently closed tasks | `lithos_task_list(resolved_since="2026-06-01T00:00:00Z")` |
+
+> There is no single query that returns all tasks for a project regardless of which agent created them. Run both `tags` and `metadata_match` queries and union the results.
+
+---
+
+## Ideas (Pre-Project Knowledge)
+
+Ideas live separately from project knowledge until they mature:
+
+| Field | Value |
+|-------|-------|
+| Path | `ideas/` |
+| Tags | `["idea"]` (add `"project:<slug>"` if associated) |
+| Confidence | 0.5–0.7 (signals speculative/unvalidated) |
+| note_type | `hypothesis` or `concept` |
+
+### Idea Lifecycle
+
+- **Becomes a task** → create task tagged with project, update idea doc to link
+- **Becomes project knowledge** → move to `projects/<slug>/`, update tags
+- **Spawns a new project** → create project context document, tag idea
+
+### Idea Query Patterns
+
+| Goal | Tool Call |
+|------|-----------|
+| All unattached ideas | `lithos_list(tags=["idea"])` |
+| Ideas for a project | `lithos_list(tags=["idea", "project:<slug>"])` |
+| Search ideas semantically | `lithos_search(query="...", path_prefix="ideas/")` |
+
+---
+
+## Tagging Conventions
+
+Tags are the primary discovery mechanism. Be generous. Use `lithos_tags(prefix="...")` to discover existing tags before inventing new ones.
+
+| Pattern | Purpose |
+|---------|---------|
+| `project:<slug>` | Project association — always use colon, not slash |
+| `agent-memory`, `lithos`, `architecture`, `mcp` | Topic tags |
+| `research`, `decision`, `bug`, `guide` | Type tags |
+| `project-context`, `idea`, `influx:inbox` | Functional tags |
+
+---
+
+## Namespaces
+
+Path determines namespace for access scoping and retrieval filtering:
+
+| Path | Namespace |
+|------|-----------|
+| `projects/<slug>/foo.md` | `projects/<slug>` |
+| `research/foo.md` | `research` |
+| `ideas/foo.md` | `ideas` |
+| Root-level | `default` |
+
+Use `namespace_filter` on `lithos_retrieve` for project-scoped cognitive retrieval.

--- a/agent-skills/plugins/lithos/skills/lithos/references/search-and-retrieval.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/search-and-retrieval.md
@@ -1,0 +1,123 @@
+# Search and Retrieval Reference
+
+## Four Search Tools — Full Decision Matrix
+
+| Scenario | Tool |
+|----------|------|
+| "Does a doc about X already exist?" (before writing) | `lithos_cache_lookup(query="X")` |
+| "Does a doc from this URL exist?" | `lithos_cache_lookup(source_url="https://...")` |
+| "Find docs about X" (browsing/exploring) | `lithos_search(query="X")` |
+| "Find docs about X in project Y" | `lithos_list(content_query="X", tags=["project:Y"])` |
+| "Get the best knowledge for task Z" | `lithos_retrieve(query="...", task_id="Z")` |
+| "What's related to this document?" | `lithos_related(id="<uuid>")` |
+
+---
+
+## `lithos_cache_lookup` — "Does this already exist?"
+
+Use **before creating new knowledge**, especially when you have a source URL:
+
+```
+lithos_cache_lookup(
+    query="transformer attention mechanisms",
+    source_url="https://example.com/article",   # exact dedup via normalized URL index
+    max_age_hours=168,                           # 1 week
+    min_confidence=0.5
+)
+```
+
+- With `source_url`: exact lookup via URL index — instant, no search involved
+- Without `source_url`: falls back to semantic search (catches everything)
+- Only evaluates up to `limit` candidates (default 3) — quick existence check, not comprehensive
+- **Three outcomes**: `hit=True` (fresh, returns full content), `stale_exists=True` (expired, returns `stale_id`), clean miss
+- **Key pattern**: If `stale_exists=True`, pass `stale_id` as `id` to `lithos_write` to UPDATE rather than create a duplicate
+
+---
+
+## `lithos_search` — "Find documents matching this query"
+
+Use for **exploratory discovery** — quick keyword or semantic lookups:
+
+```
+lithos_search(query="inbox processing pipeline", mode="hybrid", limit=5)
+```
+
+Four modes:
+
+| Mode | When to use |
+|------|-------------|
+| `hybrid` (default) | Best general-purpose — merges BM25 + cosine similarity via RRF |
+| `fulltext` | Exact keyword matching or Tantivy query syntax |
+| `semantic` | Meaning matters more than exact words |
+| `graph` | Discover related docs by following wiki-links |
+
+**Important**: `lithos_search` does NOT enforce LCMA access scopes and does NOT track retrieval for salience scoring. Use only for exploration.
+
+---
+
+## `lithos_retrieve` — "Give me the best knowledge for this task"
+
+Use for **comprehensive retrieval during actual work** — when quality matters:
+
+```
+lithos_retrieve(query="inbox error handling patterns", task_id="...", limit=10)
+```
+
+- Runs 10 scouts across multiple backends with Terrace 1 reranking
+- Enforces access scopes (`agent_private`, `task` visibility)
+- Writes audit receipts — enables cited/misleading feedback loops
+- `task_id` activates the task_context scout (extra retrieval dimension)
+- **Requires LCMA enabled** — falls back to `lithos_search` if LCMA is off
+
+### Scout Weights (for tuning queries)
+
+**Phase A (parallel):**
+- `lexical` (0.22) — BM25 full-text via Tantivy (highest weight)
+- `vector` (0.21) — semantic similarity via ChromaDB
+- `exact_alias` (0.10) — title/alias exact match
+- `graph` (0.13) — wiki-link traversal from Phase A seeds
+- `coactivation` (0.10) — docs co-retrieved with Phase A results
+- `tags_recency` (0.07) — only fires if tags or path_prefix provided
+- `source_url` (0.05) — docs sharing source URLs with Phase A results
+- `freshness` (0.04) — only fires if query contains "update", "refresh", "recheck", "verify", or "latest"
+- `task_context` (0.04) — only fires if `task_id` provided
+- `provenance` (0.04) — follows `derived_from_ids` chains
+
+### Practical Retrieval Tips
+- Include `task_id` when working within a task
+- Use "latest" or "update" in queries when you want fresh content
+- Write good titles — they affect exact_alias matching
+- Use `[[wiki-links]]` in content — they feed the graph scout
+- Cite useful nodes on task completion — coactivation edges strengthen over time
+
+---
+
+## `lithos_list` with `content_query` — "Filter + search together"
+
+Use when searching within a constrained subset:
+
+```
+lithos_list(
+    content_query="error handling",
+    tags=["project:influx"],
+    path_prefix="projects/influx/"
+)
+```
+
+- `tags`, `author`, `path_prefix` are pushed down into the Tantivy query
+- `since`, `title_contains` applied as post-filters
+- More efficient than `lithos_search` + manual filtering for constrained queries
+
+---
+
+## `lithos_related` — "What's connected to this doc?"
+
+```
+lithos_related(id="doc-uuid", include=["links", "provenance", "edges"])
+```
+
+Returns three relationship types:
+- **links**: wiki-link graph traversal (BFS depth 1–3)
+- **provenance**: `derived_from_ids` chains
+- **edges**: typed LCMA edges (flat)
+- Plus `related_ids` — deduped union of all referenced IDs

--- a/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
@@ -1,0 +1,132 @@
+# Task Coordination Reference
+
+## Task Lifecycle
+
+```
+open → completed   (lithos_task_complete)
+open → cancelled   (lithos_task_cancel)
+```
+
+Terminal states are final. No reopen primitive. If a task needs revisiting, post a `[ReopenRequested]` finding.
+
+Only open tasks can be updated, completed, or cancelled — operations on closed tasks return errors.
+
+---
+
+## Creating Tasks
+
+```
+lithos_task_create(
+    title="Implement inbox health check",
+    agent="<your-id>",
+    description="Add a /health endpoint that reports inbox queue depth",
+    tags=["project:influx", "trigger:story-develop"],
+    metadata={
+        "project": "influx",
+        "priority": "medium",
+        "scheduled_for": "2026-06-15"
+    }
+)
+```
+
+**Required fields**: `title`, `agent`
+
+### Key Metadata Fields
+
+| Key | Type | Values |
+|-----|------|--------|
+| `project` | string | Project slug — used by Loom for project association |
+| `priority` | string | `highest\|high\|medium\|low\|lowest` |
+| `scheduled_for` | string | `YYYY-MM-DD` |
+| `depends_on` | list[str] | Prerequisite task IDs |
+| `parallelizable` | bool | Whether siblings can execute concurrently |
+
+### Tag Conventions
+
+| Tag | Meaning |
+|-----|---------|
+| `project:<slug>` | Associates task with a project |
+| `trigger:<route-name>` | Matches lithos-loom route-runner stanzas |
+| `github-issue` | Task originated from a GitHub issue |
+| `influx:inbox` | Task is an influx inbox submission |
+
+**Always set both tag and metadata**: `tags=["project:<slug>"]` + `metadata={"project": "<slug>"}`. Loom queries by `metadata.project`; Agent Zero queries by tag. Setting both ensures discoverability regardless of which agent created the task.
+
+---
+
+## Claiming Tasks
+
+```
+lithos_task_claim(task_id="...", aspect="research", agent="<id>", ttl_minutes=60)
+```
+
+- Claims expire after `ttl_minutes` (default 60, max 480)
+- Another agent can take an expired claim — that's by design
+- Renew before expiry: `lithos_task_renew(task_id="...", aspect="...", agent="<id>", ttl_minutes=60)`
+- Release when done or aborting: `lithos_task_release(task_id="...", aspect="...", agent="<id>")`
+- `lithos_task_complete` and `lithos_task_cancel` auto-release claims
+- **Claim denied**: returns `{success: false}` — NOT an error envelope. Try another task or wait
+
+---
+
+## Posting Findings
+
+Post intermediate results other agents may need before the task completes:
+
+```
+lithos_finding_post(
+    task_id="...",
+    agent="<id>",
+    summary="[Friction] Rate limiter config missing from example",
+    knowledge_id="<uuid>"   # optional — link to a knowledge doc
+)
+```
+
+### Conventional Finding Prefixes
+
+| Prefix | Meaning |
+|--------|---------|
+| `[Friction]` | Operational difficulty needing attention |
+| `[ReopenRequested]` | Task needs revisiting (no reopen primitive) |
+| `[BlockerFailed]` | Plugin execution failed |
+
+---
+
+## Completing Tasks with Feedback
+
+```
+lithos_task_complete(
+    task_id="...",
+    agent="<id>",
+    outcome="Implemented and tested inbox health endpoint",
+    cited_nodes=["uuid1", "uuid2"],      # docs that were useful
+    misleading_nodes=["uuid3"]           # docs that were misleading
+)
+```
+
+### How Feedback Works
+
+- `cited_nodes`: salience +0.02, creates `related_to` edges between cited pairs
+- `misleading_nodes`: salience -0.05, weakens all incident edges
+- **≥3 misleading marks → auto-quarantined** — excluded from all future search/retrieve
+- Nodes neither cited nor misleading get a mild -0.01 "ignored" penalty
+- Only nodes that appeared in a `lithos_retrieve` receipt for that task can be cited/misleading
+
+**Always provide feedback when you can** — it's how the knowledge base improves over time.
+
+---
+
+## Looking Up Tasks
+
+- `lithos_task_get(task_id="...")` — returns task directly; use when you know the ID and don't need claims
+- `lithos_task_status(task_id="...")` — returns task with its active claims
+- `lithos_task_list(status="open", with_claims=True)` — list with claim info; avoids N+1 queries
+
+---
+
+## Tool Responses
+
+- **Success**: `{success: true}` or status envelope with created ID
+- **Claim denied**: `{success: false}` — NOT an error envelope
+- **Release/renew no match**: `{success: false}` — claim expired or not owned
+- **Task not found / already closed**: `{status: "error", code: "task_not_found"}`


### PR DESCRIPTION
Fills in the TODO SKILL.md bodies from the Tessl scaffold (PR #317).

## Changes

### `lithos` skill
- **SKILL.md**: Full agent workflow — register, search-before-work, knowledge read/write, task lifecycle, project conventions, tool selection rules, pitfalls, verification
- **references/search-and-retrieval.md**: Full decision matrix, all four search tools, LCMA scout weights, retrieval tips
- **references/task-coordination.md**: Claim patterns, finding conventions, feedback mechanics, tool responses
- **references/project-conventions.md**: Project context docs, slug format, tag/metadata conventions, idea lifecycle, namespace mapping
- **references/error-handling.md**: All error codes, collision types, stale cache pattern, optimistic concurrency, reserved metadata keys, update field semantics

### `influx-inbox` skill
- **SKILL.md**: URL/PDF submission patterns, mandatory fields table, validation rules, result checking, pitfalls

## Design notes
- SKILL.md kept procedural and concise — detail pushed to `references/` (progressive disclosure)
- Both skills follow the two-section description pattern: trigger first, scope second
- `influx-inbox` is deliberately narrow — one job, tight trigger conditions
- Content derived from lithos agent guide (da6ee137) and skill authoring guide (fa72401b) in Lithos KB