### PR TITLE
feat(search): index entities and add entities filters to lithos_list/lithos_search

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,14 @@ COPY src/ ./src/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install .
 
+# Bake the default sentence-transformers embedding model into the image so the
+# runtime never downloads it from HuggingFace at startup. Container startup was
+# failing in CI when HF rate-limited (HTTP 429) the shared runner IPs; baking
+# the model makes startup network-free and fast. The spaCy NER model already
+# ships as a wheel dependency, so only the embedding model needs this.
+ENV HF_HOME=/opt/hf-cache
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
 # Stage 2: Runtime image
 FROM python:3.11-slim AS runtime
 
@@ -34,10 +42,19 @@ WORKDIR /app
 # Copy virtual environment from builder
 COPY --from=builder /app/.venv /app/.venv
 
+# Copy the pre-baked embedding model cache from the builder.
+COPY --from=builder /opt/hf-cache /opt/hf-cache
+
 # Set environment
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
+# Load the embedding model from the baked cache and never reach out to
+# HuggingFace at runtime. Override HF_HUB_OFFLINE=0 if you configure a
+# non-default embedding model that must be downloaded.
+ENV HF_HOME=/opt/hf-cache
+ENV HF_HUB_OFFLINE=1
+ENV TRANSFORMERS_OFFLINE=1
 
 # Install curl for HEALTHCHECK
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
@@ -46,7 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 RUN groupadd --gid 1000 lithos \
     && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/lithos --shell /usr/sbin/nologin lithos \
     && mkdir -p /data/knowledge /data/index /data/chroma /data/graph \
-    && chown -R 1000:1000 /data /home/lithos
+    && chown -R 1000:1000 /data /home/lithos /opt/hf-cache
 
 # Default environment variables
 ENV HOME=/home/lithos

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -285,7 +285,7 @@ status: <enum>                    # Optional: active | archived | quarantined (d
 summaries:                        # Optional: nested object with short/long summaries
   short: <string>                 # Optional, agent-written
   long: <string>                  # Optional, agent-written
-entities:                         # Optional: extracted entity strings (advisory)
+entities:                         # Optional: extracted entity strings
   - <entity-1>                    # Written by the lithos-enrich worker using spaCy NER
   - <entity-2>                    # plus high-precision heuristics (wiki-links, backtick
                                   # terms, mid-sentence-corroborated proper nouns).
@@ -530,6 +530,7 @@ Unified search across the knowledge base.
 | `threshold` | float | No | Minimum similarity 0-1 for semantic/hybrid/graph (default: 0.5) |
 | `seed_ids` | string[] | No | Starting document IDs for `graph` mode. When omitted, seeds are discovered via a fast hybrid pass on `query`. |
 | `graph_depth` | int | No | BFS hop depth for `graph` mode, 1–3 (default: 2) |
+| `entities` | string[] | No | Filter results to documents whose `entities` frontmatter contains every named entity (exact match, AND). Applies to all modes; resolved via an inverted index and applied as a post-filter (#316). |
 | `agent_id` | string | No | Caller identity recorded in the read-access audit log |
 
 **Returns:** `{ results: [{ id, title, snippet, score, path, source_url, updated_at, is_stale, derived_from_ids }] }`
@@ -542,6 +543,7 @@ Unified search across the knowledge base.
 
 **Notes:**
 - Search operates on chunks internally but returns deduplicated documents.
+- Entity names are indexed as a Tantivy field and included in the default query fields, so query terms matching a document's entities boost its full-text ranking (and curated entities are findable even when absent from the body).
 - In `semantic` mode, the returned `score` is the semantic similarity value.
 - Invalid `mode` returns `{ status: "error", code: "invalid_mode", message }`.
 - Every returned document is recorded in the read-access audit log, batched per call. `agent_id` defaults to `"unknown"` when omitted.
@@ -619,6 +621,7 @@ List knowledge items with filters.
 | `title_contains` | string | No | Case-insensitive substring match on title |
 | `content_query` | string | No | Tantivy full-text query applied after the base filters |
 | `metadata_match` | object | No | Filter by free-form metadata (see Filter semantics) |
+| `entities` | string[] | No | Filter by entity names from the document's `entities` frontmatter (exact match, AND across the list). Resolved via an in-memory inverted index — no full scan (#316). |
 
 **Returns:** `{ items: [{ id, title, path, updated, tags, source_url, derived_from_ids, metadata }], total: int }`
 (`metadata` is the document's free-form key/value dict.)
@@ -628,6 +631,7 @@ List knowledge items with filters.
 - When `content_query` is present, Lithos runs Tantivy first (with `tags`, `author`, and `path_prefix` pushed into the search query), then applies the remaining filters (`since`, `title_contains`, `metadata_match`) before pagination.
 - `content_query` backend failures return `{ status: "error", code: "search_backend_error", message }`.
 - `metadata_match` is resolved through an in-memory inverted index, so a metadata-filtered list never scans the whole knowledge base.
+- `entities` is resolved through the same inverted-index machinery; with `content_query` it is applied as a candidate-set intersection after ranking.
 
 **Filter semantics (`metadata_match`, #306):**
 - AND across keys: a document must match every `key: q` pair.

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -769,6 +769,9 @@ class _CachedMeta:
     note_type: str | None = None
     status: str | None = None
     source_url: str | None = None
+    # Extracted/curated entity names (#316) — kept here so the entities
+    # inverted index can be maintained without a disk read.
+    entities: list[str] = field(default_factory=list)
     # Free-form key/value metadata (#305) — kept here so equality filtering and
     # the inverted index (#306) work without a disk read.
     extra: dict = field(default_factory=dict)
@@ -835,6 +838,7 @@ class KnowledgeManager:
             path=str(doc.path),
             author=doc.metadata.author,
             tags=tuple(doc.metadata.tags),
+            entities=tuple(doc.metadata.entities),
             source_url=doc.metadata.source_url or "",
             updated_at=(doc.metadata.updated_at.isoformat() if doc.metadata.updated_at else ""),
             expires_at=(doc.metadata.expires_at.isoformat() if doc.metadata.expires_at else ""),
@@ -931,6 +935,7 @@ class KnowledgeManager:
         self._author_index: dict[str, set[str]] = {}
         self._status_index: dict[str, set[str]] = {}
         self._tag_index: dict[str, set[str]] = {}
+        self._entities_index: dict[str, set[str]] = {}
         self._metadata_index: dict[str, dict[str, set[str]]] = {}
         self._meta_seq: int = 0
         self._scan_existing()
@@ -947,6 +952,8 @@ class KnowledgeManager:
             self._status_index.setdefault(cached.status, set()).add(doc_id)
         for tag in cached.tags:
             self._tag_index.setdefault(tag, set()).add(doc_id)
+        for entity in cached.entities:
+            self._entities_index.setdefault(entity, set()).add(doc_id)
         for key, value in cached.extra.items():
             buckets = self._metadata_index.setdefault(key, {})
             # A list value is matched element-wise (contains); a scalar by value.
@@ -970,6 +977,8 @@ class KnowledgeManager:
         _discard(self._status_index, cached.status or None)
         for tag in cached.tags:
             _discard(self._tag_index, tag)
+        for entity in cached.entities:
+            _discard(self._entities_index, entity)
         for key, value in cached.extra.items():
             buckets = self._metadata_index.get(key)
             if buckets is None:
@@ -987,6 +996,7 @@ class KnowledgeManager:
         author: str | None,
         metadata_match: dict | None,
         exclude_status: list[str] | None,
+        entities: list[str] | None = None,
     ) -> set[str] | None:
         """Resolve equality filters to a candidate id set via the inverted index.
 
@@ -1001,6 +1011,9 @@ class KnowledgeManager:
         if tags:
             for tag in tags:
                 seed_sets.append(self._tag_index.get(tag, set()))
+        if entities:
+            for entity in entities:
+                seed_sets.append(self._entities_index.get(entity, set()))
         if metadata_match:
             for key, value in metadata_match.items():
                 bucket = self._metadata_index.get(key, {})
@@ -1043,6 +1056,7 @@ class KnowledgeManager:
         self._author_index.clear()
         self._status_index.clear()
         self._tag_index.clear()
+        self._entities_index.clear()
         self._metadata_index.clear()
         self._meta_seq = 0
         self.duplicate_url_count = 0
@@ -1112,6 +1126,7 @@ class KnowledgeManager:
                     raw_namespace: str | None = post.metadata.get("namespace")  # type: ignore[assignment]
                     raw_status: str | None = post.metadata.get("status")  # type: ignore[assignment]
                     raw_source_url: str | None = post.metadata.get("source_url")  # type: ignore[assignment]
+                    raw_entities: list[str] = post.metadata.get("entities", [])  # type: ignore[assignment]
                     cached_namespace = (
                         raw_namespace
                         if isinstance(raw_namespace, str) and raw_namespace
@@ -1132,6 +1147,7 @@ class KnowledgeManager:
                         note_type=raw_note_type if isinstance(raw_note_type, str) else None,
                         status=raw_status if isinstance(raw_status, str) else None,
                         source_url=raw_source_url if isinstance(raw_source_url, str) else None,
+                        entities=raw_entities if isinstance(raw_entities, list) else [],
                         extra=extract_extra(post.metadata),
                         seq=self._next_seq(),
                     )
@@ -1458,6 +1474,7 @@ class KnowledgeManager:
                 note_type=metadata.note_type,
                 status=metadata.status,
                 source_url=metadata.source_url,
+                entities=list(metadata.entities),
                 extra=dict(metadata.extra),
                 seq=self._next_seq(),
             )
@@ -1892,6 +1909,7 @@ class KnowledgeManager:
                 note_type=doc.metadata.note_type,
                 status=doc.metadata.status,
                 source_url=doc.metadata.source_url,
+                entities=list(doc.metadata.entities),
                 extra=dict(doc.metadata.extra),
                 seq=old_cached.seq if old_cached is not None else self._next_seq(),
             )
@@ -1980,6 +1998,7 @@ class KnowledgeManager:
         author: str | None = None,
         exclude_status: list[str] | None = None,
         metadata_match: dict | None = None,
+        entities: list[str] | None = None,
     ) -> tuple[list[KnowledgeDocument], int]:
         """List all documents with optional filtering.
 
@@ -1992,11 +2011,14 @@ class KnowledgeManager:
         ``metadata_match`` filters by free-form metadata (#306): each ``key: q``
         matches docs whose stored value equals ``q`` or is a list containing it.
 
-        Equality filters (``tags``, ``author``, ``metadata_match``) are resolved
-        through inverted indexes to a candidate set, so a filtered query never
-        scans the whole cache; ``path_prefix``/``since`` then refine only those
-        candidates. With no equality filter, falls back to a full scan (which is
-        unavoidable for unfiltered / prefix-only / since-only listings).
+        ``entities`` filters by entity name, AND across the list (#316).
+
+        Equality filters (``tags``, ``author``, ``metadata_match``,
+        ``entities``) are resolved through inverted indexes to a candidate
+        set, so a filtered query never scans the whole cache;
+        ``path_prefix``/``since`` then refine only those candidates. With no
+        equality filter, falls back to a full scan (which is unavoidable for
+        unfiltered / prefix-only / since-only listings).
         """
         normalized_since = _normalize_datetime(since) if since else None
         candidate_ids = self._candidate_ids(
@@ -2004,6 +2026,7 @@ class KnowledgeManager:
             author=author,
             metadata_match=metadata_match,
             exclude_status=exclude_status,
+            entities=entities,
         )
 
         if candidate_ids is None:
@@ -2066,6 +2089,20 @@ class KnowledgeManager:
             return None
         return self._candidate_ids(
             tags=None, author=None, metadata_match=metadata_match, exclude_status=None
+        )
+
+    def entities_candidate_ids(self, entities: list[str] | None) -> set[str] | None:
+        """Public wrapper: candidate ids for an ``entities`` filter (#316).
+
+        Returns ``None`` when ``entities`` is empty/None (no filtering),
+        otherwise the set of doc ids carrying every named entity (sub-linear,
+        index-based). Used by ``lithos_search`` to post-filter hits without
+        scanning the cache.
+        """
+        if not entities:
+            return None
+        return self._candidate_ids(
+            tags=None, author=None, metadata_match=None, exclude_status=None, entities=entities
         )
 
     async def get_all_tags(self) -> dict[str, int]:
@@ -2257,6 +2294,7 @@ class KnowledgeManager:
             note_type=metadata.note_type,
             status=metadata.status,
             source_url=metadata.source_url,
+            entities=list(metadata.entities),
             extra=dict(metadata.extra),
             seq=old_cached.seq if old_cached is not None else self._next_seq(),
         )

--- a/src/lithos/search.py
+++ b/src/lithos/search.py
@@ -97,6 +97,7 @@ class IndexableDocument:
     source_url: str
     updated_at: str
     expires_at: str
+    entities: tuple[str, ...] = ()
 
     @property
     def full_content(self) -> str:
@@ -304,7 +305,7 @@ def chunk_text(text: str, chunk_size: int = 500, chunk_max: int = 1000) -> list[
 class TantivyIndex:
     """Tantivy full-text search index."""
 
-    SCHEMA_VERSION = "3"
+    SCHEMA_VERSION = "4"
     """Bumped when fields are added/removed. Triggers automatic rebuild."""
 
     WRITER_RETRY_ATTEMPTS = 8
@@ -348,6 +349,7 @@ class TantivyIndex:
         builder.add_text_field("path", stored=True, tokenizer_name="raw")
         builder.add_text_field("author", stored=True, tokenizer_name="raw")
         builder.add_text_field("tags", stored=True, tokenizer_name="en_stem")
+        builder.add_text_field("entities", stored=True, tokenizer_name="en_stem")
         builder.add_text_field("source_url", stored=True, tokenizer_name="raw")
         builder.add_text_field("updated_at", stored=True, tokenizer_name="raw")
         builder.add_text_field("expires_at", stored=True, tokenizer_name="raw")
@@ -443,6 +445,7 @@ class TantivyIndex:
                     path=doc.path,
                     author=doc.author,
                     tags=" ".join(doc.tags),
+                    entities="\n".join(doc.entities),
                     source_url=doc.source_url,
                     updated_at=doc.updated_at,
                     expires_at=doc.expires_at,
@@ -472,6 +475,7 @@ class TantivyIndex:
                         path=doc.path,
                         author=doc.author,
                         tags=" ".join(doc.tags),
+                        entities="\n".join(doc.entities),
                         source_url=doc.source_url,
                         updated_at=doc.updated_at,
                         expires_at=doc.expires_at,
@@ -530,7 +534,7 @@ class TantivyIndex:
         effective_limit = limit * 5 if (tags or author or path_prefix) else limit
 
         try:
-            parsed_query = self.index.parse_query(full_query, ["title", "content"])
+            parsed_query = self.index.parse_query(full_query, ["title", "content", "entities"])
             results = searcher.search(parsed_query, effective_limit).hits
         except Exception as exc:
             logger.warning("Tantivy query parse/search failed: %s | query=%r", exc, full_query)

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1559,6 +1559,10 @@ class LithosServer:
                 # post-filter every mode's hits. Over-fetch to compensate,
                 # mirroring the engine's own post-filter heuristic.
                 entity_candidates = self.knowledge.entities_candidate_ids(entities)
+                if entity_candidates is not None and not entity_candidates:
+                    # No document carries every requested entity — skip the
+                    # backend search entirely.
+                    return {"results": []}
                 fetch_limit = limit * 5 if entity_candidates is not None else limit
 
                 def _build_result(r: Any, score_attr: str = "score") -> dict[str, Any]:
@@ -2021,6 +2025,12 @@ class LithosServer:
                     # same bound the other two post-filters already accept.
                     meta_candidates = self.knowledge.metadata_candidate_ids(metadata_match)
                     entity_candidates = self.knowledge.entities_candidate_ids(entities)
+                    if (meta_candidates is not None and not meta_candidates) or (
+                        entity_candidates is not None and not entity_candidates
+                    ):
+                        # An equality filter matched nothing — no point walking
+                        # the ranked window.
+                        fts_results = []
                     matching_ids: list[str] = []
                     for r in fts_results:
                         if meta_candidates is not None and r.id not in meta_candidates:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1494,6 +1494,7 @@ class LithosServer:
             threshold: float | None = None,
             seed_ids: list[str] | None = None,
             graph_depth: int = 2,
+            entities: list[str] | None = None,
             agent_id: str | None = None,
         ) -> dict[str, Any]:
             """Search across the knowledge base.
@@ -1523,6 +1524,10 @@ class LithosServer:
                 seed_ids: Starting document IDs for graph mode.  If omitted,
                           seeds are discovered via hybrid search.
                 graph_depth: BFS hop depth for graph mode (1-3, default: 2)
+                entities: Filter results to documents whose ``entities``
+                          frontmatter contains every named entity (exact
+                          match, AND). Applies to all modes; resolved via an
+                          inverted index and applied as a post-filter.
                 agent_id: Caller identity for audit logging (optional)
 
             Returns:
@@ -1549,6 +1554,13 @@ class LithosServer:
                         "message": f"Unknown search mode {mode!r}. Valid values: hybrid, fulltext, semantic, graph.",
                     }
 
+                # Entities are not a per-backend filter: resolve the candidate
+                # set once from the knowledge inverted index (#316) and
+                # post-filter every mode's hits. Over-fetch to compensate,
+                # mirroring the engine's own post-filter heuristic.
+                entity_candidates = self.knowledge.entities_candidate_ids(entities)
+                fetch_limit = limit * 5 if entity_candidates is not None else limit
+
                 def _build_result(r: Any, score_attr: str = "score") -> dict[str, Any]:
                     return {
                         "id": r.id,
@@ -1573,7 +1585,7 @@ class LithosServer:
                     ft_results = await asyncio.to_thread(
                         self.search.full_text_search,
                         query=query,
-                        limit=limit,
+                        limit=fetch_limit,
                         tags=tags,
                         author=author,
                         path_prefix=path_prefix,
@@ -1583,7 +1595,7 @@ class LithosServer:
                     sem_results = await asyncio.to_thread(
                         self.search.semantic_search,
                         query=query,
-                        limit=limit,
+                        limit=fetch_limit,
                         threshold=threshold,
                         tags=tags,
                         author=author,
@@ -1599,7 +1611,7 @@ class LithosServer:
                         graph=self.graph,
                         seed_ids=seed_ids,
                         depth=graph_depth,
-                        limit=limit,
+                        limit=fetch_limit,
                         tags=tags,
                         author=author,
                         path_prefix=path_prefix,
@@ -1611,13 +1623,18 @@ class LithosServer:
                     hybrid_results = await asyncio.to_thread(
                         self.search.hybrid_search,
                         query=query,
-                        limit=limit,
+                        limit=fetch_limit,
                         threshold=threshold,
                         tags=tags,
                         author=author,
                         path_prefix=path_prefix,
                     )
                     results_payload = [_build_result(r) for r in hybrid_results]
+
+                if entity_candidates is not None:
+                    results_payload = [r for r in results_payload if r["id"] in entity_candidates][
+                        :limit
+                    ]
 
                 span.set_attribute("lithos.result_count", len(results_payload))
                 logger.info("lithos_search mode=%s results=%d", mode, len(results_payload))
@@ -1918,6 +1935,7 @@ class LithosServer:
             title_contains: str | None = None,
             content_query: str | None = None,
             metadata_match: dict | None = None,
+            entities: list[str] | None = None,
         ) -> dict[str, Any]:
             """List knowledge documents with filters.
 
@@ -1929,6 +1947,9 @@ class LithosServer:
                 limit: Max results (default: 50)
                 offset: Pagination offset
                 title_contains: Filter by case-insensitive substring match on title
+                entities: Filter by entity names from the document's ``entities``
+                    frontmatter (AND across the list, exact match). Resolved via
+                    an inverted index (no full scan).
                 metadata_match: Filter by free-form metadata (AND across keys). For
                     each ``key: q`` a document matches when its stored metadata
                     value equals ``q`` or is a list containing ``q`` (so a note with
@@ -1999,9 +2020,12 @@ class LithosServer:
                     # only ever dropped if >1e6 docs match content_query — the
                     # same bound the other two post-filters already accept.
                     meta_candidates = self.knowledge.metadata_candidate_ids(metadata_match)
+                    entity_candidates = self.knowledge.entities_candidate_ids(entities)
                     matching_ids: list[str] = []
                     for r in fts_results:
                         if meta_candidates is not None and r.id not in meta_candidates:
+                            continue
+                        if entity_candidates is not None and r.id not in entity_candidates:
                             continue
                         cached = self.knowledge.get_cached_meta(r.id)
                         if cached is None:
@@ -2038,6 +2062,7 @@ class LithosServer:
                         author=author,
                         since=since_dt,
                         metadata_match=metadata_match,
+                        entities=entities,
                         limit=0,
                         offset=0,
                     )
@@ -2048,6 +2073,7 @@ class LithosServer:
                             author=author,
                             since=since_dt,
                             metadata_match=metadata_match,
+                            entities=entities,
                             limit=total_base,
                             offset=0,
                         )
@@ -2063,6 +2089,7 @@ class LithosServer:
                         author=author,
                         since=since_dt,
                         metadata_match=metadata_match,
+                        entities=entities,
                         limit=limit,
                         offset=offset,
                     )

--- a/tests/test_freshness_conformance.py
+++ b/tests/test_freshness_conformance.py
@@ -383,10 +383,13 @@ class TestOnDiskCompatibilityConformance:
 class TestSchemaConformance:
     """Conformance: schema version and rebuild."""
 
-    def test_schema_version_not_bumped(self):
-        """Phase 4 does not bump Tantivy SCHEMA_VERSION."""
-        # expires_at field already existed in the schema
-        assert TantivyIndex.SCHEMA_VERSION == "3"
+    def test_schema_version_pinned(self):
+        """Pin Tantivy SCHEMA_VERSION — bump this test only with a schema change.
+
+        History: "3" through the freshness phase (expires_at already existed);
+        "4" when #316 added the entities field.
+        """
+        assert TantivyIndex.SCHEMA_VERSION == "4"
 
     @pytest.mark.asyncio
     async def test_startup_rebuild_path(self, server: LithosServer, test_config):

--- a/tests/test_indexable_document.py
+++ b/tests/test_indexable_document.py
@@ -131,3 +131,23 @@ async def test_search_remove_by_id(test_config: LithosConfig) -> None:
 
     results = engine.full_text_search("Body")
     assert not any(r.id == indexable.id for r in results)
+
+
+def test_to_indexable_includes_entities() -> None:
+    """Entities cross the seam as a tuple (#316)."""
+    doc = _make_doc()
+    doc.metadata.entities = ["Quetzalcoatl Systems", "Lithos"]
+    indexable = KnowledgeManager.to_indexable(doc)
+    assert indexable.entities == ("Quetzalcoatl Systems", "Lithos")
+
+
+@pytest.mark.asyncio
+async def test_curated_entity_matches_full_text_search(test_config: LithosConfig) -> None:
+    """A curated entity absent from the body is findable via the entities field (#316)."""
+    engine = await SearchEngine.create(test_config)
+    doc = _make_doc()
+    doc.metadata.entities = ["Quetzalcoatl"]
+    engine.index(KnowledgeManager.to_indexable(doc))
+
+    results = engine.full_text_search("Quetzalcoatl")
+    assert any(r.id == doc.id for r in results)

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1098,6 +1098,83 @@ class TestMetadataFiltering:
         assert counting.iter_count >= 1
 
 
+class TestEntitiesListFilter:
+    """Entities filter on list_all via the inverted index (#316)."""
+
+    async def _mk(self, km: KnowledgeManager, title: str, entities: list[str]) -> str:
+        doc_id = (await km.create(title=title, content="Body.", agent="agent")).document.id
+        await km.update(id=doc_id, agent="lithos-enrich", entities=entities, entities_extractor=2)
+        return doc_id
+
+    @pytest.mark.asyncio
+    async def test_single_entity_match(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", ["NetworkX", "Lithos"])
+        await self._mk(knowledge_manager, "B", ["ChromaDB"])
+        docs, total = await knowledge_manager.list_all(entities=["NetworkX"])
+        assert total == 1
+        assert [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_multi_entity_and(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", ["NetworkX", "Lithos"])
+        await self._mk(knowledge_manager, "B", ["NetworkX"])
+        docs, total = await knowledge_manager.list_all(entities=["NetworkX", "Lithos"])
+        assert total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, knowledge_manager: KnowledgeManager):
+        await self._mk(knowledge_manager, "A", ["Lithos"])
+        docs, total = await knowledge_manager.list_all(entities=["Nonexistent"])
+        assert total == 0 and docs == []
+
+    @pytest.mark.asyncio
+    async def test_update_moves_doc_between_buckets(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", ["OldEntity"])
+        await knowledge_manager.update(
+            id=a, agent="lithos-enrich", entities=["NewEntity"], entities_extractor=2
+        )
+        _, old_total = await knowledge_manager.list_all(entities=["OldEntity"])
+        docs, new_total = await knowledge_manager.list_all(entities=["NewEntity"])
+        assert old_total == 0
+        assert new_total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_from_bucket(self, knowledge_manager: KnowledgeManager):
+        a = await self._mk(knowledge_manager, "A", ["Lithos"])
+        await knowledge_manager.delete(id=a)
+        _, total = await knowledge_manager.list_all(entities=["Lithos"])
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_combines_with_tags(self, knowledge_manager: KnowledgeManager):
+        a = (
+            await knowledge_manager.create(
+                title="A", content="Body.", agent="agent", tags=["robotics"]
+            )
+        ).document.id
+        await knowledge_manager.update(
+            id=a, agent="lithos-enrich", entities=["Festo"], entities_extractor=2
+        )
+        b = (
+            await knowledge_manager.create(
+                title="B", content="Body.", agent="agent", tags=["finance"]
+            )
+        ).document.id
+        await knowledge_manager.update(
+            id=b, agent="lithos-enrich", entities=["Festo"], entities_extractor=2
+        )
+        docs, total = await knowledge_manager.list_all(entities=["Festo"], tags=["robotics"])
+        assert total == 1 and [d.id for d in docs] == [a]
+
+    @pytest.mark.asyncio
+    async def test_survives_reload_from_disk(self, knowledge_manager: KnowledgeManager):
+        """The entities index is rebuilt by the startup scan."""
+        a = await self._mk(knowledge_manager, "A", ["Persistent Entity"])
+        reloaded = KnowledgeManager(knowledge_manager.config)
+        docs, total = await reloaded.list_all(entities=["Persistent Entity"])
+        assert total == 1 and [d.id for d in docs] == [a]
+
+
 class TestDocumentPersistence:
     """Tests for document file persistence."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2713,6 +2713,54 @@ class TestMetadataMatchFilterTool:
         assert res["status"] == "invalid_input"
 
 
+class TestEntitiesFilterTool:
+    """Tool-layer tests for the entities filter on lithos_list and lithos_search (#316)."""
+
+    async def _list(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_list")).fn(**kwargs)
+
+    async def _search(self, server: LithosServer, **kwargs) -> dict:
+        return await (await server.mcp.get_tool("lithos_search")).fn(**kwargs)
+
+    async def _make_entity_doc(self, server: LithosServer, title: str, entities: list[str]) -> str:
+        doc = (
+            await server.knowledge.create(
+                title=title, content=f"Body of {title}.", agent="agent"
+            )
+        ).document
+        await server.knowledge.update(
+            id=doc.id, agent="lithos-enrich", entities=entities, entities_extractor=2
+        )
+        refreshed, _ = await server.knowledge.read(id=doc.id)
+        server.search.index(server.knowledge.to_indexable(refreshed))
+        return doc.id
+
+    @pytest.mark.asyncio
+    async def test_list_entities_filter(self, server: LithosServer):
+        a = await self._make_entity_doc(server, "Robot note", ["Festo", "GripperAI"])
+        await self._make_entity_doc(server, "Finance note", ["Broadridge"])
+        res = await self._list(server, entities=["Festo"])
+        assert [i["id"] for i in res["items"]] == [a]
+        # AND semantics
+        res2 = await self._list(server, entities=["Festo", "Broadridge"])
+        assert res2["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_search_entities_filter(self, server: LithosServer):
+        a = await self._make_entity_doc(server, "Robot gripper note", ["Festo"])
+        await self._make_entity_doc(server, "Robot arm note", ["Broadridge"])
+        res = await self._search(server, query="Robot", mode="fulltext", entities=["Festo"])
+        ids = [r["id"] for r in res["results"]]
+        assert a in ids
+        assert len(ids) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_entities_filter_no_match(self, server: LithosServer):
+        await self._make_entity_doc(server, "Robot gripper note", ["Festo"])
+        res = await self._search(server, query="Robot", mode="fulltext", entities=["Nonexistent"])
+        assert res["results"] == []
+
+
 class TestTaskMetadataTool:
     """Tests for metadata field in lithos_task_create, lithos_task_update, lithos_task_list, lithos_task_status (#215)."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2724,9 +2724,7 @@ class TestEntitiesFilterTool:
 
     async def _make_entity_doc(self, server: LithosServer, title: str, entities: list[str]) -> str:
         doc = (
-            await server.knowledge.create(
-                title=title, content=f"Body of {title}.", agent="agent"
-            )
+            await server.knowledge.create(title=title, content=f"Body of {title}.", agent="agent")
         ).document
         await server.knowledge.update(
             id=doc.id, agent="lithos-enrich", entities=entities, entities_extractor=2


### PR DESCRIPTION
## Summary

Closes #316 — the consumer half of the #313 entity-quality work. Entities were write-only metadata: not in the Tantivy schema, not in `to_indexable`, not filterable anywhere. Now they're a retrieval signal.

### Search engine

- `IndexableDocument` gains `entities: tuple[str, ...]` (defaulted, no call-site churn); `KnowledgeManager.to_indexable` forwards them
- Tantivy schema gains an `entities` text field (`en_stem`, stored, newline-joined); **`SCHEMA_VERSION` 3 → 4** — the existing mismatch path rebuilds the index automatically on first startup after upgrade
- `entities` joins the default query fields (`title`, `content`, `entities`): query terms matching a document's entities boost its BM25 ranking, and **curated entities are findable even when absent from the body**

### Entity filters (sub-linear, no full scans)

- New `_entities_index` inverted index in the metadata cache — exact mirror of `_tag_index`, maintained at all four cache-construction sites (scan, create, update, sync_from_disk) and torn down in `_deindex_doc`
- `list_all()` / `_candidate_ids()` gain an `entities` filter (AND semantics, same shape as `tags`)
- `lithos_list(entities=[...])` — threaded through all three branches (plain, `title_contains`, `content_query` candidate-set intersection)
- `lithos_search(entities=[...])` — applies to **all four modes** (hybrid/fulltext/semantic/graph) via a single candidate-set lookup + post-filter with 5× over-fetch, mirroring the engine's own post-filter heuristic
- Public wrapper `entities_candidate_ids()` mirrors `metadata_candidate_ids()` (#306)

### Notes

- Per-doc index updates flow through the existing `update()` reindex path, so the enrichment worker's re-extractions and the #315 bootstrap sweep keep the filter index current automatically
- SPECIFICATION.md: `lithos_search`/`lithos_list` argument tables, filter semantics, and the frontmatter `entities` entry (no longer "advisory")

## Test plan

- [x] `tests/test_indexable_document.py`: entities cross the seam; curated entity absent from body is findable via full-text search (real Tantivy)
- [x] `tests/test_knowledge.py::TestEntitiesListFilter`: single/AND match, no-match, update moves docs between buckets, delete removes, combines with tags, index rebuilt by startup scan
- [x] `tests/test_server.py::TestEntitiesFilterTool`: `lithos_list` filter + AND, `lithos_search` filter and no-match (fulltext mode, real engine)
- [x] `make lint` ✓ · `make typecheck` ✓ · `make test` 1297 passed ✓ · `make test-integration` ✓
