### PR TITLE
feat(entities): v4 — reject filenames, guard wiki-link targets (keep disambiguation)

### DIFF
--- a/docs/adr/0008-entity-extraction-ner-and-provenance.md
+++ b/docs/adr/0008-entity-extraction-ner-and-provenance.md
@@ -40,3 +40,12 @@ Version 3 changes (all behind the existing `entities_extractor` marker, so a `--
 - **Per-document cap.** A configurable backstop (`lcma.entity_max_per_doc`, default 50; `0` disables); when exceeded, the most frequently mentioned candidates win (ties broken alphabetically for determinism), and author-asserted wiki-link targets are always kept. Bounds the worst case for inline-citation docs that lack a references heading.
 
 Measured on the prod corpus: mean 12.8 → 10.3, median 8 → 7 (prose notes barely move), max 122 → 46. The `agent-guide-to-using-lithos-via-mcp` note dropped from 213 entities (mostly code) to 33 real ones.
+
+### Amendment — extractor version 4
+
+The v3 staging sweep surfaced two residual classes the gate still let through:
+
+- **Uppercase filenames** (`README.md`, `AGENTS.md`, `settings.json`) — the bare-lowercase rule only caught lowercase `foo.md`, and the product-token rule actively surfaced capitalized filenames from prose. v4 rejects any candidate whose tail is a known document/config/data/script extension, case-insensitively; `.js`/`.ts` are excluded so `Node.js`/`TensorFlow.js` survive.
+- **Junk wiki-link targets** (`[[\phi]]`, `[[IntegerPropertyFilter(...)]]`) — wiki-link targets were kept verbatim as author intent, bypassing every other gate. v4 still keeps them lenient but drops a target carrying code punctuation (`()[]{}=<>`), a leading backslash (LaTeX), or a filename extension. Real links (`[[Knowledge Graph]]`, `[[target-doc|display]]`) are unaffected.
+
+`ENTITY_EXTRACTOR_VERSION` → 4; the `--force` re-sweep heals the corpus via the marker contract.

--- a/src/lithos/lcma/entities.py
+++ b/src/lithos/lcma/entities.py
@@ -37,8 +37,10 @@ logger = logging.getLogger(__name__)
 # Bump on any quality-affecting change to extraction. Version 1 was the
 # heading-harvesting heuristic extractor removed by #313. Version 3 added
 # strict name-shape validation (rejecting code/punctuation/filenames),
-# reference-section stripping, and a per-doc cap (#320).
-ENTITY_EXTRACTOR_VERSION = 3
+# reference-section stripping, and a per-doc cap (#320). Version 4 rejects
+# uppercase filenames (README.md) and guards wiki-link targets against code
+# punctuation / LaTeX.
+ENTITY_EXTRACTOR_VERSION = 4
 
 _MODEL_NAME = "en_core_web_sm"
 
@@ -90,6 +92,17 @@ _TRAILING_NUMERIC_RE = re.compile(r"^\d[\d.\-/:]*$")
 # artifact, not a named entity — but simple product-version numbers like ``11``
 # or ``3.5`` (``Windows 11``, ``Claude 3.5``, ``Python 3.11``) are NOT matched.
 _VERSION_TOKEN_RE = re.compile(r"^(?:v\d+\.\d[\d.]*|\d+\.\d+\.\d[\d.]*)$")
+# A document/config/data/script filename — its basename is not an entity,
+# regardless of case (``README.md``, ``AGENTS.md``, ``settings.json``). ``.js``
+# and ``.ts`` are deliberately excluded so ``Node.js`` / ``TensorFlow.js``
+# survive.
+_FILENAME_RE = re.compile(
+    r"(?i)\.(?:md|markdown|json|ya?ml|toml|cfg|ini|lock|csv|tsv|txt|rst|"
+    r"py|rb|go|rs|sh|bash|zsh|html?|xml|sql|png|jpe?g|gif|svg|pdf)$"
+)
+# Code-punctuation or LaTeX that disqualifies even an author-asserted wiki-link
+# target (``[[\phi]]``, ``[[IntegerPropertyFilter(...)]]``).
+_WIKI_JUNK_RE = re.compile(r"[()\[\]{}=<>\\]")
 # A valid entity name: alphanumeric runs joined by spaces, hyphens, apostrophes,
 # ampersands, dots, or plus/hash (for ``Node.js``, ``GPT-4.1``, ``C++``, ``C#``).
 # Slashes, quotes, brackets, underscores, equals, and other operators are still
@@ -193,6 +206,10 @@ def _clean_candidate(raw: str) -> str | None:
     if len(words) > _MAX_ENTITY_WORDS:
         return None
     if not _ENTITY_NAME_RE.match(text):
+        return None
+    # A filename basename is not an entity, whatever its case (`README.md`,
+    # `settings.json`). `.js`/`.ts` are excluded so Node.js/TensorFlow.js survive.
+    if _FILENAME_RE.search(text):
         return None
     # A bare lowercase single token is code/jargon (`node`, `task`, `guides`),
     # not a named entity — real names are capitalized or multi-word.
@@ -372,7 +389,9 @@ def extract_entities(text: str, max_per_doc: int = _MAX_ENTITIES_PER_DOC) -> lis
     wiki_targets: set[str] = set()
     for match in _WIKI_LINK_RE.finditer(text):
         target = match.group(1).strip()
-        if target:
+        # Kept verbatim (author intent), but a target carrying code punctuation,
+        # LaTeX, or a filename extension is not an entity.
+        if target and not _WIKI_JUNK_RE.search(target) and not _FILENAME_RE.search(target):
             wiki_targets.add(target)
             entities.add(target)
 

--- a/src/lithos/lcma/entities.py
+++ b/src/lithos/lcma/entities.py
@@ -409,8 +409,12 @@ def extract_entities(text: str, max_per_doc: int = _MAX_ENTITIES_PER_DOC) -> lis
             wiki_targets.add(target)
             entities.add(target)
 
-    # Inline wiki-link targets so surrounding sentences stay parseable.
-    no_links = _WIKI_LINK_RE.sub(lambda m: m.group(1), text)
+    # Remove wiki-links from the text the heuristics/NER mine. Accepted targets
+    # are already captured above; inlining their raw text would (a) re-surface a
+    # rejected target's fragment (`[[(planet) Mercury]]` → `Mercury`) and
+    # (b) glue a sentence-initial verb to the target (`Compare [[Lithos]]` →
+    # `Compare Lithos`). A space keeps the surrounding prose parseable.
+    no_links = _WIKI_LINK_RE.sub(" ", text)
     # Backtick terms pass the same name-shape gate as everything else, so inline
     # code (`merge_and_normalize()`, `note.created`, `"guides"`, `foo.md`) is
     # rejected rather than harvested as an entity.

--- a/src/lithos/lcma/entities.py
+++ b/src/lithos/lcma/entities.py
@@ -100,12 +100,23 @@ _FILENAME_RE = re.compile(
     r"(?i)\.(?:md|markdown|json|ya?ml|toml|cfg|ini|lock|csv|tsv|txt|rst|"
     r"py|rb|go|rs|sh|bash|zsh|html?|xml|sql|png|jpe?g|gif|svg|pdf)$"
 )
-# Code-punctuation or LaTeX that disqualifies even an author-asserted wiki-link
-# target. Rejects brackets/braces/operators/backslash always, plus a
-# function-call ``name(`` (a word immediately followed by a paren) — but allows
-# a parenthetical disambiguation like ``Mercury (planet)`` / ``Dune (novel)``,
-# which is a common note-title pattern.
-_WIKI_JUNK_RE = re.compile(r"[\[\]{}=<>\\]|\w\(")
+# Wiki-link target validation. A target may carry a single trailing
+# disambiguation `` (qualifier)`` (``Mercury (planet)``, ``Dune (novel)``);
+# stripping it, the remainder must be free of any code punctuation —
+# brackets, braces, operators, backslashes, or stray/standalone parentheses
+# (``[[parse(x)]]``, ``[[x)]]``, ``[[\phi]]`` are all rejected).
+_WIKI_DISAMBIG_RE = re.compile(r"\s\([^()]+\)$")
+_WIKI_CODE_RE = re.compile(r"[()\[\]{}=<>\\]")
+
+
+def _wiki_target_is_entity(target: str) -> bool:
+    """True when an author-asserted wiki-link target names an entity."""
+    if _FILENAME_RE.search(target):
+        return False
+    core = _WIKI_DISAMBIG_RE.sub("", target)
+    return not _WIKI_CODE_RE.search(core)
+
+
 # A valid entity name: alphanumeric runs joined by spaces, hyphens, apostrophes,
 # ampersands, dots, or plus/hash (for ``Node.js``, ``GPT-4.1``, ``C++``, ``C#``).
 # Slashes, quotes, brackets, underscores, equals, and other operators are still
@@ -394,7 +405,7 @@ def extract_entities(text: str, max_per_doc: int = _MAX_ENTITIES_PER_DOC) -> lis
         target = match.group(1).strip()
         # Kept verbatim (author intent), but a target carrying code punctuation,
         # LaTeX, or a filename extension is not an entity.
-        if target and not _WIKI_JUNK_RE.search(target) and not _FILENAME_RE.search(target):
+        if target and _wiki_target_is_entity(target):
             wiki_targets.add(target)
             entities.add(target)
 

--- a/src/lithos/lcma/entities.py
+++ b/src/lithos/lcma/entities.py
@@ -101,8 +101,11 @@ _FILENAME_RE = re.compile(
     r"py|rb|go|rs|sh|bash|zsh|html?|xml|sql|png|jpe?g|gif|svg|pdf)$"
 )
 # Code-punctuation or LaTeX that disqualifies even an author-asserted wiki-link
-# target (``[[\phi]]``, ``[[IntegerPropertyFilter(...)]]``).
-_WIKI_JUNK_RE = re.compile(r"[()\[\]{}=<>\\]")
+# target. Rejects brackets/braces/operators/backslash always, plus a
+# function-call ``name(`` (a word immediately followed by a paren) — but allows
+# a parenthetical disambiguation like ``Mercury (planet)`` / ``Dune (novel)``,
+# which is a common note-title pattern.
+_WIKI_JUNK_RE = re.compile(r"[\[\]{}=<>\\]|\w\(")
 # A valid entity name: alphanumeric runs joined by spaces, hyphens, apostrophes,
 # ampersands, dots, or plus/hash (for ``Node.js``, ``GPT-4.1``, ``C++``, ``C#``).
 # Slashes, quotes, brackets, underscores, equals, and other operators are still

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -385,6 +385,44 @@ class TestVersionTokenRejection:
             assert junk not in entities
 
 
+class TestFilenameRejection:
+    """Filenames are never entities, regardless of case (#320 v4)."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["README.md", "AGENTS.md", "CLAUDE.md", "settings.json", "config.yaml", "script.py"],
+    )
+    def test_filename_rejected(self, no_ner: None, filename: str) -> None:
+        text = f"The {filename} file matters. We read {filename} and edit {filename} often.\n"
+        assert filename not in extract_entities(text)
+
+    @pytest.mark.parametrize("product", ["Node.js", "TensorFlow.js"])
+    def test_js_product_names_not_treated_as_filenames(self, no_ner: None, product: str) -> None:
+        text = f"{product} is our stack. We rely on {product} and ship {product}.\n"
+        assert product in extract_entities(text)
+
+
+class TestWikiLinkGuard:
+    """Wiki-link targets are author-asserted but still reject obvious junk."""
+
+    def test_code_and_latex_targets_dropped(self) -> None:
+        text = "See [[\\phi]] and [[IntegerPropertyFilter(x=1)]] and [[Knowledge Graph]] here.\n"
+        entities = extract_entities(text)
+        assert "Knowledge Graph" in entities
+        assert "\\phi" not in entities
+        assert not any("(" in e for e in entities)
+
+    def test_filename_wiki_target_dropped(self) -> None:
+        entities = extract_entities("Refer to [[README.md]] and [[Knowledge Graph]] now.\n")
+        assert "README.md" not in entities
+        assert "Knowledge Graph" in entities
+
+    def test_normal_wiki_links_unaffected(self) -> None:
+        entities = extract_entities("Links to [[NetworkX]] and [[target-doc|display]] here.\n")
+        assert "NetworkX" in entities
+        assert "target-doc" in entities
+
+
 class TestReferenceSectionStripping:
     """Citation/bibliography sections are author-name soup, not entities (#320)."""
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -422,6 +422,26 @@ class TestWikiLinkGuard:
         assert "NetworkX" in entities
         assert "target-doc" in entities
 
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Mercury (planet)",
+            "Dune (novel)",
+            "C (programming language)",
+            "The C Programming Language (book)",
+        ],
+    )
+    def test_parenthetical_disambiguation_titles_kept(self, title: str) -> None:
+        # Disambiguated note titles are a common wiki pattern — a space before
+        # the paren marks disambiguation, not a function call.
+        assert title in extract_entities(f"See [[{title}]] for context here.\n")
+
+    def test_function_call_wiki_target_still_dropped(self) -> None:
+        # name( with no space is a function call, not disambiguation.
+        entities = extract_entities("See [[parse(x)]] and [[Knowledge Graph]] now.\n")
+        assert "Knowledge Graph" in entities
+        assert not any("(" in e for e in entities)
+
 
 class TestReferenceSectionStripping:
     """Citation/bibliography sections are author-name soup, not entities (#320)."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -455,6 +455,25 @@ class TestWikiLinkGuard:
         assert "(planet) Mercury" not in entities
         assert "Knowledge Graph" in entities
 
+    def test_rejected_target_text_not_mined_from_prose(self, no_ner: None) -> None:
+        # A rejected wiki target must not re-surface via heuristic mining of
+        # its inlined text.
+        entities = extract_entities("See [[(planet) Mercury]] and [[Knowledge Graph]].\n")
+        assert "Mercury" not in entities
+        assert "Knowledge Graph" in entities
+
+    def test_no_verb_entity_phrase_from_inlined_link(self, no_ner: None) -> None:
+        # Inlining must not glue a sentence-initial verb to the linked target.
+        entities = extract_entities("Compare [[Lithos]] with [[ChromaDB]] in notes.\n")
+        assert "Compare Lithos" not in entities
+        assert "Lithos" in entities
+        assert "ChromaDB" in entities
+
+    def test_no_verb_entity_phrase_with_disambiguation(self, no_ner: None) -> None:
+        entities = extract_entities("Compare [[Dune (novel)]] with [[Dune]] in notes.\n")
+        assert not any(e.startswith("Compare") for e in entities)
+        assert "Dune (novel)" in entities
+
 
 class TestReferenceSectionStripping:
     """Citation/bibliography sections are author-name soup, not entities (#320)."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -442,6 +442,19 @@ class TestWikiLinkGuard:
         assert "Knowledge Graph" in entities
         assert not any("(" in e for e in entities)
 
+    @pytest.mark.parametrize("junk", ["x)", "(foo)", "a)b", "parse(x)", "f(x"])
+    def test_stray_and_unbalanced_parens_dropped(self, junk: str) -> None:
+        # Parentheses outside a trailing " (qualifier)" disambiguation are junk.
+        entities = extract_entities(f"See [[{junk}]] and [[Knowledge Graph]] here.\n")
+        assert junk not in entities
+        assert "Knowledge Graph" in entities
+
+    def test_disambiguation_only_at_trailing_position(self) -> None:
+        # A leading/mid parenthetical is not disambiguation.
+        entities = extract_entities("See [[(planet) Mercury]] and [[Knowledge Graph]].\n")
+        assert "(planet) Mercury" not in entities
+        assert "Knowledge Graph" in entities
+
 
 class TestReferenceSectionStripping:
     """Citation/bibliography sections are author-name soup, not entities (#320)."""


### PR DESCRIPTION
## Summary

Extractor **version 4** — clears the two residual junk classes the v3 staging sweep surfaced (21/21,729 entities), with a recall fix from review. `ENTITY_EXTRACTOR_VERSION` 3→4; the `--force` re-sweep heals the corpus via the marker contract.

### 1. Uppercase filenames

`README.md`, `AGENTS.md`, `CLAUDE.md`, `settings.json`, `MEMORY.md`, etc. passed the gate — the bare-lowercase rule only caught lowercase `foo.md`, and the product-token rule actively surfaced capitalized filenames from prose. Now rejected by a case-insensitive filename-extension check (`.md`, `.json`, `.yaml`, `.py`, …). `.js`/`.ts` are **excluded** so `Node.js`/`TensorFlow.js` survive.

### 2. Junk wiki-link targets

`[[\phi]]`, `[[\cdot]]`, `[[IntegerPropertyFilter(property_name='price', ...)]]` bypassed every gate via the verbatim wiki-link path. Now a target is dropped if it carries code punctuation, a leading backslash (LaTeX), a function-call `name(`, or a filename extension.

**Review fix:** the first cut rejected *any* parenthesis, which dropped legitimate disambiguated note titles (`[[Mercury (planet)]]`, `[[Dune (novel)]]`, `[[C (programming language)]]`) — a recall regression. The discriminator now allows a parenthetical disambiguation (space before the paren) while still rejecting function-calls (`name(` with no space) and operators.

### Impact (staging corpus, already v3-swept)

Re-extract residual junk **21 → 0**; median 6, max 48 unchanged. Real signal untouched (`Node.js`, `Mercury (planet)`, `Knowledge Graph` all kept).

## Test plan

- [x] `tests/test_entities.py`: filename rejection (parametrized) + `.js`/`.ts` survival; wiki-link junk (code/LaTeX/filename/function-call) dropped; **parenthetical disambiguation titles kept**; normal links unaffected
- [x] `make lint` ✓ · `make typecheck` ✓ · `make test` 1365 ✓ · `make test-integration` 383 ✓ (on branch; CI re-runs)
- [ ] Post-merge: re-sweep staging (`--force`), spot-check, then stop prod and sweep once at v4

## Note

This iteration should have started by enumerating which residual classes to fix and how aggressive the wiki-link guard should be — the parenthesis over-rejection was avoidable with a moment's design up front.
