### PR TITLE
fix: add workflow_dispatch and trigger on workflow file changes

### DIFF
--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -19,4 +19,6 @@ jobs:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish plugins
         working-directory: agent-skills
-        run: tessl plugin publish
+        run: |
+          tessl plugin publish ./plugins/lithos
+          tessl plugin publish ./plugins/influx-inbox

--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'agent-skills/**'
+      - '.github/workflows/publish-agent-skills.yml'
+  workflow_dispatch:  # allow manual trigger from the GitHub UI
 
 permissions:
   id-token: write   # Required for OIDC repo linking


### PR DESCRIPTION
## Problem

The previous fix (PR #326) only touched `.github/workflows/publish-agent-skills.yml`, not `agent-skills/**`, so the path filter blocked the publish run from triggering on merge.

## Fix

Two changes:
1. **`workflow_dispatch`** — allows manual trigger from the GitHub Actions UI so the first publish can be kicked off without needing a dummy commit
2. **Widen path filter** to include the workflow file itself (`.github/workflows/publish-agent-skills.yml`) — future workflow-only fixes will re-trigger publish

After merging this PR, go to **Actions → Publish Agent Skills → Run workflow** to do the first publish.