### PR TITLE
fix(deps): stop publishing en-core-web-sm direct-URL dep + bump 0.3.3 (PyPI publish fix)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,11 +26,25 @@ COPY src/ ./src/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install .
 
+# Bake the spaCy NER model into the image. It is NOT a package dependency —
+# en_core_web_sm is a direct-URL wheel, which PyPI rejects, so it lives in the
+# dev group (installed by `uv sync`, but the builder uses `--no-dev`). At
+# runtime lithos would download it on first NER use, but baking it here keeps
+# container startup network-free (matching the embedding model below). Retried
+# with backoff because the GitHub release host is intermittently rate-limited
+# from shared CI IPs.
+RUN for attempt in 1 2 3 4 5; do \
+        python -m spacy download en_core_web_sm && exit 0; \
+        echo "spaCy model download attempt ${attempt} failed; retrying in $((attempt * 10))s"; \
+        sleep $((attempt * 10)); \
+    done; \
+    echo "ERROR: spaCy model download failed after 5 attempts" >&2; \
+    exit 1
+
 # Bake the default sentence-transformers embedding model into the image so the
 # runtime never downloads it from HuggingFace at startup. Container startup was
 # failing in CI when HF rate-limited (HTTP 429) the shared runner IPs; baking
-# the model makes startup network-free and fast. The spaCy NER model already
-# ships as a wheel dependency, so only the embedding model needs this.
+# the model makes startup network-free and fast.
 #
 # The download is retried with backoff: HuggingFace is intermittently
 # unreachable from shared CI IPs, and without retries a transient outage fails

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,6 +138,14 @@ each document's `entities` list with the current extractor's output and stamps
 agent-curated and skipped unless `--force` is given. Run `lithos reconcile`
 afterwards to refresh derived views.
 
+> **NER model:** entity extraction uses the spaCy `en_core_web_sm` model. It is
+> **not** a PyPI dependency (the model is distributed as a direct-URL wheel,
+> which PyPI rejects), so lithos **downloads it on first use** and caches it.
+> If the download fails (e.g. offline), extraction transparently falls back to
+> high-precision heuristic extraction — NER simply runs in degraded mode. To
+> pre-install it (or for fully offline use), run `python -m spacy download
+> en_core_web_sm`. The Docker image bakes it in at build time.
+
 ## Specifying a Data Directory
 
 All commands accept `--data-dir` (or `-d`) to point at a non-default data location:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,9 +142,10 @@ afterwards to refresh derived views.
 > **not** a PyPI dependency (the model is distributed as a direct-URL wheel,
 > which PyPI rejects), so lithos **downloads it on first use** and caches it.
 > If the download fails (e.g. offline), extraction transparently falls back to
-> high-precision heuristic extraction — NER simply runs in degraded mode. To
-> pre-install it (or for fully offline use), run `python -m spacy download
-> en_core_web_sm`. The Docker image bakes it in at build time.
+> high-precision heuristic extraction — NER simply runs in degraded mode.
+> To pre-install it (or for fully offline use), run
+> `python -m spacy download en_core_web_sm`. The Docker image bakes it in at
+> build time.
 
 ## Specifying a Data Directory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lithos-mcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "Shared cognitive substrate for AI agents (local-first, Markdown-native, MCP)"
 readme = "README.md"
 license = "MIT"
@@ -34,8 +34,6 @@ dependencies = [
     "click>=8.0.0",
     "python-json-logger>=3.0",
     "spacy>=3.8",
-    # Pinned NER model wheel; bump alongside the spacy minor version.
-    "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]
 
 [project.optional-dependencies]
@@ -55,10 +53,20 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
     "pyright>=1.1.0",
+    # spaCy NER model — kept OUT of [project.dependencies] because it is a
+    # direct-URL reference, which PyPI rejects on upload (`400 Can't have direct
+    # dependency`). It is not on PyPI. Here in the dev group, `uv sync` installs
+    # it for development/CI; production images install it explicitly (see
+    # docker/Dockerfile), and at runtime lithos downloads it on first NER use
+    # (lithos.lcma.entities), falling back to heuristic extraction if offline.
+    # Bump the pinned version alongside the spacy minor version.
+    "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]
 
 [tool.hatch.metadata]
-# Required for the en-core-web-sm direct wheel URL dependency.
+# Allow the dev-group's direct wheel URL (en-core-web-sm) during local/editable
+# builds. The published distribution carries no direct-URL deps (PyPI forbids
+# them); this only affects local `uv sync`/editable installs.
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]

--- a/src/lithos/lcma/entities.py
+++ b/src/lithos/lcma/entities.py
@@ -155,11 +155,40 @@ _NER_UNAVAILABLE = False
 _STOP_WORDS: frozenset[str] | None = None
 
 
+def _download_model() -> None:
+    """Download the spaCy NER model on demand.
+
+    ``en_core_web_sm`` is not on PyPI, and PyPI forbids direct-URL dependencies,
+    so the model cannot be a published package dependency — it is fetched the
+    first time NER runs. spaCy's downloader shells out to pip and may
+    ``sys.exit`` on failure; that ``SystemExit`` is normalised to a regular
+    exception so the caller's ``except Exception`` fallback path catches it.
+    """
+    # spaCy re-exports ``download`` from ``spacy.cli`` but doesn't list it in its
+    # type stubs' ``__all__``; the import is valid at runtime.
+    from spacy.cli import download  # pyright: ignore[reportPrivateImportUsage]
+
+    try:
+        download(_MODEL_NAME)
+    except SystemExit as exc:
+        raise RuntimeError(f"spaCy model download failed: {_MODEL_NAME}") from exc
+
+
 def _load_model() -> Language:
-    """Load the spaCy NER pipeline (separated for testability)."""
+    """Load the spaCy NER pipeline, downloading the model on first use.
+
+    Separated for testability. When the model is not installed, attempt a
+    one-time download and retry the load; any failure propagates to
+    :func:`_get_nlp`, which logs and falls back to heuristic extraction.
+    """
     import spacy
 
-    return spacy.load(_MODEL_NAME, disable=["lemmatizer"])
+    try:
+        return spacy.load(_MODEL_NAME, disable=["lemmatizer"])
+    except OSError:
+        logger.info("NER model %s not installed; attempting on-demand download", _MODEL_NAME)
+        _download_model()
+        return spacy.load(_MODEL_NAME, disable=["lemmatizer"])
 
 
 def _get_nlp() -> Language | None:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -251,6 +251,61 @@ class TestHeuristicFallback:
         assert "ChromaDB" in entities
 
 
+class TestModelAutoDownload:
+    """First-use download of the spaCy model.
+
+    en_core_web_sm is not a PyPI dependency (PyPI forbids direct-URL deps), so
+    lithos downloads it on first NER use and degrades to heuristics on failure.
+    """
+
+    def test_load_model_downloads_then_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import spacy
+
+        calls = {"load": 0, "download": 0}
+        sentinel = object()
+
+        def fake_load(name: str, disable: object = None) -> object:
+            calls["load"] += 1
+            if calls["load"] == 1:
+                raise OSError("[E050] Can't find model 'en_core_web_sm'")
+            return sentinel
+
+        monkeypatch.setattr(spacy, "load", fake_load)
+        monkeypatch.setattr(
+            entities_mod, "_download_model", lambda: calls.__setitem__("download", 1)
+        )
+
+        assert entities_mod._load_model() is sentinel
+        assert calls == {"load": 2, "download": 1}
+
+    def test_get_nlp_falls_back_when_download_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import spacy
+
+        def fake_load(name: str, disable: object = None) -> object:
+            raise OSError("[E050] Can't find model 'en_core_web_sm'")
+
+        def boom_download() -> None:
+            raise RuntimeError("no network")
+
+        monkeypatch.setattr(spacy, "load", fake_load)
+        monkeypatch.setattr(entities_mod, "_download_model", boom_download)
+        monkeypatch.setattr(entities_mod, "_NLP", None)
+        monkeypatch.setattr(entities_mod, "_NER_UNAVAILABLE", False)
+
+        assert entities_mod._get_nlp() is None
+        assert entities_mod._NER_UNAVAILABLE is True
+
+    def test_download_model_normalises_systemexit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import spacy.cli
+
+        def fake_download(*args: object, **kwargs: object) -> None:
+            raise SystemExit(1)
+
+        monkeypatch.setattr(spacy.cli, "download", fake_download)
+        with pytest.raises(RuntimeError):
+            entities_mod._download_model()
+
+
 class TestBacktickCodeRejection:
     """Backtick spans in technical docs are code, not entities (#320)."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1395,14 +1395,13 @@ wheels = [
 
 [[package]]
 name = "lithos-mcp"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiosqlite" },
     { name = "chromadb" },
     { name = "click" },
-    { name = "en-core-web-sm" },
     { name = "fastmcp" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1424,6 +1423,7 @@ otel = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "en-core-web-sm" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1437,7 +1437,6 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.17.0" },
     { name = "chromadb", specifier = ">=0.4.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "networkx", specifier = ">=3.2" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.28.0" },
@@ -1455,6 +1454,7 @@ provides-extras = ["otel"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "pyright", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary

Fixes the failed **Publish to PyPI** step for the 0.3.x release ([run](https://github.com/agent-lore/lithos/actions/runs/27220370549/job/80375985156)) and bumps to **0.3.3** so the fix can ship.

### Root cause

PyPI rejects any uploaded distribution whose metadata contains a **direct-URL dependency**:

```
400 Can't have direct dependency: en-core-web-sm @ https://github.com/.../en_core_web_sm-3.8.0-py3-none-any.whl
ERROR  HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
```

The spaCy NER model `en-core-web-sm` was added to `[project.dependencies]` as a direct wheel URL in #315. It is **not on PyPI** (spaCy models ship as GitHub release wheels). `0.3.1` predated the dep and published fine; **0.3.2 was the first release carrying it**. The `Build` and `Test package` jobs passed because they resolve the URL locally — only the upload step enforces PyPI's policy. `[tool.hatch.metadata] allow-direct-references` only affects local hatchling builds; it has no effect on the upload-side rejection.

### Fix

- **Move the model out of `[project.dependencies]` → the `dev` group.** The published wheel's `Requires-Dist` is now URL-free (only `spacy>=3.8`, which is on PyPI), so PyPI accepts it. `uv sync` still installs the model for development and CI, so `make test` keeps exercising real NER.
- **Download on first use** (`lithos/lcma/entities.py`): if the model isn't installed when NER first runs, fetch it on demand and retry the load. Any failure — offline, pip error, spaCy's `SystemExit` — propagates to the existing **heuristic fallback**, so extraction never crashes.
- **Dockerfile** bakes the model at build time, keeping container startup network-free (matching the embedding-model bake).
- **Docs** (`docs/cli.md`) document the auto-download + heuristic-fallback behavior and the optional `python -m spacy download en_core_web_sm`.
- **Version → 0.3.3** (`pyproject.toml` + `uv.lock` via `scripts/bump_version.sh`). The `v0.3.2` tag points at the unpublishable code, so a fresh version is required to publish.

### Verification

- Built the wheel and inspected `METADATA`: **no `@ <url>` / `en-core-web-sm` in `Requires-Dist`** — only PyPI-resolvable specifiers.
- `make lint` ✅ · `make typecheck` (0 errors) ✅ · `make test` — **1377 passed**.
- `uv.lock` regenerated: `en-core-web-sm` now lives only under the `dev` group (Docker's `uv sync --locked --no-dev` excludes it; Docker installs it explicitly).
- 3 new tests cover download-then-retry, heuristic fallback on download failure, and `SystemExit` normalisation.

### Known minor tradeoff

For a **pip-installed** user who never pre-installed the model, the first NER extraction triggers a one-time, synchronous model download (the existing enrich path already calls spaCy synchronously). Production images bake the model in, so they never hit this. Documented; not refactored to a thread here to keep the change focused.

### Test plan

- [x] Wheel metadata is PyPI-compatible (no direct-URL deps)
- [x] `make test` green (1377)
- [x] NER works with model present; falls back to heuristics when absent/offline
- [ ] CI green on this PR
- [ ] After merge: publish 0.3.3 (tag/release) → PyPI upload succeeds
