### PR TITLE
feat(server): serve StreamableHTTP /mcp alongside legacy SSE (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ Use `localhost` if running on the same machine as OpenClaw, otherwise the name o
 claude mcp add --transport sse lithos http://localhost:8765/sse
 ```
 
+### MCP endpoints
+
+The HTTP server (`lithos serve --transport http`, the Docker default) exposes
+**both** MCP transports on the same port, so any compliant client can connect
+without a bridge:
+
+| Endpoint | Transport | Use with |
+|---|---|---|
+| `GET http://localhost:8765/sse` | Legacy SSE | Agent Zero, OpenClaw, older clients |
+| `POST http://localhost:8765/mcp` | StreamableHTTP (MCP 2025-03-26+, stateless) | Claude Desktop, Hermes Agent, newer clients |
+
+Clients that speak StreamableHTTP should point at `/mcp`:
+
+```bash
+claude mcp add --transport http lithos http://localhost:8765/mcp
+```
+
 ## Documentation
 
 - [CLI Reference](docs/cli.md) — installing and using the `lithos` command-line tool
@@ -132,8 +149,8 @@ uv run ruff check --fix . && uv run ruff format src/ tests/
 # Start server (stdio)
 uv run lithos serve
 
-# Start server (SSE)
-uv run lithos serve --transport sse --port 8765
+# Start server (HTTP — serves both /mcp and /sse)
+uv run lithos serve --transport http --port 8765
 
 # Docker
 cd docker && docker compose up -d --build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,5 +90,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 USER 1000:1000
 
-# Default command: run SSE server
-CMD ["python", "-m", "lithos.cli", "serve", "--transport", "sse", "--host", "0.0.0.0", "--port", "8765"]
+# Default command: run the HTTP server (serves both /mcp and /sse)
+CMD ["python", "-m", "lithos.cli", "serve", "--transport", "http", "--host", "0.0.0.0", "--port", "8765"]

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1071,6 +1071,8 @@ surfacing a particular document, without having to query SQLite directly.
 
 These endpoints are standard HTTP routes mounted alongside the MCP transport. They are **not** MCP tools and do not appear in `tools/list`. The server mounts three: `GET /health`, `GET /events`, and `GET /audit`.
 
+When run with `--transport http`, the server exposes both MCP transport endpoints on the same port: `POST /mcp` (StreamableHTTP, MCP 2025-03-26+, stateless) and `GET /sse` + `POST /messages/` (legacy SSE). Any compliant MCP client can connect to whichever it supports, with no bridge or proxy. The three custom routes above are served on the same port.
+
 #### `GET /health`
 
 Lightweight health check for Docker `HEALTHCHECK`, load balancers, and monitoring.
@@ -1361,9 +1363,9 @@ Configuration is managed via `pydantic-settings` (`LithosConfig`). Values are re
 ```yaml
 # Server configuration
 server:
-  transport: stdio          # stdio | sse
+  transport: stdio          # stdio | http (http serves both /mcp and /sse)
   host: 127.0.0.1          # Default bind address
-  port: 8765               # For SSE transport
+  port: 8765               # For the HTTP transport
   watch_files: true         # Enable file watcher for index updates
 
 # Storage paths
@@ -1419,8 +1421,8 @@ events:
 # Run with stdio transport (for MCP)
 lithos --data-dir ./data serve --transport stdio
 
-# Run with SSE transport (for HTTP access)
-lithos --data-dir ./data serve --transport sse --host 0.0.0.0 --port 8765
+# Run with HTTP transport (serves both /mcp StreamableHTTP and /sse)
+lithos --data-dir ./data serve --transport http --host 0.0.0.0 --port 8765
 
 # Disable file watcher
 lithos --data-dir ./data serve --no-watch

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,8 +47,9 @@ Options:
 # stdio transport (default — for MCP clients like Claude Desktop)
 lithos serve
 
-# SSE transport (for network clients like Agent Zero)
-lithos serve --transport sse --host 0.0.0.0 --port 8765
+# HTTP transport — serves both /mcp (StreamableHTTP) and /sse (legacy SSE)
+# on the same port, for network clients like Agent Zero and Hermes Agent.
+lithos serve --transport http --host 0.0.0.0 --port 8765
 
 # Disable file watcher
 lithos serve --no-watch
@@ -56,9 +57,9 @@ lithos serve --no-watch
 
 | Option | Default | Description |
 |---|---|---|
-| `-t, --transport` | `stdio` | Transport type: `stdio` or `sse` |
-| `--host` | `127.0.0.1` | Host for SSE transport |
-| `-p, --port` | `8765` | Port for SSE transport |
+| `-t, --transport` | `stdio` | Transport type: `stdio` or `http` (`http` serves both `/mcp` and `/sse`) |
+| `--host` | `127.0.0.1` | Host for the HTTP transport |
+| `-p, --port` | `8765` | Port for the HTTP transport |
 | `--watch / --no-watch` | watch enabled | Watch for file changes |
 | `--telemetry-console` | off | Route OTEL metrics + spans to stdout (for local debugging without a collector) |
 

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -47,21 +47,21 @@ def cli(ctx: click.Context, config: Path | None, data_dir: Path | None) -> None:
 @click.option(
     "--transport",
     "-t",
-    type=click.Choice(["stdio", "sse"]),
+    type=click.Choice(["stdio", "http"]),
     default="stdio",
-    help="Transport type (default: stdio)",
+    help="Transport type (default: stdio). 'http' serves both /mcp and /sse.",
 )
 @click.option(
     "--host",
     default="127.0.0.1",
-    help="Host for SSE transport (default: 127.0.0.1)",
+    help="Host for the HTTP transport (default: 127.0.0.1)",
 )
 @click.option(
     "--port",
     "-p",
     type=int,
     default=8765,
-    help="Port for SSE transport (default: 8765)",
+    help="Port for the HTTP transport (default: 8765)",
 )
 @click.option(
     "--watch/--no-watch",
@@ -133,17 +133,14 @@ def serve(
             # Run with stdio transport
             await server.mcp.run_stdio_async(show_banner=False)
         else:
-            # Run with SSE transport using run_http_async.
+            # Run the HTTP transport, which exposes both /mcp (StreamableHTTP)
+            # and /sse (legacy SSE) on the same port (#304).
             # Uvicorn loggers propagate to the root logger, which already has the
-            # JSON handler installed by setup_logging() below.  No separate
-            # uvicorn log_config is needed.
-            click.echo(f"Listening on http://{host}:{port}")
-            await server.mcp.run_http_async(
-                transport="sse",
+            # JSON handler installed by setup_logging() below.
+            click.echo(f"Listening on http://{host}:{port} (/mcp StreamableHTTP, /sse legacy)")
+            await server.serve_http(
                 host=host,
                 port=port,
-                path="/sse",
-                show_banner=False,
                 uvicorn_config={
                     "log_config": {
                         "version": 1,

--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -49,7 +49,7 @@ _DEFAULT_NOTE_TYPE_PRIORS: dict[str, float] = {
 class ServerConfig(BaseModel):
     """Server configuration."""
 
-    transport: Literal["stdio", "sse"] = "stdio"
+    transport: Literal["stdio", "http"] = "stdio"
     host: str = "127.0.0.1"
     port: int = 8765
     watch_files: bool = True

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -215,7 +215,25 @@ class LithosServer:
         base lifespan. Custom routes (``/events``, ``/health``, ``/audit``) are
         registered via ``custom_route`` and therefore appear in *both*
         sub-apps; the SSE copies are filtered out by path to avoid duplicates.
+
+        Splicing the SSE routes into the StreamableHTTP app is sound only while
+        both apps carry the *same* app-level middleware — which they do today:
+        with no auth configured, FastMCP gives each app just
+        ``RequestContextMiddleware``, so the base app's stack covers the spliced
+        routes identically. Configuring FastMCP auth would diverge the two
+        stacks (per-transport auth routes + middleware), so this method refuses
+        to run under auth rather than silently serving the SSE routes without
+        their auth wiring — revisit the composition before enabling auth.
         """
+        if self.mcp.auth is not None:
+            raise NotImplementedError(
+                "build_http_app composes the SSE and StreamableHTTP transports by "
+                "splicing routes under a shared middleware stack, which assumes no "
+                "per-transport auth wiring. FastMCP auth is configured — rework the "
+                "composition (e.g. mount each transport app with its own middleware) "
+                "before enabling it."
+            )
+
         # ``transport="http"`` is FastMCP's alias for StreamableHTTP.
         streamable_app = self.mcp.http_app(path="/mcp", transport="http", stateless_http=True)
         sse_app = self.mcp.http_app(path="/sse", transport="sse")

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
+from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 
@@ -191,6 +192,71 @@ class LithosServer:
     def config(self) -> LithosConfig:
         """Get configuration."""
         return self._config
+
+    def build_http_app(self) -> Starlette:
+        """Build a single ASGI app exposing both MCP HTTP transports (#304).
+
+        Lithos serves two transports on one port so any compliant MCP client
+        can connect without a bridge:
+
+        - ``POST /mcp`` — StreamableHTTP (MCP 2025-03-26+), stateless. All
+          Lithos state lives in the knowledge base (SQLite, ChromaDB,
+          Tantivy), never in the MCP session, so stateless mode is the right
+          fit — each request is independent.
+        - ``GET /sse`` + ``POST /messages/`` — legacy SSE, unchanged so
+          existing clients keep working.
+
+        The StreamableHTTP app is the base because its lifespan is a superset
+        of the SSE app's: both run FastMCP's ``_lifespan_manager`` (idempotent
+        — the second entry is a no-op), and the StreamableHTTP lifespan
+        additionally runs the session manager. The SSE transport needs nothing
+        beyond ``_lifespan_manager``, so its transport routes (``/sse`` and the
+        ``/messages`` mount) are appended to the base app and served under the
+        base lifespan. Custom routes (``/events``, ``/health``, ``/audit``) are
+        registered via ``custom_route`` and therefore appear in *both*
+        sub-apps; the SSE copies are filtered out by path to avoid duplicates.
+        """
+        # ``transport="http"`` is FastMCP's alias for StreamableHTTP.
+        streamable_app = self.mcp.http_app(path="/mcp", transport="http", stateless_http=True)
+        sse_app = self.mcp.http_app(path="/sse", transport="sse")
+
+        existing_paths = {getattr(route, "path", None) for route in streamable_app.router.routes}
+        for route in sse_app.router.routes:
+            if getattr(route, "path", None) not in existing_paths:
+                streamable_app.router.routes.append(route)
+
+        return streamable_app
+
+    async def serve_http(
+        self, host: str, port: int, uvicorn_config: dict[str, Any] | None = None
+    ) -> None:
+        """Serve both MCP HTTP transports via uvicorn until cancelled.
+
+        Mirrors the uvicorn configuration FastMCP uses in ``run_http_async``
+        (graceful-shutdown disabled, ASGI lifespan enabled, sans-io
+        websockets). The app's own lifespan — enabled by ``lifespan="on"`` —
+        runs the FastMCP lifespan manager and the StreamableHTTP session
+        manager, so no extra wrapping is required.
+
+        Args:
+            host: Interface to bind.
+            port: TCP port to bind.
+            uvicorn_config: Extra uvicorn ``Config`` kwargs (e.g. ``log_config``)
+                merged over the defaults.
+        """
+        import uvicorn
+
+        app = self.build_http_app()
+        config_kwargs: dict[str, Any] = {
+            "timeout_graceful_shutdown": 0,
+            "lifespan": "on",
+            "ws": "websockets-sansio",
+        }
+        if uvicorn_config:
+            config_kwargs.update(uvicorn_config)
+
+        config = uvicorn.Config(app, host=host, port=port, **config_kwargs)
+        await uvicorn.Server(config).serve()
 
     async def _emit(self, event: LithosEvent) -> None:
         """Emit an event, logging any failure without propagating."""

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -277,25 +277,18 @@ class TestCLIContracts:
         assert "Backend health" in unhealthy.output
         assert "search: unavailable: forced health failure" in unhealthy.output
 
-    def test_serve_stdio_and_sse_paths(self, temp_dir, monkeypatch):
+    def test_serve_stdio_and_http_paths(self, temp_dir, monkeypatch):
         config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
         config.ensure_directories()
         # set_config() needed for CLI commands invoked via Click's test runner (see
         # test_reindex_and_search_output_shape for the full explanation).
         set_config(config)
 
-        calls = {"watch_started": 0, "watch_stopped": 0, "stdio": 0, "sse": 0}
+        calls = {"watch_started": 0, "watch_stopped": 0, "stdio": 0, "http": 0}
 
         class _DummyMCP:
             async def run_stdio_async(self, show_banner=False):
                 calls["stdio"] += 1
-
-            async def run_http_async(self, **kwargs):
-                assert kwargs["transport"] == "sse"
-                assert kwargs["host"] == "127.0.0.1"
-                assert kwargs["port"] == 8766
-                assert kwargs["path"] == "/sse"
-                calls["sse"] += 1
 
         class _DummyWatchIntake:
             async def start(self, _loop):
@@ -312,6 +305,14 @@ class TestCLIContracts:
             async def initialize(self):
                 return None
 
+            async def serve_http(self, host, port, uvicorn_config=None):
+                assert host == "127.0.0.1"
+                assert port == 8766
+                # The HTTP transport serves both /mcp and /sse; the CLI no longer
+                # passes a transport/path — those are owned by serve_http itself.
+                assert uvicorn_config is not None
+                calls["http"] += 1
+
             async def shutdown(self):
                 calls["watch_stopped"] += 1
 
@@ -322,14 +323,14 @@ class TestCLIContracts:
         assert stdio.exit_code == 0, stdio.output
         assert "Starting MCP server (stdio transport)..." in stdio.output
 
-        sse = runner.invoke(
+        http = runner.invoke(
             cli,
             [
                 "--data-dir",
                 str(temp_dir),
                 "serve",
                 "--transport",
-                "sse",
+                "http",
                 "--host",
                 "127.0.0.1",
                 "--port",
@@ -337,11 +338,11 @@ class TestCLIContracts:
                 "--watch",
             ],
         )
-        assert sse.exit_code == 0, sse.output
-        assert "Listening on http://127.0.0.1:8766" in sse.output
+        assert http.exit_code == 0, http.output
+        assert "Listening on http://127.0.0.1:8766" in http.output
 
         assert calls["stdio"] == 1
-        assert calls["sse"] == 1
+        assert calls["http"] == 1
         assert calls["watch_started"] == 1
         assert calls["watch_stopped"] == 0
 

--- a/tests/test_integration_mcp_sse.py
+++ b/tests/test_integration_mcp_sse.py
@@ -1,4 +1,9 @@
-"""Integration test for MCP-over-SSE connectivity to a running server."""
+"""Integration tests for MCP HTTP connectivity to a running server.
+
+Lithos serves both transports on one port (#304): legacy SSE at ``/sse`` and
+StreamableHTTP at ``/mcp``. These tests exercise both against the real
+``LithosServer.serve_http`` boundary.
+"""
 
 import asyncio
 import json
@@ -15,6 +20,13 @@ from lithos.server import LithosServer
 mcp = pytest.importorskip("mcp", reason="mcp package is only installed in integration CI job")
 ClientSession = mcp.ClientSession
 sse_client = pytest.importorskip("mcp.client.sse").sse_client
+_streamable_http = pytest.importorskip("mcp.client.streamable_http")
+# ``streamable_http_client`` is the current name; older mcp releases only ship
+# the deprecated ``streamablehttp_client`` alias. Prefer the new name.
+streamablehttp_client = (
+    getattr(_streamable_http, "streamable_http_client", None)
+    or _streamable_http.streamablehttp_client
+)
 
 pytestmark = pytest.mark.integration
 
@@ -26,7 +38,8 @@ def _find_free_port() -> int:
 
 
 @asynccontextmanager
-async def _local_sse_endpoint(temp_dir: Path):
+async def _local_server(temp_dir: Path):
+    """Start a local Lithos HTTP server and yield its base URL (no path)."""
     config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
     config.ensure_directories()
     server = LithosServer(config)
@@ -34,29 +47,21 @@ async def _local_sse_endpoint(temp_dir: Path):
 
     host = "127.0.0.1"
     port = _find_free_port()
-    task = asyncio.create_task(
-        server.mcp.run_http_async(
-            transport="sse",
-            host=host,
-            port=port,
-            path="/sse",
-            show_banner=False,
-        )
-    )
+    task = asyncio.create_task(server.serve_http(host=host, port=port))
 
-    endpoint = f"http://{host}:{port}/sse"
+    base = f"http://{host}:{port}"
     try:
-        # Wait until endpoint is reachable.
+        # Wait until the SSE endpoint is reachable before yielding.
         for _ in range(100):
             try:
-                async with sse_client(endpoint):
+                async with sse_client(f"{base}/sse"):
                     break
             except Exception:
                 await asyncio.sleep(0.05)
         else:
-            raise AssertionError("Timed out waiting for local SSE endpoint to start")
+            raise AssertionError("Timed out waiting for local HTTP server to start")
 
-        yield endpoint
+        yield base
     finally:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
@@ -64,22 +69,51 @@ async def _local_sse_endpoint(temp_dir: Path):
 
 
 @asynccontextmanager
-async def _resolve_endpoint(temp_dir: Path):
+async def _resolve_base(temp_dir: Path):
+    """Yield the base server URL, honouring LITHOS_MCP_URL for CI.
+
+    ``LITHOS_MCP_URL`` may point at either the base URL or a transport path
+    (``/sse`` or ``/mcp``); the trailing transport segment is stripped so both
+    endpoints can be derived from the base.
+    """
     endpoint = os.environ.get("LITHOS_MCP_URL")
     if endpoint:
-        yield endpoint
+        base = endpoint.rstrip("/")
+        for suffix in ("/sse", "/mcp"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        yield base
         return
 
-    async with _local_sse_endpoint(temp_dir) as local_endpoint:
-        yield local_endpoint
+    async with _local_server(temp_dir) as base:
+        yield base
 
 
 @pytest.mark.asyncio
 async def test_mcp_sse_lists_tools(temp_dir):
     """Connect to Lithos MCP SSE endpoint and verify tool discovery."""
     async with (
-        _resolve_endpoint(temp_dir) as endpoint,
-        sse_client(endpoint) as (reader, writer),
+        _resolve_base(temp_dir) as base,
+        sse_client(f"{base}/sse") as (reader, writer),
+        ClientSession(reader, writer) as session,
+    ):
+        await asyncio.wait_for(session.initialize(), timeout=20)
+        tools = await asyncio.wait_for(session.list_tools(), timeout=20)
+
+    assert len(tools.tools) >= 20
+
+
+@pytest.mark.asyncio
+async def test_mcp_streamable_http_lists_tools(temp_dir):
+    """Connect to Lithos MCP StreamableHTTP endpoint (/mcp) and verify tools.
+
+    Guards the #304 acceptance criteria: POST /mcp speaks StreamableHTTP and
+    exposes the same tool set as /sse, with no proxy in between.
+    """
+    async with (
+        _resolve_base(temp_dir) as base,
+        streamablehttp_client(f"{base}/mcp") as (reader, writer, _get_session_id),
         ClientSession(reader, writer) as session,
     ):
         await asyncio.wait_for(session.initialize(), timeout=20)
@@ -100,8 +134,8 @@ def _decode_call_result(result) -> dict:
 async def test_mcp_sse_remote_tool_roundtrip(temp_dir):
     """Run an end-to-end tool workflow through the SSE MCP boundary."""
     async with (
-        _resolve_endpoint(temp_dir) as endpoint,
-        sse_client(endpoint) as (reader, writer),
+        _resolve_base(temp_dir) as base,
+        sse_client(f"{base}/sse") as (reader, writer),
         ClientSession(reader, writer) as session,
     ):
         await asyncio.wait_for(session.initialize(), timeout=20)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,13 +32,19 @@ class TestServerInitialization:
 
     def test_build_http_app_exposes_both_transports(self, server: LithosServer):
         """#304: the combined app serves StreamableHTTP (/mcp) and legacy SSE
-        (/sse + /messages) on one app, with custom routes present exactly once."""
+        (/sse + the message endpoint) on one app, with custom routes present
+        exactly once."""
         app = server.build_http_app()
-        paths = [getattr(route, "path", None) for route in app.router.routes]
+        routes = app.router.routes
+        paths = [getattr(route, "path", None) for route in routes]
 
         assert "/mcp" in paths, paths
         assert "/sse" in paths, paths
-        assert "/messages" in paths, paths
+        # The SSE message endpoint is a Mount. Starlette normalises its ``.path``
+        # to "/messages", but the prefix it actually serves — and the URL FastMCP
+        # advertises to SSE clients in the ``endpoint`` event — is "/messages/".
+        message_mount = next(r for r in routes if getattr(r, "path", None) == "/messages")
+        assert message_mount.path_format == "/messages/{path}", message_mount.path_format
         # Custom routes are registered once and must not be duplicated when the
         # SSE transport routes are merged into the StreamableHTTP base app.
         for custom in ("/events", "/health", "/audit"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,6 +30,20 @@ class TestServerInitialization:
         assert server.graph is not None
         assert server.coordination is not None
 
+    def test_build_http_app_exposes_both_transports(self, server: LithosServer):
+        """#304: the combined app serves StreamableHTTP (/mcp) and legacy SSE
+        (/sse + /messages) on one app, with custom routes present exactly once."""
+        app = server.build_http_app()
+        paths = [getattr(route, "path", None) for route in app.router.routes]
+
+        assert "/mcp" in paths, paths
+        assert "/sse" in paths, paths
+        assert "/messages" in paths, paths
+        # Custom routes are registered once and must not be duplicated when the
+        # SSE transport routes are merged into the StreamableHTTP base app.
+        for custom in ("/events", "/health", "/audit"):
+            assert paths.count(custom) == 1, (custom, paths)
+
     @pytest.mark.asyncio
     async def test_agent_count_cache_primed_at_startup(self, server: LithosServer):
         """Regression for #181: _cached_agent_count must reflect reality

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from starlette.routing import Mount
 
 from lithos.config import LithosConfig
 from lithos.knowledge import KnowledgeManager
@@ -44,6 +45,7 @@ class TestServerInitialization:
         # to "/messages", but the prefix it actually serves — and the URL FastMCP
         # advertises to SSE clients in the ``endpoint`` event — is "/messages/".
         message_mount = next(r for r in routes if getattr(r, "path", None) == "/messages")
+        assert isinstance(message_mount, Mount), type(message_mount)
         assert message_mount.path_format == "/messages/{path}", message_mount.path_format
         # Custom routes are registered once and must not be duplicated when the
         # SSE transport routes are merged into the StreamableHTTP base app.


### PR DESCRIPTION
## Summary

Closes #304. The Lithos HTTP server now exposes **both** MCP transports on the same port (8765), so any compliant client connects without the `supergateway` bridge:

| Endpoint | Transport | Status |
|---|---|---|
| `GET /sse` | Legacy SSE | ✅ Unchanged |
| `POST /mcp` | StreamableHTTP (MCP 2025-03-26+, stateless) | ✅ Newly enabled |

State lives entirely in the knowledge base (SQLite, ChromaDB, Tantivy), never in the MCP session, so the StreamableHTTP endpoint runs in **stateless** mode — each request is independent.

## ⚠️ Breaking change — server-side `--transport` value renamed `sse` → `http`

This is a deliberate, backwards-incompatible **CLI + config** change (clean rename, no BC alias, per project convention). It affects only the **server-side run-mode selector**, not any client connection:

- `lithos serve --transport sse` now **errors** (Click rejects the value). Use `lithos serve --transport http`.
- A config file with `server.transport: sse` now **raises a Pydantic validation error**. Use `transport: http`.
- The Docker `CMD` is updated in this PR. Any external scripts/configs pinning `sse` must be updated.

**Client compatibility is unaffected:** the `/sse` HTTP endpoint behaves exactly as before — SSE clients still connect to `http://host:8765/sse` unchanged. `/mcp` is purely additive. The renamed flag is how the *server process* chooses its run mode; clients never use it.

## How it works

`LithosServer.build_http_app()` composes one ASGI app from FastMCP's two transport apps. The StreamableHTTP app is the base (its lifespan runs both the FastMCP lifespan manager *and* the StreamableHTTP session manager); the SSE transport needs nothing beyond the FastMCP lifespan, so its routes (`/sse`, `/messages/`) are appended to the base app. Custom routes (`/events`, `/health`, `/audit`) appear in both sub-apps and are deduped by path. `serve_http()` runs the combined app under uvicorn, mirroring FastMCP's own `run_http_async` config.

The splice is valid because both transport apps carry identical app-level middleware today (`RequestContextMiddleware` only; no auth configured). To keep that assumption honest, `build_http_app()` raises `NotImplementedError` if FastMCP auth is ever configured, rather than silently serving the SSE routes without their auth wiring.

## Acceptance criteria

- [x] `POST /mcp` returns a valid MCP `initialize` response (StreamableHTTP)
- [x] `GET /sse` continues to work exactly as before (no client regression)
- [x] All existing Lithos MCP tools accessible via both endpoints
- [x] No additional process, port, or proxy required
- [x] Documentation updated with the StreamableHTTP endpoint

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` (src/) — 0 errors
- [x] `make test` — 1374 passed
- [x] `make test-integration` — passed, including new `test_mcp_streamable_http_lists_tools` (`/mcp`) + existing SSE roundtrips routed through the real `serve_http` boundary
- New unit test `test_build_http_app_exposes_both_transports` asserts `/mcp`, `/sse`, the `/messages/` mount, and that custom routes are not duplicated.
