### PR TITLE
ci: cache uv downloads to survive transient CDN failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
         run: uv sync
@@ -34,6 +36,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
         run: uv sync
@@ -111,6 +115,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install integration test dependencies
         run: |


### PR DESCRIPTION
## Summary

#329's CI failed (Lint + Test) on a **504 Gateway Timeout** fetching the pinned `en_core_web_sm` spaCy model wheel from GitHub's release CDN during `uv sync`:

```
error: Failed to generate package metadata for `en-core-web-sm==3.8.0 @ direct+https://github.com/explosion/spacy-models/.../en_core_web_sm-3.8.0-py3-none-any.whl`
  Caused by: HTTP status server error (504 Gateway Timeout)
```

CI used `astral-sh/setup-uv@v4` **without caching**, so every Lint/Test/Integration run re-downloaded all dependencies (including that wheel) from scratch — a single transient CDN blip fails the whole job, requiring a manual re-run.

This adds `enable-cache: true` + `cache-dependency-glob: "uv.lock"` to all three `setup-uv` steps, so the uv cache (wheels included) persists across runs keyed on the lockfile. A transient CDN 504 can no longer fail a job once the wheel is cached, and CI gets faster.

Distinct from the two HuggingFace fixes (#319 baked the runtime model; #330 retries the build-time download) — this targets the **`uv sync` dependency-download** path.

## Test plan
- [x] `ci.yml` validates as YAML
- [ ] CI on this PR populates and reuses the cache
