### PR TITLE
fix: publish each plugin by explicit path

### DIFF
--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -19,4 +19,6 @@ jobs:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish plugins
         working-directory: agent-skills
-        run: tessl plugin publish
+        run: |
+          tessl plugin publish ./plugins/lithos
+          tessl plugin publish ./plugins/influx-inbox


### PR DESCRIPTION
## Problem

`tessl plugin publish` without a path argument looks for `.tessl-plugin/plugin.json` in the current working directory. The workflow runs it from `agent-skills/` which has no manifest at that level — manifests are nested under `plugins/lithos/` and `plugins/influx-inbox/`.

This caused the first CI run to fail immediately:
> ✘ No plugin manifest found. Expected tile.json or .tessl-plugin/plugin.json in the package root.

## Fix

Pass each plugin directory explicitly:
```yaml
run: |
  tessl plugin publish ./plugins/lithos
  tessl plugin publish ./plugins/influx-inbox
```

Fixes: https://github.com/agent-lore/lithos/actions/runs/27114714080/job/80019335323