### PR TITLE
fix(ci): bump actions/checkout to v5, add --bump patch to tessl publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -30,7 +30,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -66,7 +66,7 @@ jobs:
           haskell: true
           large-packages: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
           haskell: true
           large-packages: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract version
         id: version
@@ -102,7 +102,7 @@ jobs:
     needs: build-and-push
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -15,12 +15,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish plugins
         working-directory: agent-skills
         run: |
-          tessl plugin publish ./plugins/lithos
-          tessl plugin publish ./plugins/influx-inbox
+          tessl plugin publish ./plugins/lithos --bump patch
+          tessl plugin publish ./plugins/influx-inbox --bump patch

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -58,7 +58,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/review-agent-skills.yml
+++ b/.github/workflows/review-agent-skills.yml
@@ -9,7 +9,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}


### PR DESCRIPTION
## Summary

Two CI fixes in one pass:

### 1. `--bump patch` on tessl publish

The publish job was failing with:
```
✘ agent-lore/lithos@0.1.0 already exists. Bump the version in the manifest or use --bump patch|minor|major to auto-increment.
```
Every push to `main` retried the same `0.1.0` that was already published on the first run. Adding `--bump patch` lets tessl auto-increment on each publish.

Applies to both `plugins/lithos` and `plugins/influx-inbox`.

### 2. `actions/checkout@v4` → `@v5` (all 9 instances)

GitHub is forcing Node.js 24 on all actions from **June 16 2026**; `@v4` runs on Node.js 20 and will break. Bumped across all 5 workflow files:
- `.github/workflows/publish-agent-skills.yml`
- `.github/workflows/review-agent-skills.yml`
- `.github/workflows/ci.yml` (3 jobs)
- `.github/workflows/pypi.yml` (2 jobs)
- `.github/workflows/docker-publish.yml` (2 jobs)

Fixes: https://github.com/agent-lore/lithos/actions/runs/27135933021