### PR TITLE
feat(coordination): task graph Phase 1 — edges, ready/blocked, backfill

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -750,9 +750,11 @@ Create a coordination task.
 | `description` | string | No | Task description |
 | `tags` | string[] | No | Task tags |
 | `agent` | string | Yes | Creating agent identifier |
-| `metadata` | object | No | Arbitrary JSON metadata dict persisted on the task row at insert time. Omitted (or `null`) creates a task with empty metadata. This is an **initial set**, not a merge — the row does not yet exist, so there is nothing to merge into. Subsequent mutations go through `lithos_task_update`, which applies an additive per-key merge (see that tool's **Behavior** for the contract). |
+| `metadata` | object | No | Arbitrary JSON metadata dict persisted on the task row at insert time. Omitted (or `null`) creates a task with empty metadata. This is an **initial set**, not a merge — the row does not yet exist, so there is nothing to merge into. Subsequent mutations go through `lithos_task_update`, which applies an additive per-key merge (see that tool's **Behavior** for the contract). Must **not** contain `depends_on`/`blocked_on` — dependencies are first-class task edges now (use `depends_on` below or `lithos_task_edge_upsert`); a write containing those keys is rejected with `invalid_metadata_key`. |
+| `task_type` | string | No | First-class task type. Only `task` is accepted in this phase (`epic` arrives in Phase 2, `gate` in Phase 3); any other value is rejected with `invalid_task_type`. Defaults to `task`. |
+| `depends_on` | string[] | No | Predecessor task IDs. Each creates a `blocks` edge `predecessor -> this task`, so this task is not ready until every predecessor is `completed`. Predecessors must already exist (else `task_not_found`). A brand-new task has no outgoing edges, so `depends_on` can never form a cycle. |
 
-**Returns:** `{ task_id: string }`
+**Returns:** `{ task_id: string }` on success, or `{ status: "error", code, message }` on validation failure (codes: `invalid_metadata_key`, `invalid_task_type`, `task_not_found`).
 
 #### `lithos_task_update`
 Update mutable task fields.
@@ -765,12 +767,13 @@ Update mutable task fields.
 | `title` | string | No | Replacement title |
 | `description` | string | No | Replacement description |
 | `tags` | string[] | No | Replacement tags |
-| `metadata` | object | No | Additive per-key merge patch into the existing task metadata dict. See **Behavior** for merge semantics. |
+| `metadata` | object | No | Additive per-key merge patch into the existing task metadata dict. See **Behavior** for merge semantics. Must **not** contain `depends_on`/`blocked_on` (rejected with `invalid_metadata_key`); dependencies are task edges. |
 
-**Returns:** `{ success: true, message }` on success, or `{ status: "error", code, message }` on failure (codes: `invalid_input`, `task_not_found`).
+**Returns:** `{ success: true, message }` on success, or `{ status: "error", code, message }` on failure (codes: `invalid_input`, `invalid_metadata_key`, `task_not_found`).
 
 **Behavior:**
 - At least one of `title`, `description`, `tags`, or `metadata` must be provided.
+- A `metadata` patch containing `depends_on`/`blocked_on` (any value, including a `null` delete) is rejected — those keys are no longer read, and closing the write path prevents stale scheduler-invisible dependency state being recreated.
 - Only `open` tasks can be updated. Completed and cancelled tasks are treated as not found at the MCP boundary.
 - `metadata` is applied as an **additive per-key merge**: keys with non-null values overwrite the existing value, keys whose value is `null` are deleted from the existing metadata, and keys not mentioned are preserved. `metadata={}` is a no-op (preserves all existing keys); there is no wholesale-clear affordance. To clear a specific key, pass `{"key": null}`. The merge is performed atomically (single `BEGIN IMMEDIATE` transaction) so concurrent writers updating different keys never clobber each other.
 
@@ -827,7 +830,7 @@ Mark a task as completed.
 | `misleading_nodes` | string[] | No | Optional node IDs the caller found misleading; used for LCMA reinforcement feedback |
 | `receipt_id` | string | No | Optional specific LCMA receipt to bind the feedback to; otherwise the latest receipt for the same `(task_id, agent)` is used |
 
-**Returns:** `{ success: true }` on success, `{ status: "error", code: "task_not_found", message }` if the task does not exist or is not open, or `{ status: "error", code: "receipt_not_found", message }` if feedback references a missing or unrelated receipt.
+**Returns:** `{ success: true, unblocked: string[] }` on success, `{ status: "error", code: "task_not_found", message }` if the task does not exist or is not open, or `{ status: "error", code: "receipt_not_found", message }` if feedback references a missing or unrelated receipt. `unblocked` lists task IDs that this completion just made ready (a `blocks` dependent whose last unsatisfied predecessor was this task), so an orchestrator can pick them up without re-polling `lithos_task_ready`.
 
 **Behavior:** Sets task status to `completed`, persists `resolved_at = now`, stores `outcome`, and releases all active claims on the task. When `cited_nodes` / `misleading_nodes` are supplied, Lithos validates them against the bound LCMA receipt before completion, then applies reinforcement side effects after the task closes. If no receipt can be found and no explicit `receipt_id` was supplied, the feedback is silently dropped and the task still completes.
 
@@ -853,13 +856,14 @@ List tasks with optional filters.
 |------|------|----------|-------------|
 | `agent` | string | No | Filter by creating agent |
 | `status` | string | No | Filter by task status: `open`, `completed`, or `cancelled` |
+| `task_type` | string | No | Filter by first-class task type (`task`/`epic`/`gate`) |
 | `tags` | string[] | No | Filter to tasks containing all listed tags |
 | `since` | string | No | Filter by `created_at >= since` (ISO datetime) |
 | `resolved_since` | string | No | Filter by `resolved_at >= resolved_since` (ISO datetime). `resolved_at` is set on both terminal transitions (`complete` and `cancel`), so this surfaces tasks resolved in either way within the window. Open tasks and historical cancellations whose `resolved_at` is `NULL` are excluded automatically. |
 | `with_claims` | boolean | No | When `true`, each task in the response includes its active (non-expired) claims inline as a `claims` array (same shape as `lithos_task_status`). Defaults to `false`. Use to avoid an N+1 of `lithos_task_status` calls when rendering a list view. |
 | `metadata_match` | object | No | Filter by task metadata. Same semantics as `lithos_list.metadata_match` (AND across keys; stored value equals the query or is a list containing it; scalar query values; type-sensitive). Pushed into SQLite via `json_extract`/`json_each`, so it is engine-evaluated rather than a Python post-scan. Invalid query values return `{ status: "invalid_input", message, warnings: [] }`. |
 
-**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). `outcome` is `null` until the task is completed with an outcome. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
+**Returns:** `{ tasks: [{ id, title, description, status, task_type, created_by, created_at, resolved_at, tags, metadata, outcome }] }`. `resolved_at` is `null` for open tasks (and for historical cancellations from before the dual-write was added). `outcome` is `null` until the task is completed with an outcome. When `with_claims=true`, each task also carries `claims: [{ agent, aspect, expires_at }]`.
 
 #### `lithos_task_status`
 Get the full record of a task along with its active claims.
@@ -869,7 +873,7 @@ Get the full record of a task along with its active claims.
 |------|------|----------|-------------|
 | `task_id` | string | Yes | Specific task ID |
 
-**Returns:** `{ tasks: [{ id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome, claims: [{ agent, aspect, expires_at }] }] }`. Returns `{ tasks: [] }` when the task does not exist (mirrors historical behaviour — does not return the error envelope). Use `lithos_task_get` when you want a single-task fetch with an explicit not-found envelope and don't need claims.
+**Returns:** `{ tasks: [{ id, title, description, status, task_type, created_by, created_at, resolved_at, tags, metadata, outcome, claims: [{ agent, aspect, expires_at }] }] }`. Returns `{ tasks: [] }` when the task does not exist (mirrors historical behaviour — does not return the error envelope). Use `lithos_task_get` when you want a single-task fetch with an explicit not-found envelope and don't need claims.
 
 **Claim expiry handling:** Expired claims (where `expires_at < now()`) are automatically excluded from results. Cleanup is lazy—expired claims are filtered at query time rather than eagerly deleted.
 
@@ -881,9 +885,62 @@ Fetch a single task by ID. Returns the full task record without claims; use `lit
 |------|------|----------|-------------|
 | `task_id` | string | Yes | Task ID |
 
-**Returns (success):** `{ task: { id, title, description, status, created_by, created_at, resolved_at, tags, metadata, outcome } }`
+**Returns (success):** `{ task: { id, title, description, status, task_type, created_by, created_at, resolved_at, tags, metadata, outcome } }`
 
 **Returns (unknown task):** `{ status: "error", code: "task_not_found", message: string }`
+
+#### Task Graph (Phase 1)
+
+The task graph makes dependencies first-class via a `task_edges` table (see §7) and a `task_type` column. Lithos remains **passive**: readiness is computed at query time from edges and task status; nothing polls external systems. The accepted edge types grow per delivery phase — Phase 1 ships `blocks` (blocking), `parent_child` (structural, non-blocking), and `discovered_from` (provenance, non-blocking); `waits_on_gate` and deferred relational types are rejected until later phases.
+
+**Readiness predicate.** A task is *ready* when it is `open`, is not a `gate`/`epic`, has no incoming blocking edge whose predecessor is unsatisfied (a `blocks` predecessor must be `completed` — a predecessor still `open`, or terminal-but-cancelled, leaves the edge unsatisfied), and is not held by an unresolved gate. A predecessor that ends `cancelled` leaves its dependents **permanently** blocked (`blocker_unsatisfiable`) rather than spuriously ready — Lithos refuses to call them ready and explains why, leaving re-open/re-route/cancel to the orchestrator.
+
+#### `lithos_task_edge_upsert`
+Create or update a typed relation between two tasks.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `from_task_id` | string | Yes | Source task (blocker / parent / source) |
+| `to_task_id` | string | Yes | Target task (blocked / child / discovered) |
+| `type` | string | Yes | Edge type accepted this phase: `blocks`, `parent_child`, `discovered_from` |
+| `agent` | string | Yes | Agent creating the edge |
+| `metadata` | object | No | Optional edge metadata (replaced on conflict) |
+
+**Returns:** `{ success: true }`, or `{ status: "error", code, message }` (codes: `invalid_edge_type`, `self_edge`, `task_not_found`, `cycle`). Cycles in blocking edges are rejected on write via a bounded traversal over the `task_edges` indexes (never a full-table walk).
+
+#### `lithos_task_edge_list`
+List edges touching a task.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `task_id` | string | Yes | Task whose edges to list |
+| `direction` | string | No | `incoming`, `outgoing`, or `both` (default) |
+| `types` | string[] | No | Optional edge-type filter |
+
+**Returns:** `{ edges: [{ from_task_id, to_task_id, type, direction, metadata, created_by, created_at }] }`. `direction` is relative to `task_id`.
+
+#### `lithos_task_ready`
+Return open tasks whose blocking predecessors are all satisfied (the feasible frontier).
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `project` | string | No | Shorthand for `metadata.project == project` |
+| `tags` | string[] | No | Filter to tasks containing all listed tags |
+| `metadata_match` | object | No | Metadata filter (same semantics as `lithos_task_list.metadata_match`) |
+| `limit` | int | No | Maximum tasks to return (default 50) |
+| `with_claims` | boolean | No | Attach each task's active claims inline (default `true`) |
+
+**Returns:** `{ tasks: [...] }`. Claims are **attached** when `with_claims` but never used to exclude a task — collision-correctness comes from the atomic claim, and claims are per-aspect, so the picking agent decides what "taken" means. The query first restricts to the indexed `status='open'` frontier, then applies an index-driven anti-join over blocking edges, so cost scales with the open frontier rather than total task count.
+
+#### `lithos_task_blocked`
+Return open tasks that are not ready, each with structured blocker reasons.
+
+**Arguments:** same filter surface as `lithos_task_ready` (no `with_claims`).
+
+**Returns:** `{ tasks: [{ ..., blockers: [{ kind, task_id, type, status, message }] }] }`. `kind` is one of `task` (predecessor still `open` — just waiting), `blocker_unsatisfiable` (predecessor `cancelled` — needs intervention), or `cycle` (the blocking chain forms a dependency cycle; `message` names the members). Gate blocker kinds arrive in Phase 3.
 
 #### `lithos_finding_post`
 Post a finding to a task.
@@ -1222,6 +1279,7 @@ CREATE TABLE tasks (
   title TEXT NOT NULL,
   description TEXT,
   status TEXT DEFAULT 'open',  -- open, completed, cancelled
+  task_type TEXT NOT NULL DEFAULT 'task',  -- task (Phase 1); epic (Phase 2); gate (Phase 3)
   created_by TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   tags JSON,
@@ -1229,6 +1287,23 @@ CREATE TABLE tasks (
   resolved_at TIMESTAMP,       -- dual-written on both terminal transitions (complete and cancel); NULL while open
   metadata JSON
 );
+
+-- Task graph edges (ordering, hierarchy, provenance)
+CREATE TABLE task_edges (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  from_task_id TEXT NOT NULL,  -- source (blocker / parent / source)
+  to_task_id TEXT NOT NULL,    -- target (blocked / child / discovered)
+  type TEXT NOT NULL,          -- blocks | parent_child | discovered_from (Phase 1)
+  metadata JSON,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (from_task_id) REFERENCES tasks(id),
+  FOREIGN KEY (to_task_id) REFERENCES tasks(id),
+  UNIQUE(from_task_id, to_task_id, type)
+);
+-- Both directions indexed: ready/blocked queries and cycle detection must stay sub-linear
+CREATE INDEX idx_task_edges_from ON task_edges(from_task_id, type);
+CREATE INDEX idx_task_edges_to ON task_edges(to_task_id, type);
 
 -- Claims (with automatic expiry)
 CREATE TABLE claims (
@@ -1253,6 +1328,8 @@ CREATE TABLE findings (
   FOREIGN KEY (task_id) REFERENCES tasks(id)
 );
 ```
+
+**Migration & backfill.** Schema changes are applied as idempotent, column-presence-guarded `ALTER`s at `initialize()` time (no separate migration tool). When `tasks.task_type` is first added to an existing database, a **one-time backfill** runs in the same migration transaction: open tasks' legacy `metadata.depends_on` / `metadata.blocked_on` values become canonical `blocks` edges (marked `{"migrated_from": ...}` in edge metadata), references to nonexistent task IDs are logged and skipped, and any edges that form a cycle are retained (cycle members are excluded from `ready` and surfaced as `cycle` blockers). After the backfill, `task_edges` is the **only** thing the scheduler reads; `metadata.depends_on`/`blocked_on` are no longer read, and writing them via `lithos_task_create`/`lithos_task_update` is rejected so stale scheduler-invisible state cannot be recreated. The backfill is tied to the column-addition branch, so it runs exactly once and is a no-op on fresh databases (which have no legacy dependency metadata).
 
 ---
 
@@ -1472,7 +1549,7 @@ lithos --data-dir ./data audit --doc <id> --since 2026-01-01T00:00:00
 Tools indicate routine domain failures through return values, and unexpected backend failures may still surface as MCP-level exceptions.
 
 - **Structured status envelopes**: `lithos_write` returns `{ status: "error", code, message, ... }` for invalid input and contract-level failures
-- **Structured error envelopes on many tools**: `lithos_delete`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_update`, `lithos_task_cancel`, `lithos_task_get`, `lithos_search`, `lithos_list`, and `lithos_cache_lookup` use `{ status: "error", code, message }` for routine domain failures
+- **Structured error envelopes on many tools**: `lithos_delete`, `lithos_task_create`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_update`, `lithos_task_cancel`, `lithos_task_get`, `lithos_task_edge_upsert`, `lithos_search`, `lithos_list`, and `lithos_cache_lookup` use `{ status: "error", code, message }` for routine domain failures
 - **Nullable results**: `lithos_agent_info` returns `null` when the agent is not found
 - **Exceptions**: Unexpected file/index/backend errors may still propagate at the MCP layer
 
@@ -1583,11 +1660,12 @@ These are explicitly not part of the initial implementation but may be considere
 | Graph | `lithos_tags`, `lithos_related` |
 | Agent | `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list` |
 | Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_list`, `lithos_task_status`, `lithos_task_get`, `lithos_finding_post`, `lithos_finding_list` |
+| Task Graph | `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, `lithos_task_blocked` |
 | System | `lithos_stats` |
 | LCMA (Phase 7 MVP 1) | `lithos_retrieve`, `lithos_edge_upsert`, `lithos_edge_list`, `lithos_conflict_resolve`, `lithos_node_stats` |
 | HTTP | `GET /health`, `GET /events`, `GET /audit` (not MCP tools; see §5.7 and §8.7) |
 
-**Total: 29 MCP tools + 3 HTTP endpoints** (includes `lithos_task_get` in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
+**Total: 33 MCP tools + 3 HTTP endpoints** (Phase 1 of the task graph added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
 
 ---
 

--- a/docs/plans/task-graph-coordination-extension.md
+++ b/docs/plans/task-graph-coordination-extension.md
@@ -406,7 +406,8 @@ A task is ready when all of the following are true:
 2. the task is a directly-workable unit — i.e. not a `gate` (and, once Phase 2 ships the `epic` type, not an `epic`: you execute an epic's children, not the epic itself). The readiness predicate uses a forward-compatible `task_type NOT IN ('gate', 'epic')` guard from Phase 1; the excluded types simply cannot be created yet until their phase lands.
 3. every incoming blocking edge is **satisfied** — for a `blocks` edge that means the predecessor is `completed` (a predecessor still `open`, or terminal-but-not-`completed` i.e. `cancelled`, leaves the edge unsatisfied; see the blocker-failure policy below)
 4. it is not blocked by an unresolved gate
-5. if filtering excludes claimed tasks, it has no active conflicting claims
+
+Claims do **not** enter the readiness predicate: a claimed task is still ready. `lithos_task_ready` *attaches* active claims (when `with_claims`) but never excludes by them — see §6.1 for why (atomic-claim correctness + per-aspect claims).
 
 MVP blocked rule:
 

--- a/docs/plans/task-graph-coordination-extension.md
+++ b/docs/plans/task-graph-coordination-extension.md
@@ -106,15 +106,16 @@ Allowed values:
 
 - `task` — default discrete unit of work
 - `epic` — parent roll-up container
-- `subtask` — child task under a parent
 - `gate` — external wait condition
 
-(`message`, an async coordination artifact, was considered and deferred until a concrete use case exists.)
+There is deliberately **no `subtask` type**. "Child" is a purely relational property, so it lives on the `parent_child` edge (§5.2), not on the node: a child is any task that is the `to` end of a `parent_child` edge. Encoding the relationship as a node attribute as well would create two sources of truth that can drift. (`message`, an async coordination artifact, was likewise considered and deferred until a concrete use case exists.)
 
 Storage:
 
 - new `task_type TEXT NOT NULL DEFAULT 'task'` column on `tasks`, added by schema migration
 - the column is the only source of truth; `metadata.task_type` is not read
+
+**Write-validation is phase-gated, mirroring the edge-type rule in §5.2.** The column defaults to `'task'` and physically holds any string, but a value is only *accepted on write* once the phase implementing its semantics has shipped: Phase 1 accepts only `task`; `epic` is accepted from Phase 2 (when roll-up and ready-exclusion semantics land); `gate` from Phase 3. This stops agents creating a `gate` that gates nothing, or an `epic` that `ready` would wrongly surface as workable.
 
 ## 5.2 Task Edges
 
@@ -257,7 +258,7 @@ Arguments:
 - `tags: list[str] | None = None`
 - `metadata_match: dict | None = None`
 - `limit: int = 50`
-- `include_claims: bool = True`
+- `with_claims: bool = True`
 
 Returns:
 
@@ -268,7 +269,7 @@ Behavior:
 - only `status='open'`
 - excludes tasks with an unsatisfied blocking predecessor — one not yet `completed` (still `open`, or terminal-but-not-completed i.e. `cancelled`; see §8)
 - excludes tasks blocked by unresolved gates
-- optionally excludes already-claimed tasks unless requested otherwise
+- **never excludes by claim.** When `with_claims` (default), each task's active claims are *attached* inline; the tool does not filter claimed tasks out. Collision-correctness already comes from the atomic claim in `claim_task`, and claims are per-aspect (a task can have one aspect claimed while another is free), so a task-level "claimed" exclusion would both be ill-defined and hide legitimately-available parallel work. The picking agent decides what "taken" means. (The parameter is named `with_claims` to match `lithos_task_list`.)
 
 ### `lithos_task_blocked`
 
@@ -402,7 +403,7 @@ MVP readiness rule:
 A task is ready when all of the following are true:
 
 1. `status == "open"`
-2. the task itself is not a `gate`
+2. the task is a directly-workable unit — i.e. not a `gate` (and, once Phase 2 ships the `epic` type, not an `epic`: you execute an epic's children, not the epic itself). The readiness predicate uses a forward-compatible `task_type NOT IN ('gate', 'epic')` guard from Phase 1; the excluded types simply cannot be created yet until their phase lands.
 3. every incoming blocking edge is **satisfied** — for a `blocks` edge that means the predecessor is `completed` (a predecessor still `open`, or terminal-but-not-`completed` i.e. `cancelled`, leaves the edge unsatisfied; see the blocker-failure policy below)
 4. it is not blocked by an unresolved gate
 5. if filtering excludes claimed tasks, it has no active conflicting claims

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1927,7 +1927,12 @@ class CoordinationService:
         but never used to exclude a task — collision-correctness lives in the
         atomic claim, and claims are per-aspect.
         """
-        rows = await self._frontier_rows(ready=True, project=project, metadata_match=metadata_match)
+        rows = await self._frontier_rows(
+            ready=True,
+            project=project,
+            metadata_match=metadata_match,
+            sql_limit=None if tags else limit,
+        )
         results = self._apply_tags_and_limit(rows, tags, limit)
         if with_claims and results:
             async with aiosqlite.connect(self.db_path) as db:
@@ -1952,7 +1957,10 @@ class CoordinationService:
         ``task``/``blocker_unsatisfiable``/``cycle`` (gate kinds arrive in Phase 3).
         """
         rows = await self._frontier_rows(
-            ready=False, project=project, metadata_match=metadata_match
+            ready=False,
+            project=project,
+            metadata_match=metadata_match,
+            sql_limit=None if tags else limit,
         )
         results = self._apply_tags_and_limit(rows, tags, limit)
         async with aiosqlite.connect(self.db_path) as db:
@@ -1965,12 +1973,17 @@ class CoordinationService:
         ready: bool,
         project: str | None,
         metadata_match: dict | None,
+        sql_limit: int | None = None,
     ) -> list[Any]:
         """Fetch open workable rows partitioned by the readiness anti-join.
 
         ``ready=True`` selects tasks with no unsatisfied blocking predecessor;
         ``ready=False`` selects those with at least one. Both ride on the indexed
         ``status='open'`` frontier and the task_edges indexes.
+
+        ``sql_limit`` pushes ``LIMIT`` into SQL so the engine stops early. Callers
+        pass it only when no Python-side ``tags`` post-scan follows (a tag filter
+        would otherwise drop rows after the cap and under-fill the result).
         """
         effective_match = dict(metadata_match) if metadata_match else {}
         if project is not None:
@@ -1990,6 +2003,9 @@ class CoordinationService:
             f"{md_clause} ORDER BY t.created_at DESC"
         )
         params = [*NON_WORKABLE_TASK_TYPES, *blocking, *md_params]
+        if sql_limit is not None:
+            query += " LIMIT ?"
+            params.append(sql_limit)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(query, params)

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1927,6 +1927,8 @@ class CoordinationService:
         but never used to exclude a task — collision-correctness lives in the
         atomic claim, and claims are per-aspect.
         """
+        if limit <= 0:
+            return []
         rows = await self._frontier_rows(
             ready=True,
             project=project,
@@ -1956,6 +1958,8 @@ class CoordinationService:
         ``blockers`` list whose entries have ``kind`` in
         ``task``/``blocker_unsatisfiable``/``cycle`` (gate kinds arrive in Phase 3).
         """
+        if limit <= 0:
+            return []
         rows = await self._frontier_rows(
             ready=False,
             project=project,
@@ -2017,8 +2021,16 @@ class CoordinationService:
         tags: list[str] | None,
         limit: int,
     ) -> list[dict[str, Any]]:
-        """Tag-filter (post-scan over the open frontier) and cap to ``limit``."""
+        """Tag-filter (post-scan over the open frontier) and cap to ``limit``.
+
+        A non-positive ``limit`` yields no tasks (the append-then-check loop would
+        otherwise return one). The MCP layer rejects ``limit < 1`` outright; this
+        guard keeps direct service callers consistent — and consistent with the
+        SQL ``LIMIT 0`` path — rather than off-by-one.
+        """
         results: list[dict[str, Any]] = []
+        if limit <= 0:
+            return results
         for row in rows:
             task = _task_row_to_dict(row)
             if tags and not all(t in task["tags"] for t in tags):

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -17,6 +17,70 @@ from lithos.telemetry import lithos_metrics, traced
 
 logger = logging.getLogger(__name__)
 
+# Edge types accepted on write. The set grows per delivery phase: an edge type
+# is only accepted once the phase implementing its readiness semantics has
+# shipped, so agents can never write a blocking edge whose meaning is not yet
+# implemented. Phase 1 ships blocks/parent_child/discovered_from. Phase 3 adds
+# ``waits_on_gate``. Deferred types (caused_by, validates, relates_to,
+# duplicate_of, superseded_by) are added only when something consumes them.
+ACCEPTED_EDGE_TYPES: frozenset[str] = frozenset({"blocks", "parent_child", "discovered_from"})
+
+# Edge types that gate readiness. A task is not ready while it has an incoming
+# blocking edge whose predecessor is not ``completed``. Gains ``waits_on_gate``
+# in Phase 3.
+BLOCKING_EDGE_TYPES: frozenset[str] = frozenset({"blocks"})
+
+# Task types accepted on write this phase (see ACCEPTED_EDGE_TYPES rationale).
+# ``epic`` is accepted from Phase 2, ``gate`` from Phase 3. The column itself
+# defaults to 'task' and physically holds any string; only the write-validation
+# set is phase-gated.
+ACCEPTED_TASK_TYPES: frozenset[str] = frozenset({"task"})
+
+# Task types that are never directly workable units and so are excluded from the
+# ready frontier. ``epic`` is a roll-up container (you execute its children, not
+# the epic); ``gate`` is an external wait. Neither can be written yet in Phase 1,
+# but the readiness guard names them now so the predicate is forward-compatible.
+NON_WORKABLE_TASK_TYPES: tuple[str, ...] = ("gate", "epic")
+
+# metadata keys whose scheduling meaning is now owned by task_edges. Writing them
+# is rejected so stale, scheduler-invisible dependency state cannot be recreated
+# through the additive metadata write path (see SPECIFICATION migration notes).
+FORBIDDEN_METADATA_KEYS: tuple[str, ...] = ("depends_on", "blocked_on")
+
+
+class CoordinationError(Exception):
+    """A coordination operation failed validation.
+
+    Carries a stable ``code`` and human ``message`` so the MCP layer can map it
+    onto the standard ``{"status": "error", "code", "message"}`` envelope without
+    re-deriving the reason.
+    """
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _reject_scheduling_metadata(metadata: dict[str, Any] | None) -> None:
+    """Raise if ``metadata`` carries a now-forbidden scheduling key.
+
+    Rejects any presence of ``depends_on``/``blocked_on`` (including a ``None``
+    delete), because even a delete implies the caller still treats metadata as
+    the source of dependency truth. Dependencies are first-class edges now.
+    """
+    if not metadata:
+        return
+    present = [k for k in FORBIDDEN_METADATA_KEYS if k in metadata]
+    if present:
+        raise CoordinationError(
+            "invalid_metadata_key",
+            f"metadata key(s) {present} are no longer accepted: task dependencies are "
+            "first-class task edges. Use depends_on on lithos_task_create, or "
+            "lithos_task_edge_upsert.",
+        )
+
+
 # SQL Schema
 SCHEMA = """
 -- Agent registry
@@ -35,12 +99,27 @@ CREATE TABLE IF NOT EXISTS tasks (
     title TEXT NOT NULL,
     description TEXT,
     status TEXT DEFAULT 'open',
+    task_type TEXT NOT NULL DEFAULT 'task',
     created_by TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     tags JSON,
     outcome TEXT,
     resolved_at TIMESTAMP,
     metadata JSON
+);
+
+-- Typed task-graph edges (ordering, hierarchy, provenance)
+CREATE TABLE IF NOT EXISTS task_edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_task_id TEXT NOT NULL,
+    to_task_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    metadata JSON,
+    created_by TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (from_task_id) REFERENCES tasks(id),
+    FOREIGN KEY (to_task_id) REFERENCES tasks(id),
+    UNIQUE(from_task_id, to_task_id, type)
 );
 
 -- Claims (with automatic expiry)
@@ -77,6 +156,10 @@ CREATE TABLE IF NOT EXISTS access_log (
 
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+-- Ready/blocked queries join task_edges against open tasks; both directions
+-- must stay index-driven (sub-linear). Cycle detection also traverses these.
+CREATE INDEX IF NOT EXISTS idx_task_edges_from ON task_edges(from_task_id, type);
+CREATE INDEX IF NOT EXISTS idx_task_edges_to ON task_edges(to_task_id, type);
 CREATE INDEX IF NOT EXISTS idx_claims_task_id ON claims(task_id);
 CREATE INDEX IF NOT EXISTS idx_claims_expires_at ON claims(expires_at);
 CREATE INDEX IF NOT EXISTS idx_findings_task_id ON findings(task_id);
@@ -106,12 +189,25 @@ class Task:
     title: str
     description: str | None = None
     status: Literal["open", "completed", "cancelled"] = "open"
+    task_type: str = "task"
     created_by: str = ""
     created_at: datetime | None = None
     tags: list[str] = field(default_factory=list)
     outcome: str | None = None
     resolved_at: datetime | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TaskEdge:
+    """A typed relation between two tasks in the task graph."""
+
+    from_task_id: str
+    to_task_id: str
+    type: str
+    created_by: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime | None = None
 
 
 @dataclass
@@ -160,6 +256,7 @@ class TaskStatus:
     claims: list[Claim]
     metadata: dict[str, Any] = field(default_factory=dict)
     description: str | None = None
+    task_type: str = "task"
     created_by: str = ""
     created_at: datetime | None = None
     tags: list[str] = field(default_factory=list)
@@ -275,6 +372,66 @@ def _decode_metadata(raw: Any) -> dict[str, Any]:
     return decoded
 
 
+def _task_row_to_dict(row: Any) -> dict[str, Any]:
+    """Build the standard task payload dict from a ``tasks`` row.
+
+    Shared by ``list_tasks``/``list_ready``/``list_blocked`` so every surface
+    emits the same shape, including ``task_type``. ``created_at``/``resolved_at``
+    are returned as the raw stored strings (callers that need parsed datetimes
+    use the dataclass surfaces). Columns absent on legacy rows degrade to safe
+    defaults.
+    """
+    import json
+
+    row_keys = row.keys()
+    tags: list[str] = []
+    if row["tags"]:
+        with contextlib.suppress(json.JSONDecodeError):
+            tags = json.loads(row["tags"])
+    metadata = _decode_metadata(row["metadata"]) if "metadata" in row_keys else {}
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "description": row["description"],
+        "status": row["status"],
+        "task_type": row["task_type"] if "task_type" in row_keys else "task",
+        "created_by": row["created_by"],
+        "created_at": row["created_at"],
+        "resolved_at": row["resolved_at"] if "resolved_at" in row_keys else None,
+        "tags": tags,
+        "metadata": metadata,
+        "outcome": row["outcome"] if "outcome" in row_keys else None,
+    }
+
+
+def _metadata_match_clause(
+    metadata_match: dict[str, Any] | None,
+    column: str = "metadata",
+) -> tuple[str, list[Any]]:
+    """Build a type-sensitive ``metadata_match`` SQL fragment + bound params (#306).
+
+    For each ``key: q`` the task matches when its stored value equals ``q`` or is
+    an element of a JSON *array* at that key. ``column`` lets callers qualify the
+    column (e.g. ``t.metadata``) when the query joins multiple tables. ``column``
+    is an internal constant, never user input, so it cannot inject SQL; the JSON
+    path and value are bound parameters.
+    """
+    if not metadata_match:
+        return "", []
+    clause = ""
+    params: list[Any] = []
+    for key, value in metadata_match.items():
+        path = _json_path_for_key(key)
+        jtype = _json_type_label(value)
+        clause += (
+            f" AND ( (json_type({column}, ?) = ? AND json_extract({column}, ?) = ?)"
+            f" OR (json_type({column}, ?) = 'array' AND EXISTS"
+            f" (SELECT 1 FROM json_each({column}, ?) WHERE type = ? AND value = ?)) )"
+        )
+        params.extend([path, jtype, path, value, path, path, jtype, value])
+    return clause, params
+
+
 class CoordinationService:
     """SQLite-based coordination service."""
 
@@ -319,6 +476,7 @@ class CoordinationService:
             await self._migrate_tasks_add_outcome(db)
             await self._migrate_tasks_ensure_resolved_at(db)
             await self._migrate_tasks_add_metadata(db)
+            await self._migrate_tasks_add_task_type(db)
             await db.commit()
         logger.info("coordination service initialized: db_path=%s", self.db_path)
 
@@ -432,6 +590,84 @@ class CoordinationService:
         if "metadata" not in columns:
             await db.execute("ALTER TABLE tasks ADD COLUMN metadata JSON")
             logger.info("coordination.db migration applied: added tasks.metadata")
+
+    @staticmethod
+    async def _migrate_tasks_add_task_type(db: aiosqlite.Connection) -> None:
+        """Add tasks.task_type and run the one-time metadata->edges backfill.
+
+        The backfill is tied to the column-addition branch so it runs exactly
+        once with no separate version table: an old DB lacks the column, gets it
+        added, and is backfilled in the same migration; a fresh DB already has
+        the column (from SCHEMA) and has no legacy dependency metadata, so both
+        steps are skipped. ``initialize`` commits all migrations together, so the
+        column add and the backfill are atomic — a mid-migration crash redoes
+        both on the next start rather than leaving the column without its edges.
+        """
+        cursor = await db.execute("PRAGMA table_info(tasks)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "task_type" in columns:
+            return
+        await db.execute("ALTER TABLE tasks ADD COLUMN task_type TEXT NOT NULL DEFAULT 'task'")
+        backfilled = await CoordinationService._backfill_task_edges_from_metadata(db)
+        logger.info(
+            "coordination.db migration applied: added tasks.task_type and backfilled "
+            "%d blocks edge(s) from task metadata",
+            backfilled,
+        )
+
+    @staticmethod
+    async def _backfill_task_edges_from_metadata(db: aiosqlite.Connection) -> int:
+        """One-time backfill of ``blocks`` edges from legacy dependency metadata.
+
+        Scans ``open`` tasks, reads ``metadata.depends_on`` / ``metadata.blocked_on``
+        (each a task id or list of ids), and creates a canonical ``blocks`` edge
+        ``predecessor -> task`` for every reference to an existing task. References
+        to nonexistent task ids are logged and skipped. Uses ``INSERT OR IGNORE``
+        against the ``UNIQUE(from,to,type)`` constraint so it is idempotent.
+
+        Edges are retained even when they form a cycle (never silently dropped):
+        cycle members are excluded from ``ready`` automatically (mutual open
+        blockers) and surfaced as ``cycle`` blockers by ``list_blocked``.
+        """
+        import json
+
+        cursor = await db.execute("SELECT id FROM tasks")
+        existing_ids = {row[0] for row in await cursor.fetchall()}
+
+        cursor = await db.execute("SELECT id, metadata FROM tasks WHERE status = 'open'")
+        rows = await cursor.fetchall()
+        now = _format_datetime(datetime.now(timezone.utc))
+        created = 0
+        for task_id, metadata_raw in rows:
+            md = _decode_metadata(metadata_raw)
+            for key in FORBIDDEN_METADATA_KEYS:
+                preds = md.get(key)
+                if preds is None:
+                    continue
+                pred_list = preds if isinstance(preds, list) else [preds]
+                for pred in pred_list:
+                    if not isinstance(pred, str) or pred == task_id:
+                        continue
+                    if pred not in existing_ids:
+                        logger.warning(
+                            "coordination.db backfill: task %s metadata.%s references "
+                            "nonexistent task %s; skipping",
+                            task_id,
+                            key,
+                            pred,
+                        )
+                        continue
+                    edge_metadata = json.dumps({"migrated_from": f"metadata.{key}"})
+                    edge_cursor = await db.execute(
+                        """
+                        INSERT OR IGNORE INTO task_edges
+                            (from_task_id, to_task_id, type, metadata, created_by, created_at)
+                        VALUES (?, ?, 'blocks', ?, 'migration', ?)
+                        """,
+                        (pred, task_id, edge_metadata, now),
+                    )
+                    created += edge_cursor.rowcount
+        return created
 
     async def _get_db(self) -> aiosqlite.Connection:
         """Get database connection."""
@@ -616,6 +852,8 @@ class CoordinationService:
         description: str | None = None,
         tags: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
+        task_type: str = "task",
+        depends_on: list[str] | None = None,
     ) -> str:
         """Create a new task.
 
@@ -624,12 +862,28 @@ class CoordinationService:
             agent: Creating agent identifier
             description: Task description
             tags: Task tags
-            metadata: Arbitrary JSON metadata dict (optional)
+            metadata: Arbitrary JSON metadata dict (optional). Must not contain
+                ``depends_on``/``blocked_on`` — dependencies are task edges now.
+            task_type: First-class task type. Phase 1 accepts only ``task``.
+            depends_on: Predecessor task ids. Each creates a ``blocks`` edge
+                ``predecessor -> this task``. Predecessors must already exist.
 
         Returns:
             Task ID
+
+        Raises:
+            CoordinationError: invalid task_type, forbidden metadata key, or a
+                ``depends_on`` reference to a nonexistent task.
         """
         import json
+
+        _reject_scheduling_metadata(metadata)
+        if task_type not in ACCEPTED_TASK_TYPES:
+            raise CoordinationError(
+                "invalid_task_type",
+                f"task_type '{task_type}' is not accepted in this phase "
+                f"(accepted: {sorted(ACCEPTED_TASK_TYPES)}).",
+            )
 
         lithos_metrics.coordination_ops.add(1, {"op": "create_task"})
         await self.ensure_agent_known(agent)
@@ -638,18 +892,52 @@ class CoordinationService:
         tags_json = json.dumps(tags) if tags else None
         metadata_json = json.dumps(metadata) if metadata is not None else None
         now = _format_datetime(datetime.now(timezone.utc))
+        # Dedupe and drop a self-reference; a brand-new task has no outgoing
+        # edges, so depends_on can never form a cycle (nothing depends on it yet).
+        predecessors = [p for p in dict.fromkeys(depends_on or []) if p != task_id]
 
         async with aiosqlite.connect(self.db_path) as db:
+            if predecessors:
+                placeholders = ",".join("?" for _ in predecessors)
+                cursor = await db.execute(
+                    f"SELECT id FROM tasks WHERE id IN ({placeholders})",
+                    predecessors,
+                )
+                found = {row[0] for row in await cursor.fetchall()}
+                missing = [p for p in predecessors if p not in found]
+                if missing:
+                    raise CoordinationError(
+                        "task_not_found",
+                        f"depends_on references nonexistent task(s): {missing}",
+                    )
+
             await db.execute(
                 """
-                INSERT INTO tasks (id, title, description, created_by, tags, created_at, metadata)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO tasks
+                    (id, title, description, status, task_type, created_by, tags,
+                     created_at, metadata)
+                VALUES (?, ?, ?, 'open', ?, ?, ?, ?, ?)
                 """,
-                (task_id, title, description, agent, tags_json, now, metadata_json),
+                (task_id, title, description, task_type, agent, tags_json, now, metadata_json),
             )
+            for pred in predecessors:
+                await db.execute(
+                    """
+                    INSERT OR IGNORE INTO task_edges
+                        (from_task_id, to_task_id, type, created_by, created_at)
+                    VALUES (?, ?, 'blocks', ?, ?)
+                    """,
+                    (pred, task_id, agent, now),
+                )
             await db.commit()
 
-        logger.info("Task created: task_id=%s agent=%s", task_id, agent)
+        logger.info(
+            "Task created: task_id=%s agent=%s task_type=%s depends_on=%d",
+            task_id,
+            agent,
+            task_type,
+            len(predecessors),
+        )
         return task_id
 
     @traced("lithos.coordination.get_task")
@@ -688,6 +976,7 @@ class CoordinationService:
                 title=row["title"],
                 description=row["description"],
                 status=row["status"],
+                task_type=row["task_type"] if "task_type" in row_keys else "task",
                 created_by=row["created_by"],
                 created_at=_parse_datetime(row["created_at"]),
                 tags=tags,
@@ -719,9 +1008,14 @@ class CoordinationService:
 
         Returns:
             True if task was found, is open, and was updated; False otherwise
+
+        Raises:
+            CoordinationError: ``metadata`` contains a forbidden scheduling key
+                (``depends_on``/``blocked_on``).
         """
         import json
 
+        _reject_scheduling_metadata(metadata)
         lithos_metrics.coordination_ops.add(1, {"op": "update_task"})
         await self.ensure_agent_known(agent)
 
@@ -952,6 +1246,7 @@ class CoordinationService:
         resolved_since: str | None = None,
         with_claims: bool = False,
         metadata_match: dict | None = None,
+        task_type: str | None = None,
     ) -> list[dict[str, Any]]:
         """List tasks with optional filters.
 
@@ -975,14 +1270,13 @@ class CoordinationService:
                 claims inline as a ``claims`` array. Defaults to False to
                 preserve the lightweight payload for callers that don't need
                 them.
+            task_type: Filter by first-class task type (task/epic/gate).
 
         Returns:
-            List of task dicts with id, title, description, status, created_by,
-            created_at, resolved_at, tags, metadata, outcome, and (when
-            with_claims) claims.
+            List of task dicts with id, title, description, status, task_type,
+            created_by, created_at, resolved_at, tags, metadata, outcome, and
+            (when with_claims) claims.
         """
-        import json
-
         query = "SELECT * FROM tasks WHERE 1=1"
         params: list[Any] = []
 
@@ -994,6 +1288,10 @@ class CoordinationService:
             query += " AND status = ?"
             params.append(status)
 
+        if task_type:
+            query += " AND task_type = ?"
+            params.append(task_type)
+
         if since:
             query += " AND created_at >= ?"
             params.append(since)
@@ -1002,25 +1300,9 @@ class CoordinationService:
             query += " AND resolved_at >= ?"
             params.append(resolved_since)
 
-        # Metadata equality/contains filter (#306), pushed into SQL so the
-        # engine evaluates it (no full-table load into Python). For each key the
-        # task matches when the stored value equals the query OR is an element of
-        # a JSON *array* at that key. Matching is type-sensitive to mirror the
-        # knowledge side: ``json_type`` is checked so a JSON boolean (stored as
-        # 1/0 by SQLite) never matches an integer query, and the array branch is
-        # gated on ``json_type(...) = 'array'`` so JSON objects are not iterated.
-        # The JSON path and value are bound parameters, so caller keys cannot
-        # inject SQL.
-        if metadata_match:
-            for key, value in metadata_match.items():
-                path = _json_path_for_key(key)
-                jtype = _json_type_label(value)
-                query += (
-                    " AND ( (json_type(metadata, ?) = ? AND json_extract(metadata, ?) = ?)"
-                    " OR (json_type(metadata, ?) = 'array' AND EXISTS"
-                    " (SELECT 1 FROM json_each(metadata, ?) WHERE type = ? AND value = ?)) )"
-                )
-                params.extend([path, jtype, path, value, path, path, jtype, value])
+        md_clause, md_params = _metadata_match_clause(metadata_match)
+        query += md_clause
+        params.extend(md_params)
 
         query += " ORDER BY created_at DESC"
 
@@ -1030,50 +1312,12 @@ class CoordinationService:
             rows = await cursor.fetchall()
 
             results: list[dict[str, Any]] = []
-            row_keys: list[str] | None = None
             for row in rows:
-                if row_keys is None:
-                    row_keys = list(row.keys())
-
-                task_tags: list[str] = []
-                if row["tags"]:
-                    with contextlib.suppress(json.JSONDecodeError):
-                        task_tags = json.loads(row["tags"])
-
+                task = _task_row_to_dict(row)
                 # Filter by tags: task must contain all requested tags
-                if tags and not all(t in task_tags for t in tags):
+                if tags and not all(t in task["tags"] for t in tags):
                     continue
-
-                # Route metadata decode through _decode_metadata for parity
-                # with get_task / get_task_status. Raw json.loads accepted
-                # legacy/corrupt rows whose JSON parses to non-objects
-                # (`null`, arrays, scalars), causing list_tasks to return a
-                # non-dict metadata payload while the other surfaces regularised
-                # it back to {}.
-                task_metadata: dict[str, Any] = {}
-                if "metadata" in row_keys:
-                    task_metadata = _decode_metadata(row["metadata"])
-
-                resolved_at = (
-                    row["resolved_at"]
-                    if row_keys is not None and "resolved_at" in row_keys
-                    else None
-                )
-                outcome = row["outcome"] if row_keys is not None and "outcome" in row_keys else None
-                results.append(
-                    {
-                        "id": row["id"],
-                        "title": row["title"],
-                        "description": row["description"],
-                        "status": row["status"],
-                        "created_by": row["created_by"],
-                        "created_at": row["created_at"],
-                        "resolved_at": resolved_at,
-                        "tags": task_tags,
-                        "metadata": task_metadata,
-                        "outcome": outcome,
-                    }
-                )
+                results.append(task)
 
             if with_claims and results:
                 claims_by_task = await self._fetch_active_claims_for(db, [r["id"] for r in results])
@@ -1199,6 +1443,7 @@ class CoordinationService:
                         claims=claims,
                         metadata=task_metadata,
                         description=task["description"],
+                        task_type=task["task_type"] if "task_type" in task_row_keys else "task",
                         created_by=task["created_by"],
                         created_at=_parse_datetime(task["created_at"]),
                         tags=task_tags,
@@ -1466,6 +1711,385 @@ class CoordinationService:
                 )
                 for row in rows
             ]
+
+    # ==================== Task Graph Operations ====================
+
+    @traced("lithos.coordination.upsert_task_edge")
+    async def upsert_task_edge(
+        self,
+        from_task_id: str,
+        to_task_id: str,
+        edge_type: str,
+        agent: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Create or update a typed relation between two tasks.
+
+        Args:
+            from_task_id: Source task (e.g. the blocker / parent / source).
+            to_task_id: Target task (e.g. the blocked / child / discovered task).
+            edge_type: One of the edge types accepted this phase
+                (:data:`ACCEPTED_EDGE_TYPES`).
+            agent: Agent creating the edge.
+            metadata: Optional edge metadata (merged-by-replace on conflict).
+
+        Returns:
+            True on success.
+
+        Raises:
+            CoordinationError: unaccepted edge type, self-edge, missing task, or a
+                blocking edge that would close a dependency cycle.
+        """
+        import json
+
+        if edge_type not in ACCEPTED_EDGE_TYPES:
+            raise CoordinationError(
+                "invalid_edge_type",
+                f"edge type '{edge_type}' is not accepted in this phase "
+                f"(accepted: {sorted(ACCEPTED_EDGE_TYPES)}).",
+            )
+        if from_task_id == to_task_id:
+            raise CoordinationError("self_edge", "An edge cannot connect a task to itself.")
+
+        lithos_metrics.coordination_ops.add(1, {"op": "upsert_task_edge"})
+        await self.ensure_agent_known(agent)
+        now = _format_datetime(datetime.now(timezone.utc))
+        metadata_json = json.dumps(metadata) if metadata is not None else None
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT id FROM tasks WHERE id IN (?, ?)",
+                (from_task_id, to_task_id),
+            )
+            found = {row[0] for row in await cursor.fetchall()}
+            missing = [t for t in (from_task_id, to_task_id) if t not in found]
+            if missing:
+                raise CoordinationError(
+                    "task_not_found", f"edge references nonexistent task(s): {missing}"
+                )
+
+            if edge_type in BLOCKING_EDGE_TYPES:
+                cycle = await self._find_dependency_path(db, from_task_id, to_task_id)
+                if cycle is not None:
+                    raise CoordinationError(
+                        "cycle",
+                        "blocking edge "
+                        f"{from_task_id} -> {to_task_id} would create a dependency cycle: "
+                        f"{' -> '.join(cycle)} -> {from_task_id}",
+                    )
+
+            await db.execute(
+                """
+                INSERT INTO task_edges
+                    (from_task_id, to_task_id, type, metadata, created_by, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(from_task_id, to_task_id, type)
+                    DO UPDATE SET metadata = excluded.metadata
+                """,
+                (from_task_id, to_task_id, edge_type, metadata_json, agent, now),
+            )
+            await db.commit()
+
+        logger.info(
+            "Task edge upserted: from=%s to=%s type=%s agent=%s",
+            from_task_id,
+            to_task_id,
+            edge_type,
+            agent,
+        )
+        return True
+
+    @traced("lithos.coordination.list_task_edges")
+    async def list_task_edges(
+        self,
+        task_id: str,
+        direction: Literal["incoming", "outgoing", "both"] = "both",
+        types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """List edges touching ``task_id``.
+
+        Each returned edge dict carries ``direction`` ("incoming" / "outgoing")
+        relative to ``task_id``. Index-driven via idx_task_edges_from/to.
+        """
+        type_clause = ""
+        type_params: list[Any] = []
+        if types:
+            placeholders = ",".join("?" for _ in types)
+            type_clause = f" AND type IN ({placeholders})"
+            type_params = list(types)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            edges: list[dict[str, Any]] = []
+            if direction in ("outgoing", "both"):
+                cursor = await db.execute(
+                    f"SELECT * FROM task_edges WHERE from_task_id = ?{type_clause}",
+                    (task_id, *type_params),
+                )
+                edges.extend(self._edge_row_to_dict(r, "outgoing") for r in await cursor.fetchall())
+            if direction in ("incoming", "both"):
+                cursor = await db.execute(
+                    f"SELECT * FROM task_edges WHERE to_task_id = ?{type_clause}",
+                    (task_id, *type_params),
+                )
+                edges.extend(self._edge_row_to_dict(r, "incoming") for r in await cursor.fetchall())
+            return edges
+
+    @staticmethod
+    def _edge_row_to_dict(row: Any, direction: str) -> dict[str, Any]:
+        """Build an edge payload dict from a ``task_edges`` row."""
+        return {
+            "from_task_id": row["from_task_id"],
+            "to_task_id": row["to_task_id"],
+            "type": row["type"],
+            "direction": direction,
+            "metadata": _decode_metadata(row["metadata"]),
+            "created_by": row["created_by"],
+            "created_at": row["created_at"],
+        }
+
+    async def _find_dependency_path(
+        self,
+        db: aiosqlite.Connection,
+        start: str,
+        target: str,
+    ) -> list[str] | None:
+        """Return a dependency path ``[start, ..., target]`` or None.
+
+        Follows the *depends-on* relation: the blockers of ``X`` are the
+        ``from_task_id`` of incoming blocking edges (``to_task_id = X``), read via
+        idx_task_edges_to. Bounded by the reachable blocking subgraph with a
+        visited-set — never a full-table walk. Used both to reject cycles on
+        write (does ``start`` already depend on ``target``?) and to classify a
+        cycle blocker in :meth:`list_blocked`.
+        """
+        types = tuple(BLOCKING_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in types)
+        visited = {start}
+        parent: dict[str, str] = {}
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            cursor = await db.execute(
+                f"SELECT from_task_id FROM task_edges WHERE to_task_id = ? AND type IN ({placeholders})",
+                (node, *types),
+            )
+            for (blocker,) in await cursor.fetchall():
+                if blocker in visited:
+                    continue
+                parent[blocker] = node
+                if blocker == target:
+                    path = [target]
+                    cur = node
+                    while cur != start:
+                        path.append(cur)
+                        cur = parent[cur]
+                    path.append(start)
+                    path.reverse()
+                    return path
+                visited.add(blocker)
+                stack.append(blocker)
+        return None
+
+    async def _is_task_ready(self, db: aiosqlite.Connection, task_id: str) -> bool:
+        """Whether a single task currently satisfies the readiness predicate."""
+        blocking = tuple(BLOCKING_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in blocking)
+        non_workable = ",".join("?" for _ in NON_WORKABLE_TASK_TYPES)
+        cursor = await db.execute(
+            f"""
+            SELECT 1 FROM tasks t
+            WHERE t.id = ? AND t.status = 'open' AND t.task_type NOT IN ({non_workable})
+              AND NOT EXISTS (
+                SELECT 1 FROM task_edges e JOIN tasks p ON p.id = e.from_task_id
+                WHERE e.to_task_id = t.id AND e.type IN ({placeholders})
+                  AND p.status != 'completed')
+            """,
+            (task_id, *NON_WORKABLE_TASK_TYPES, *blocking),
+        )
+        return await cursor.fetchone() is not None
+
+    @traced("lithos.coordination.list_ready")
+    async def list_ready(
+        self,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        metadata_match: dict | None = None,
+        limit: int = 50,
+        with_claims: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Return open tasks whose blocking predecessors are all ``completed``.
+
+        Restricts to the indexed ``status='open'`` frontier first, then applies an
+        index-driven anti-join over blocking edges, so cost scales with the open
+        frontier (not total task count). ``project`` is shorthand for
+        ``metadata.project == project``. Claims are *attached* when ``with_claims``
+        but never used to exclude a task — collision-correctness lives in the
+        atomic claim, and claims are per-aspect.
+        """
+        rows = await self._frontier_rows(ready=True, project=project, metadata_match=metadata_match)
+        results = self._apply_tags_and_limit(rows, tags, limit)
+        if with_claims and results:
+            async with aiosqlite.connect(self.db_path) as db:
+                db.row_factory = aiosqlite.Row
+                claims_by_task = await self._fetch_active_claims_for(db, [r["id"] for r in results])
+            for task in results:
+                task["claims"] = claims_by_task.get(task["id"], [])
+        return results
+
+    @traced("lithos.coordination.list_blocked")
+    async def list_blocked(
+        self,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        metadata_match: dict | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return open tasks that are not ready, each with structured blockers.
+
+        Same filter surface as :meth:`list_ready`. Each task carries a
+        ``blockers`` list whose entries have ``kind`` in
+        ``task``/``blocker_unsatisfiable``/``cycle`` (gate kinds arrive in Phase 3).
+        """
+        rows = await self._frontier_rows(
+            ready=False, project=project, metadata_match=metadata_match
+        )
+        results = self._apply_tags_and_limit(rows, tags, limit)
+        async with aiosqlite.connect(self.db_path) as db:
+            for task in results:
+                task["blockers"] = await self._compute_blockers(db, task["id"])
+        return results
+
+    async def _frontier_rows(
+        self,
+        ready: bool,
+        project: str | None,
+        metadata_match: dict | None,
+    ) -> list[Any]:
+        """Fetch open workable rows partitioned by the readiness anti-join.
+
+        ``ready=True`` selects tasks with no unsatisfied blocking predecessor;
+        ``ready=False`` selects those with at least one. Both ride on the indexed
+        ``status='open'`` frontier and the task_edges indexes.
+        """
+        effective_match = dict(metadata_match) if metadata_match else {}
+        if project is not None:
+            effective_match["project"] = project
+        md_clause, md_params = _metadata_match_clause(effective_match or None, column="t.metadata")
+
+        blocking = tuple(BLOCKING_EDGE_TYPES)
+        bph = ",".join("?" for _ in blocking)
+        non_workable = ",".join("?" for _ in NON_WORKABLE_TASK_TYPES)
+        exists_kw = "NOT EXISTS" if ready else "EXISTS"
+        query = (
+            "SELECT t.* FROM tasks t "
+            f"WHERE t.status = 'open' AND t.task_type NOT IN ({non_workable}) "
+            f"AND {exists_kw} ("
+            "  SELECT 1 FROM task_edges e JOIN tasks p ON p.id = e.from_task_id"
+            f"  WHERE e.to_task_id = t.id AND e.type IN ({bph}) AND p.status != 'completed')"
+            f"{md_clause} ORDER BY t.created_at DESC"
+        )
+        params = [*NON_WORKABLE_TASK_TYPES, *blocking, *md_params]
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(query, params)
+            return list(await cursor.fetchall())
+
+    @staticmethod
+    def _apply_tags_and_limit(
+        rows: list[Any],
+        tags: list[str] | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Tag-filter (post-scan over the open frontier) and cap to ``limit``."""
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            task = _task_row_to_dict(row)
+            if tags and not all(t in task["tags"] for t in tags):
+                continue
+            results.append(task)
+            if len(results) >= limit:
+                break
+        return results
+
+    async def _compute_blockers(
+        self,
+        db: aiosqlite.Connection,
+        task_id: str,
+    ) -> list[dict[str, Any]]:
+        """Explain why ``task_id`` is blocked: one entry per unsatisfied predecessor."""
+        blocking = tuple(BLOCKING_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in blocking)
+        cursor = await db.execute(
+            f"""
+            SELECT e.from_task_id, e.type, p.status
+            FROM task_edges e JOIN tasks p ON p.id = e.from_task_id
+            WHERE e.to_task_id = ? AND e.type IN ({placeholders})
+            """,
+            (task_id, *blocking),
+        )
+        blockers: list[dict[str, Any]] = []
+        for pred_id, edge_type, pred_status in await cursor.fetchall():
+            if pred_status == "completed":
+                continue
+            if pred_status == "cancelled":
+                blockers.append(
+                    {
+                        "kind": "blocker_unsatisfiable",
+                        "task_id": pred_id,
+                        "type": edge_type,
+                        "status": "cancelled",
+                        "message": (
+                            f"Blocking predecessor {pred_id} was cancelled; this task can "
+                            "never become ready without intervention (re-open or re-route "
+                            "the predecessor, or cancel this subtree)."
+                        ),
+                    }
+                )
+                continue
+            # predecessor is open: distinguish a genuine wait from a dependency cycle
+            cycle = await self._find_dependency_path(db, pred_id, task_id)
+            if cycle is not None:
+                blockers.append(
+                    {
+                        "kind": "cycle",
+                        "task_id": pred_id,
+                        "type": edge_type,
+                        "status": "open",
+                        "message": "dependency cycle: " + " -> ".join(cycle) + f" -> {pred_id}",
+                    }
+                )
+            else:
+                blockers.append(
+                    {
+                        "kind": "task",
+                        "task_id": pred_id,
+                        "type": edge_type,
+                        "status": "open",
+                        "message": f"Waiting on predecessor {pred_id} to complete.",
+                    }
+                )
+        return blockers
+
+    @traced("lithos.coordination.newly_unblocked_by")
+    async def newly_unblocked_by(self, task_id: str) -> list[str]:
+        """Return ids of tasks that ``task_id`` blocked and that are now ready.
+
+        Called by the MCP layer right after a successful completion. Each
+        candidate is a ``blocks`` dependent of ``task_id``; it is reported only if
+        it now satisfies the readiness predicate (this completion may have cleared
+        its last blocker).
+        """
+        blocking = tuple(BLOCKING_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in blocking)
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                f"SELECT DISTINCT to_task_id FROM task_edges "
+                f"WHERE from_task_id = ? AND type IN ({placeholders})",
+                (task_id, *blocking),
+            )
+            candidates = [row[0] for row in await cursor.fetchall()]
+            return [c for c in candidates if await self._is_task_ready(db, c)]
 
     # ==================== Statistics ====================
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -3152,7 +3152,7 @@ class LithosServer:
             metadata_match: dict | None = None,
             limit: int = 50,
             with_claims: bool = True,
-        ) -> dict[str, list[dict[str, Any]]]:
+        ) -> dict[str, Any]:
             """Return open tasks that are ready to work.
 
             A task is ready when it is open, not a gate/epic, has no incoming
@@ -3182,6 +3182,12 @@ class LithosServer:
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.task_ready") as span:
                 span.set_attribute("lithos.tool", "lithos_task_ready")
+                if limit < 1:
+                    return {
+                        "status": "error",
+                        "code": "invalid_input",
+                        "message": f"limit must be >= 1, got {limit}.",
+                    }
                 if metadata_match is not None:
                     try:
                         validate_metadata_match(metadata_match)
@@ -3204,7 +3210,7 @@ class LithosServer:
             tags: list[str] | None = None,
             metadata_match: dict | None = None,
             limit: int = 50,
-        ) -> dict[str, list[dict[str, Any]]]:
+        ) -> dict[str, Any]:
             """Return open tasks that are NOT ready, with structured blocker reasons.
 
             Same filter surface as ``lithos_task_ready``. Each returned task carries
@@ -3226,6 +3232,12 @@ class LithosServer:
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.task_blocked") as span:
                 span.set_attribute("lithos.tool", "lithos_task_blocked")
+                if limit < 1:
+                    return {
+                        "status": "error",
+                        "code": "invalid_input",
+                        "message": f"limit must be >= 1, got {limit}.",
+                    }
                 if metadata_match is not None:
                     try:
                         validate_metadata_match(metadata_match)

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -3111,7 +3111,7 @@ class LithosServer:
             task_id: str,
             direction: str = "both",
             types: list[str] | None = None,
-        ) -> dict[str, list[dict[str, Any]]]:
+        ) -> dict[str, Any]:
             """List edges touching a task.
 
             Args:
@@ -3128,9 +3128,18 @@ class LithosServer:
             with tracer.start_as_current_span("lithos.tool.task_edge_list") as span:
                 span.set_attribute("lithos.tool", "lithos_task_edge_list")
                 span.set_attribute("lithos.task_id", task_id)
+                if direction not in ("incoming", "outgoing", "both"):
+                    return {
+                        "status": "error",
+                        "code": "invalid_input",
+                        "message": (
+                            f"direction must be 'incoming', 'outgoing', or 'both', got "
+                            f"{direction!r}."
+                        ),
+                    }
                 edges = await self.coordination.list_task_edges(
                     task_id=task_id,
-                    direction=direction,  # type: ignore[arg-type]
+                    direction=direction,
                     types=types,
                 )
                 return {"edges": edges}

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -20,7 +20,7 @@ from starlette.responses import Response, StreamingResponse
 
 from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig, get_config, set_config
-from lithos.coordination import CoordinationService, Task, TaskStatus
+from lithos.coordination import CoordinationError, CoordinationService, Task, TaskStatus
 from lithos.edge_store import EdgeStore
 from lithos.errors import SearchBackendError
 from lithos.events import (
@@ -89,6 +89,7 @@ def _serialize_task_record(task: Task | TaskStatus) -> dict[str, Any]:
         "title": task.title,
         "description": task.description,
         "status": task.status,
+        "task_type": task.task_type,
         "created_by": task.created_by,
         "created_at": task.created_at.isoformat() if task.created_at else None,
         "resolved_at": task.resolved_at.isoformat() if task.resolved_at else None,
@@ -2507,7 +2508,9 @@ class LithosServer:
             description: str | None = None,
             tags: list[str] | None = None,
             metadata: dict[str, Any] | None = None,
-        ) -> dict[str, str]:
+            task_type: str = "task",
+            depends_on: list[str] | None = None,
+        ) -> dict[str, Any]:
             """Create a new coordination task.
 
             Args:
@@ -2515,23 +2518,36 @@ class LithosServer:
                 agent: Creating agent identifier
                 description: Task description
                 tags: Task tags
-                metadata: Arbitrary JSON metadata dict (optional)
+                metadata: Arbitrary JSON metadata dict (optional). Must NOT contain
+                    ``depends_on``/``blocked_on`` — dependencies are first-class task
+                    edges now; pass ``depends_on`` instead.
+                task_type: First-class task type. Only ``task`` is accepted in this
+                    phase (``epic``/``gate`` arrive in later phases).
+                depends_on: Predecessor task IDs. Each creates a ``blocks`` edge so
+                    this task is not ready until that predecessor is completed.
+                    Predecessors must already exist.
 
             Returns:
-                Dict with task_id
+                Dict with task_id, or an error envelope on validation failure.
             """
             logger.info("lithos_task_create agent=%s title=%r", agent, title)
             tracer = get_tracer()
             with tracer.start_as_current_span("lithos.tool.task_create") as span:
                 span.set_attribute("lithos.tool", "lithos_task_create")
                 span.set_attribute("lithos.agent", agent)
-                task_id = await self.coordination.create_task(
-                    title=title,
-                    agent=agent,
-                    description=description,
-                    tags=tags,
-                    metadata=metadata,
-                )
+                try:
+                    task_id = await self.coordination.create_task(
+                        title=title,
+                        agent=agent,
+                        description=description,
+                        tags=tags,
+                        metadata=metadata,
+                        task_type=task_type,
+                        depends_on=depends_on,
+                    )
+                except CoordinationError as exc:
+                    span.set_attribute("lithos.success", False)
+                    return {"status": "error", "code": exc.code, "message": exc.message}
                 span.set_attribute("lithos.task_id", task_id)
 
                 await self._emit(
@@ -2590,14 +2606,18 @@ class LithosServer:
                 span.set_attribute("lithos.tool", "lithos_task_update")
                 span.set_attribute("lithos.agent", agent)
                 span.set_attribute("lithos.task_id", task_id)
-                updated = await self.coordination.update_task(
-                    task_id=task_id,
-                    agent=agent,
-                    title=title,
-                    description=description,
-                    tags=tags,
-                    metadata=metadata,
-                )
+                try:
+                    updated = await self.coordination.update_task(
+                        task_id=task_id,
+                        agent=agent,
+                        title=title,
+                        description=description,
+                        tags=tags,
+                        metadata=metadata,
+                    )
+                except CoordinationError as exc:
+                    span.set_attribute("lithos.success", False)
+                    return {"status": "error", "code": exc.code, "message": exc.message}
                 span.set_attribute("lithos.success", updated)
 
                 if updated:
@@ -2877,7 +2897,12 @@ class LithosServer:
                     )
                 )
 
-                return {"success": True}
+                # Surface tasks this completion just made ready (their last
+                # blocking predecessor is now satisfied) so an orchestrator can
+                # pick them up without re-polling lithos_task_ready.
+                unblocked = await self.coordination.newly_unblocked_by(task_id)
+                span.set_attribute("lithos.unblocked_count", len(unblocked))
+                return {"success": True, "unblocked": unblocked}
 
         @self.mcp.tool()
         @tool_metrics()
@@ -2959,12 +2984,14 @@ class LithosServer:
             resolved_since: str | None = None,
             with_claims: bool = False,
             metadata_match: dict | None = None,
+            task_type: str | None = None,
         ) -> dict[str, list[dict[str, Any]]]:
             """List tasks with optional filters.
 
             Args:
                 agent: Filter by creating agent
                 status: Filter by status: "open", "completed", or "cancelled" (None = all)
+                task_type: Filter by first-class task type (task/epic/gate)
                 tags: Filter by tags (task must have all specified tags)
                 metadata_match: Filter by metadata (AND across keys). For each
                     ``key: q`` a task matches when its stored metadata value
@@ -3021,7 +3048,187 @@ class LithosServer:
                     resolved_since=resolved_since,
                     with_claims=with_claims,
                     metadata_match=metadata_match,
+                    task_type=task_type,
                 )
+                return {"tasks": tasks}
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_edge_upsert(
+            from_task_id: str,
+            to_task_id: str,
+            type: str,
+            agent: str,
+            metadata: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            """Create or update a typed relation between two tasks.
+
+            Edge types accepted in this phase: ``blocks`` (to_task is not ready
+            until from_task is completed), ``parent_child`` (from_task is the
+            parent; purely structural, never blocks), and ``discovered_from``
+            (to_task was discovered while executing from_task; non-blocking).
+
+            Args:
+                from_task_id: Source task (blocker / parent / source).
+                to_task_id: Target task (blocked / child / discovered).
+                type: Edge type (see above).
+                agent: Agent creating the edge.
+                metadata: Optional edge metadata.
+
+            Returns:
+                ``{"success": true}`` or an error envelope (unaccepted type,
+                self-edge, missing task, or a blocking edge that would create a
+                dependency cycle).
+            """
+            logger.info(
+                "lithos_task_edge_upsert from=%s to=%s type=%s agent=%s",
+                from_task_id,
+                to_task_id,
+                type,
+                agent,
+            )
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_edge_upsert") as span:
+                span.set_attribute("lithos.tool", "lithos_task_edge_upsert")
+                span.set_attribute("lithos.agent", agent)
+                span.set_attribute("lithos.edge_type", type)
+                try:
+                    await self.coordination.upsert_task_edge(
+                        from_task_id=from_task_id,
+                        to_task_id=to_task_id,
+                        edge_type=type,
+                        agent=agent,
+                        metadata=metadata,
+                    )
+                except CoordinationError as exc:
+                    span.set_attribute("lithos.success", False)
+                    return {"status": "error", "code": exc.code, "message": exc.message}
+                return {"success": True}
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_edge_list(
+            task_id: str,
+            direction: str = "both",
+            types: list[str] | None = None,
+        ) -> dict[str, list[dict[str, Any]]]:
+            """List edges touching a task.
+
+            Args:
+                task_id: Task whose edges to list.
+                direction: "incoming", "outgoing", or "both" (default).
+                types: Optional edge-type filter.
+
+            Returns:
+                ``{"edges": [...]}`` — each edge carries from/to/type, its
+                ``direction`` relative to ``task_id``, metadata, and provenance.
+            """
+            logger.info("lithos_task_edge_list task=%s direction=%s", task_id, direction)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_edge_list") as span:
+                span.set_attribute("lithos.tool", "lithos_task_edge_list")
+                span.set_attribute("lithos.task_id", task_id)
+                edges = await self.coordination.list_task_edges(
+                    task_id=task_id,
+                    direction=direction,  # type: ignore[arg-type]
+                    types=types,
+                )
+                return {"edges": edges}
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_ready(
+            project: str | None = None,
+            tags: list[str] | None = None,
+            metadata_match: dict | None = None,
+            limit: int = 50,
+            with_claims: bool = True,
+        ) -> dict[str, list[dict[str, Any]]]:
+            """Return open tasks that are ready to work.
+
+            A task is ready when it is open, not a gate/epic, has no incoming
+            blocking edge whose predecessor is unsatisfied (every ``blocks``
+            predecessor must be ``completed``), and is not blocked by a gate.
+            Active claims are *attached* when ``with_claims`` but never used to
+            exclude a task — claims are per-aspect and collision-safety comes
+            from the atomic claim, so the picking agent decides what "taken" means.
+
+            Args:
+                project: Shorthand for ``metadata.project == project``.
+                tags: Filter by tags (task must have all specified tags).
+                metadata_match: Metadata filter (AND across keys); scalars only.
+                limit: Maximum tasks to return.
+                with_claims: Attach each task's active claims inline (default True).
+
+            Returns:
+                Dict with a ``tasks`` list (the feasible frontier).
+            """
+            logger.info(
+                "lithos_task_ready project=%s tags=%s limit=%s with_claims=%s",
+                project,
+                tags,
+                limit,
+                with_claims,
+            )
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_ready") as span:
+                span.set_attribute("lithos.tool", "lithos_task_ready")
+                if metadata_match is not None:
+                    try:
+                        validate_metadata_match(metadata_match)
+                    except ValueError as e:
+                        return {"status": "invalid_input", "message": str(e), "warnings": []}  # type: ignore[return-value]
+                tasks = await self.coordination.list_ready(
+                    project=project,
+                    tags=tags,
+                    metadata_match=metadata_match,
+                    limit=limit,
+                    with_claims=with_claims,
+                )
+                span.set_attribute("lithos.ready_count", len(tasks))
+                return {"tasks": tasks}
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_blocked(
+            project: str | None = None,
+            tags: list[str] | None = None,
+            metadata_match: dict | None = None,
+            limit: int = 50,
+        ) -> dict[str, list[dict[str, Any]]]:
+            """Return open tasks that are NOT ready, with structured blocker reasons.
+
+            Same filter surface as ``lithos_task_ready``. Each returned task carries
+            a ``blockers`` list; each blocker has ``kind``:
+            ``task`` (predecessor still open — just waiting),
+            ``blocker_unsatisfiable`` (predecessor was cancelled — needs
+            intervention), or ``cycle`` (the dependency chain forms a cycle).
+
+            Args:
+                project: Shorthand for ``metadata.project == project``.
+                tags: Filter by tags (task must have all specified tags).
+                metadata_match: Metadata filter (AND across keys); scalars only.
+                limit: Maximum tasks to return.
+
+            Returns:
+                Dict with a ``tasks`` list, each task including its ``blockers``.
+            """
+            logger.info("lithos_task_blocked project=%s tags=%s limit=%s", project, tags, limit)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_blocked") as span:
+                span.set_attribute("lithos.tool", "lithos_task_blocked")
+                if metadata_match is not None:
+                    try:
+                        validate_metadata_match(metadata_match)
+                    except ValueError as e:
+                        return {"status": "invalid_input", "message": str(e), "warnings": []}  # type: ignore[return-value]
+                tasks = await self.coordination.list_blocked(
+                    project=project,
+                    tags=tags,
+                    metadata_match=metadata_match,
+                    limit=limit,
+                )
+                span.set_attribute("lithos.blocked_count", len(tasks))
                 return {"tasks": tasks}
 
         @self.mcp.tool()

--- a/tests/test_task_complete_feedback.py
+++ b/tests/test_task_complete_feedback.py
@@ -85,7 +85,7 @@ class TestTaskCompleteNoFeedback:
     async def test_no_feedback_params_existing_behaviour(self, srv: LithosServer) -> None:
         task_id = await _create_task(srv)
         result = await _call(srv, "lithos_task_complete", task_id=task_id, agent="test-agent")
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
     @pytest.mark.asyncio
     async def test_cited_none_misleading_none_no_learning(self, srv: LithosServer) -> None:
@@ -102,7 +102,7 @@ class TestTaskCompleteNoFeedback:
             cited_nodes=None,
             misleading_nodes=None,
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # Verify no stats changes -- ignored_count should be 0
         for nid in node_ids:
@@ -136,7 +136,7 @@ class TestReceiptValidation:
                 misleading_nodes=[],
             )
 
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
         assert any("dropping all feedback" in r.message.lower() for r in caplog.records)
 
         # Verify no reinforcement applied
@@ -160,7 +160,7 @@ class TestReceiptValidation:
             cited_nodes=[node_ids[0]],
             receipt_id="rcpt-exact",
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         stats = await srv.memory._stats_store.get_node_stats(node_ids[0])
         assert stats is not None
@@ -208,7 +208,7 @@ class TestReceiptValidation:
 
         # The task should still be open -- a second complete call should succeed
         result2 = await _call(srv, "lithos_task_complete", task_id=task_id, agent="test-agent")
-        assert result2 == {"success": True}
+        assert result2 == {"success": True, "unblocked": []}
 
 
 # -- Feedback intersection ------------------------------------------------
@@ -232,7 +232,7 @@ class TestFeedbackIntersection:
             agent="test-agent",
             cited_nodes=[node_ids[0], node_ids[2]],  # node_ids[2] not in receipt
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # node_ids[0] was cited (in receipt)
         stats0 = await srv.memory._stats_store.get_node_stats(node_ids[0])
@@ -258,7 +258,7 @@ class TestFeedbackIntersection:
             agent="test-agent",
             misleading_nodes=[node_ids[1], node_ids[2]],  # node_ids[2] not in receipt
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # node_ids[1] was penalized (in receipt)
         stats1 = await srv.memory._stats_store.get_node_stats(node_ids[1])
@@ -287,7 +287,7 @@ class TestFeedbackIntersection:
             agent="test-agent",
             cited_nodes=node_ids,
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # node_ids[0] still exists -- should be cited
         stats0 = await srv.memory._stats_store.get_node_stats(node_ids[0])
@@ -322,7 +322,7 @@ class TestIgnoredPenalization:
             cited_nodes=[],
             misleading_nodes=[],
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # All receipt nodes should have ignored_count incremented
         for nid in node_ids:
@@ -351,7 +351,7 @@ class TestReinforcementApplication:
             agent="test-agent",
             cited_nodes=node_ids,
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         for nid in node_ids:
             stats = await srv.memory._stats_store.get_node_stats(nid)
@@ -376,7 +376,7 @@ class TestReinforcementApplication:
             agent="test-agent",
             misleading_nodes=node_ids,
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         for nid in node_ids:
             stats = await srv.memory._stats_store.get_node_stats(nid)
@@ -481,7 +481,7 @@ class TestFullReinforcementCycle:
             misleading_nodes=[misleading_id],
             receipt_id=receipt_id,
         )
-        assert result == {"success": True}
+        assert result == {"success": True, "unblocked": []}
 
         # cited node: cited_count=1, salience ~0.52, spaced_rep_strength ~0.05
         stats_cited = await srv.memory._stats_store.get_node_stats(cited_id)

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -190,6 +190,20 @@ class TestReadyBlocked:
         ready = await coordination_service.list_ready(limit=3)
         assert len(ready) == 3
 
+    async def test_ready_limit_with_tags_post_scan(
+        self, coordination_service: CoordinationService
+    ):
+        # With a tag filter the limit is applied AFTER the Python post-scan, so a
+        # SQL LIMIT must NOT be pushed down (it would under-fill). Create more
+        # tagged-matching tasks than the limit and confirm we still get `limit`.
+        for i in range(5):
+            await _mk(coordination_service, f"T{i}", tags=["x"])
+        for i in range(3):
+            await _mk(coordination_service, f"U{i}", tags=["other"])
+        ready = await coordination_service.list_ready(tags=["x"], limit=2)
+        assert len(ready) == 2
+        assert all("x" in t["tags"] for t in ready)
+
 
 # ==================== Cycles ====================
 
@@ -447,3 +461,9 @@ class TestServerTaskGraphTools:
         res = await _call(server, "lithos_task_create", title="T", agent="a", task_type="epic")
         assert res["status"] == "error"
         assert res["code"] == "invalid_task_type"
+
+    async def test_edge_list_invalid_direction_rejected(self, server: LithosServer):
+        a = await server.coordination.create_task(title="A", agent="a")
+        res = await _call(server, "lithos_task_edge_list", task_id=a, direction="sideways")
+        assert res["status"] == "error"
+        assert res["code"] == "invalid_input"

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -1,0 +1,449 @@
+"""Tests for the Phase 1 task graph: edges, ready/blocked, cycles, backfill.
+
+Service-level tests use the ``coordination_service`` fixture; a small set of
+server-level tests exercise the new MCP tool envelopes via ``server.mcp.get_tool``.
+"""
+
+import json
+from typing import Any
+
+import aiosqlite
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.coordination import CoordinationError, CoordinationService
+from lithos.server import LithosServer
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mk(service: CoordinationService, title: str, agent: str = "a", **kwargs: Any) -> str:
+    """Create a task and return its id."""
+    return await service.create_task(title=title, agent=agent, **kwargs)
+
+
+def _ids(tasks: list[dict[str, Any]]) -> set[str]:
+    return {t["id"] for t in tasks}
+
+
+# ==================== Edges: CRUD + validation ====================
+
+
+class TestTaskEdges:
+    async def test_upsert_and_list_roundtrip(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+
+        ok = await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+        assert ok is True
+
+        outgoing = await coordination_service.list_task_edges(a, direction="outgoing")
+        assert len(outgoing) == 1
+        assert outgoing[0]["to_task_id"] == b
+        assert outgoing[0]["type"] == "blocks"
+        assert outgoing[0]["direction"] == "outgoing"
+
+        incoming = await coordination_service.list_task_edges(b, direction="incoming")
+        assert len(incoming) == 1
+        assert incoming[0]["from_task_id"] == a
+        assert incoming[0]["direction"] == "incoming"
+
+        both = await coordination_service.list_task_edges(a, direction="both")
+        assert len(both) == 1
+
+    async def test_upsert_updates_metadata_on_conflict(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a", metadata={"v": 1})
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a", metadata={"v": 2})
+
+        edges = await coordination_service.list_task_edges(a, direction="outgoing")
+        assert len(edges) == 1  # UNIQUE(from,to,type) — upsert, not duplicate
+        assert edges[0]["metadata"]["v"] == 2
+
+    async def test_list_edges_type_filter(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+        await coordination_service.upsert_task_edge(a, b, "parent_child", "a")
+
+        only_blocks = await coordination_service.list_task_edges(
+            a, direction="outgoing", types=["blocks"]
+        )
+        assert [e["type"] for e in only_blocks] == ["blocks"]
+
+    async def test_self_edge_rejected(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(a, a, "blocks", "a")
+        assert exc.value.code == "self_edge"
+
+    async def test_nonexistent_task_rejected(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(a, "ghost", "blocks", "a")
+        assert exc.value.code == "task_not_found"
+
+    @pytest.mark.parametrize("bad_type", ["waits_on_gate", "duplicate_of", "relates_to", "nope"])
+    async def test_unaccepted_edge_types_rejected(
+        self, coordination_service: CoordinationService, bad_type: str
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(a, b, bad_type, "a")
+        assert exc.value.code == "invalid_edge_type"
+
+    async def test_parent_child_is_non_blocking(self, coordination_service: CoordinationService):
+        parent = await _mk(coordination_service, "Parent")
+        child = await _mk(coordination_service, "Child")
+        await coordination_service.upsert_task_edge(parent, child, "parent_child", "a")
+
+        ready = await coordination_service.list_ready()
+        # parent_child never blocks: both remain ready
+        assert {parent, child} <= _ids(ready)
+
+
+# ==================== Ready / blocked semantics ====================
+
+
+class TestReadyBlocked:
+    async def test_blocks_until_predecessor_completed(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+
+        ready = await coordination_service.list_ready()
+        assert a in _ids(ready)
+        assert b not in _ids(ready)
+
+        blocked = await coordination_service.list_blocked()
+        assert b in _ids(blocked)
+        b_row = next(t for t in blocked if t["id"] == b)
+        assert b_row["blockers"][0]["kind"] == "task"
+        assert b_row["blockers"][0]["task_id"] == a
+        assert b_row["blockers"][0]["status"] == "open"
+
+        await coordination_service.complete_task(a, "a")
+        ready = await coordination_service.list_ready()
+        assert b in _ids(ready)
+        assert a not in _ids(ready)  # completed -> off the frontier
+        assert b not in _ids(await coordination_service.list_blocked())
+
+    async def test_open_predecessor_keeps_dependent_blocked(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+        # a is merely open (not completed) -> b is not ready
+        assert b not in _ids(await coordination_service.list_ready())
+
+    async def test_cancelled_blocker_is_unsatisfiable(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+        await coordination_service.cancel_task(a, "a")
+
+        # A cancelled blocker must NOT spuriously ready its dependent.
+        assert b not in _ids(await coordination_service.list_ready())
+
+        blocked = await coordination_service.list_blocked()
+        b_row = next(t for t in blocked if t["id"] == b)
+        blocker = b_row["blockers"][0]
+        assert blocker["kind"] == "blocker_unsatisfiable"
+        assert blocker["task_id"] == a
+        assert blocker["status"] == "cancelled"
+
+    async def test_ready_attaches_claims_never_excludes(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        await coordination_service.claim_task(a, aspect="impl", agent="claimer")
+
+        ready = await coordination_service.list_ready(with_claims=True)
+        a_row = next(t for t in ready if t["id"] == a)
+        # claimed task still appears in the frontier...
+        assert a in _ids(ready)
+        # ...with its active claim attached
+        assert any(c["aspect"] == "impl" for c in a_row["claims"])
+
+    async def test_ready_filters_by_project_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A", metadata={"project": "alpha"})
+        b = await _mk(coordination_service, "B", metadata={"project": "beta"})
+
+        alpha = await coordination_service.list_ready(project="alpha")
+        assert a in _ids(alpha)
+        assert b not in _ids(alpha)
+
+    async def test_ready_respects_limit(self, coordination_service: CoordinationService):
+        for i in range(5):
+            await _mk(coordination_service, f"T{i}")
+        ready = await coordination_service.list_ready(limit=3)
+        assert len(ready) == 3
+
+
+# ==================== Cycles ====================
+
+
+class TestCycles:
+    async def test_direct_cycle_rejected_on_write(self, coordination_service: CoordinationService):
+        x = await _mk(coordination_service, "X")
+        y = await _mk(coordination_service, "Y")
+        await coordination_service.upsert_task_edge(x, y, "blocks", "a")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(y, x, "blocks", "a")
+        assert exc.value.code == "cycle"
+
+    async def test_transitive_cycle_rejected_on_write(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B")
+        c = await _mk(coordination_service, "C")
+        await coordination_service.upsert_task_edge(a, b, "blocks", "a")
+        await coordination_service.upsert_task_edge(b, c, "blocks", "a")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(c, a, "blocks", "a")
+        assert exc.value.code == "cycle"
+
+
+# ==================== create_task: depends_on + task_type ====================
+
+
+class TestCreateConvenience:
+    async def test_depends_on_creates_blocks_edges(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B", depends_on=[a])
+
+        incoming = await coordination_service.list_task_edges(b, direction="incoming")
+        assert incoming[0]["from_task_id"] == a
+        assert incoming[0]["type"] == "blocks"
+        assert b not in _ids(await coordination_service.list_ready())
+
+    async def test_depends_on_nonexistent_rejected(self, coordination_service: CoordinationService):
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(title="B", agent="a", depends_on=["ghost"])
+        assert exc.value.code == "task_not_found"
+
+    async def test_invalid_task_type_rejected(self, coordination_service: CoordinationService):
+        for bad in ("epic", "gate", "subtask"):
+            with pytest.raises(CoordinationError) as exc:
+                await coordination_service.create_task(title="T", agent="a", task_type=bad)
+            assert exc.value.code == "invalid_task_type"
+
+    async def test_default_task_type_persisted(self, coordination_service: CoordinationService):
+        tid = await _mk(coordination_service, "T")
+        task = await coordination_service.get_task(tid)
+        assert task is not None
+        assert task.task_type == "task"
+
+    async def test_list_tasks_task_type_filter(self, coordination_service: CoordinationService):
+        tid = await _mk(coordination_service, "T")
+        listed = await coordination_service.list_tasks(task_type="task")
+        assert tid in {t["id"] for t in listed}
+        assert all(t["task_type"] == "task" for t in listed)
+
+
+# ==================== Forbidden scheduling metadata ====================
+
+
+class TestForbiddenMetadata:
+    async def test_create_rejects_depends_on_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(
+                title="T", agent="a", metadata={"depends_on": ["x"]}
+            )
+        assert exc.value.code == "invalid_metadata_key"
+
+    async def test_update_rejects_blocked_on_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        tid = await _mk(coordination_service, "T")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.update_task(
+                task_id=tid, agent="a", metadata={"blocked_on": ["y"]}
+            )
+        assert exc.value.code == "invalid_metadata_key"
+
+    async def test_rejects_even_none_delete(self, coordination_service: CoordinationService):
+        # presence of the key at all is rejected, even a None delete
+        with pytest.raises(CoordinationError):
+            await coordination_service.create_task(
+                title="T", agent="a", metadata={"depends_on": None}
+            )
+
+
+# ==================== newly_unblocked_by ====================
+
+
+class TestNewlyUnblocked:
+    async def test_completion_unblocks_dependent(self, coordination_service: CoordinationService):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B", depends_on=[a])
+
+        assert await coordination_service.newly_unblocked_by(a) == []  # a still open
+        await coordination_service.complete_task(a, "a")
+        assert await coordination_service.newly_unblocked_by(a) == [b]
+
+    async def test_multiple_blockers_only_unblocks_when_all_done(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        x = await _mk(coordination_service, "X")
+        b = await _mk(coordination_service, "B", depends_on=[a, x])
+
+        await coordination_service.complete_task(a, "a")
+        assert await coordination_service.newly_unblocked_by(a) == []  # X still blocks
+        await coordination_service.complete_task(x, "a")
+        assert await coordination_service.newly_unblocked_by(x) == [b]
+
+
+# ==================== Backfill + migration ====================
+
+
+class TestBackfillMigration:
+    async def _legacy_db(self, db_path, rows: list[tuple[str, dict | None]]) -> None:
+        """Create a pre-task_type tasks table and insert (id, metadata) rows."""
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT,
+                    status TEXT DEFAULT 'open', created_by TEXT NOT NULL,
+                    created_at TIMESTAMP, tags JSON, outcome TEXT,
+                    resolved_at TIMESTAMP, metadata JSON
+                )
+                """
+            )
+            for task_id, metadata in rows:
+                await db.execute(
+                    "INSERT INTO tasks (id, title, created_by, metadata) VALUES (?, ?, 'm', ?)",
+                    (task_id, task_id, json.dumps(metadata) if metadata is not None else None),
+                )
+            await db.commit()
+
+    async def test_backfill_from_metadata_with_dangling_ids(self, test_config: LithosConfig):
+        service = CoordinationService(test_config)
+        await self._legacy_db(
+            service.db_path,
+            [
+                ("A", None),
+                ("B", {"depends_on": "A"}),  # scalar form
+                ("C", {"blocked_on": ["A", "ghost"]}),  # list form + dangling
+            ],
+        )
+
+        await service.initialize()
+
+        inc_b = await service.list_task_edges("B", direction="incoming")
+        assert [e["from_task_id"] for e in inc_b] == ["A"]
+        assert inc_b[0]["type"] == "blocks"
+        assert inc_b[0]["metadata"]["migrated_from"] == "metadata.depends_on"
+
+        inc_c = await service.list_task_edges("C", direction="incoming")
+        # "ghost" reference skipped; only "A" backfilled
+        assert {e["from_task_id"] for e in inc_c} == {"A"}
+
+    async def test_migration_is_idempotent(self, test_config: LithosConfig):
+        service = CoordinationService(test_config)
+        await self._legacy_db(service.db_path, [("A", None), ("B", {"depends_on": "A"})])
+
+        await service.initialize()
+        edges_first = await service.list_task_edges("B", direction="incoming")
+        # re-running initialize must not error or duplicate edges
+        await service.initialize()
+        edges_second = await service.list_task_edges("B", direction="incoming")
+        assert len(edges_first) == len(edges_second) == 1
+
+    async def test_backfill_cycle_retained_and_surfaced(self, test_config: LithosConfig):
+        service = CoordinationService(test_config)
+        # A depends on B and B depends on A -> a cycle the backfill must retain
+        await self._legacy_db(
+            service.db_path,
+            [("A", {"depends_on": "B"}), ("B", {"depends_on": "A"})],
+        )
+        await service.initialize()
+
+        # both cycle members excluded from ready (mutual open blockers)
+        ready_ids = _ids(await service.list_ready())
+        assert "A" not in ready_ids and "B" not in ready_ids
+
+        blocked = await service.list_blocked()
+        a_row = next(t for t in blocked if t["id"] == "A")
+        assert a_row["blockers"][0]["kind"] == "cycle"
+
+
+# ==================== Server-level tool envelopes ====================
+
+
+async def _call(server: LithosServer, tool_name: str, **kwargs: Any) -> dict[str, Any]:
+    tool = await server.mcp.get_tool(tool_name)
+    return await tool.fn(**kwargs)
+
+
+class TestServerTaskGraphTools:
+    async def test_ready_and_blocked_tools(self, server: LithosServer):
+        a = await server.coordination.create_task(title="A", agent="a")
+        b = await server.coordination.create_task(title="B", agent="a")
+        await _call(
+            server,
+            "lithos_task_edge_upsert",
+            from_task_id=a,
+            to_task_id=b,
+            type="blocks",
+            agent="a",
+        )
+
+        ready = await _call(server, "lithos_task_ready")
+        assert a in {t["id"] for t in ready["tasks"]}
+        assert b not in {t["id"] for t in ready["tasks"]}
+
+        blocked = await _call(server, "lithos_task_blocked")
+        b_row = next(t for t in blocked["tasks"] if t["id"] == b)
+        assert b_row["blockers"][0]["kind"] == "task"
+
+    async def test_edge_upsert_cycle_error_envelope(self, server: LithosServer):
+        x = await server.coordination.create_task(title="X", agent="a")
+        y = await server.coordination.create_task(title="Y", agent="a")
+        await _call(
+            server,
+            "lithos_task_edge_upsert",
+            from_task_id=x,
+            to_task_id=y,
+            type="blocks",
+            agent="a",
+        )
+        res = await _call(
+            server,
+            "lithos_task_edge_upsert",
+            from_task_id=y,
+            to_task_id=x,
+            type="blocks",
+            agent="a",
+        )
+        assert res["status"] == "error"
+        assert res["code"] == "cycle"
+
+    async def test_complete_returns_unblocked(self, server: LithosServer):
+        a = await server.coordination.create_task(title="A", agent="a")
+        b = await server.coordination.create_task(title="B", agent="a", depends_on=[a])
+        res = await _call(server, "lithos_task_complete", task_id=a, agent="a")
+        assert res["success"] is True
+        assert res["unblocked"] == [b]
+
+    async def test_create_bad_task_type_error_envelope(self, server: LithosServer):
+        res = await _call(server, "lithos_task_create", title="T", agent="a", task_type="epic")
+        assert res["status"] == "error"
+        assert res["code"] == "invalid_task_type"

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -190,9 +190,7 @@ class TestReadyBlocked:
         ready = await coordination_service.list_ready(limit=3)
         assert len(ready) == 3
 
-    async def test_ready_limit_with_tags_post_scan(
-        self, coordination_service: CoordinationService
-    ):
+    async def test_ready_limit_with_tags_post_scan(self, coordination_service: CoordinationService):
         # With a tag filter the limit is applied AFTER the Python post-scan, so a
         # SQL LIMIT must NOT be pushed down (it would under-fill). Create more
         # tagged-matching tasks than the limit and confirm we still get `limit`.
@@ -203,6 +201,19 @@ class TestReadyBlocked:
         ready = await coordination_service.list_ready(tags=["x"], limit=2)
         assert len(ready) == 2
         assert all("x" in t["tags"] for t in ready)
+
+    async def test_non_positive_limit_returns_empty(
+        self, coordination_service: CoordinationService
+    ):
+        # Non-positive limits must yield no tasks, consistently across the SQL
+        # (no-tags) and Python (tags) paths — not one task via append-then-check,
+        # and not "all rows" via SQL LIMIT -1.
+        for i in range(3):
+            await _mk(coordination_service, f"T{i}", tags=["x"])
+        assert await coordination_service.list_ready(limit=0) == []
+        assert await coordination_service.list_ready(limit=-1) == []
+        assert await coordination_service.list_ready(tags=["x"], limit=0) == []
+        assert await coordination_service.list_blocked(limit=0) == []
 
 
 # ==================== Cycles ====================
@@ -467,3 +478,10 @@ class TestServerTaskGraphTools:
         res = await _call(server, "lithos_task_edge_list", task_id=a, direction="sideways")
         assert res["status"] == "error"
         assert res["code"] == "invalid_input"
+
+    async def test_ready_blocked_reject_non_positive_limit(self, server: LithosServer):
+        await server.coordination.create_task(title="A", agent="a")
+        for tool in ("lithos_task_ready", "lithos_task_blocked"):
+            res = await _call(server, tool, limit=0)
+            assert res["status"] == "error", tool
+            assert res["code"] == "invalid_input", tool


### PR DESCRIPTION
## Context

Implements **Phase 1** of `docs/plans/task-graph-coordination-extension.md`. Until now Lithos task scheduling fields (`depends_on`, `blocked_on`, `priority`, `parallelizable`) lived only as opaque `tasks.metadata` conventions that **no code read**. This makes dependencies first-class and queryable so agents can ask *"what's ready now?"* and *"what's blocked, and why?"* without re-parsing prose — while keeping Lithos passive (readiness is computed at query time; nothing polls external systems).

Scope is deliberately Phase 1 only (foundation). Phases 2–4 (hierarchy/spawn tools, gates, priority column) are out of scope.

## Four implementation decisions (agreed before coding)

1. **Filter perf** — `ready`/`blocked` ride on the indexed `status='open'` frontier via a set-based anti-join; no independent `project` index now (cost scales with the open frontier, not total task count). A `metadata.project` expression index is a trivial additive migration if a large multi-project frontier ever appears.
2. **Claims** — `ready` *attaches* active claims inline but **never excludes** by claim. Collision-correctness already comes from the atomic claim, and claims are per-aspect. (`include_claims` → `with_claims` to match `lithos_task_list`.)
3. **Hierarchy** — dropped `subtask`; `task_type ∈ {task, epic, gate}`. "Child" is purely the `parent_child` edge (single source of truth).
4. **`task_type` write-validation is phase-gated** like edge types: Phase 1 accepts only `task`; `epic` from Phase 2, `gate` from Phase 3.

## What's in this PR

**Data model (`coordination.py`)**
- `tasks.task_type` column (`NOT NULL DEFAULT 'task'`)
- `task_edges` table + `(from_task_id, type)` / `(to_task_id, type)` indexes
- one-time backfill of `metadata.depends_on`/`blocked_on` → canonical `blocks` edges, tied to the column-add branch so it runs exactly once (dangling IDs skipped+logged; cycle edges retained, never dropped)

**Service + semantics**
- `upsert_task_edge` / `list_task_edges` (accepted: `blocks`, `parent_child`, `discovered_from`; self-edge / missing-task / cycle rejected)
- `list_ready` / `list_blocked` as indexed anti-joins; bounded-traversal cycle detection shared by write-rejection and the blocked view's `cycle` classification
- readiness requires every blocking predecessor be **`completed`** (not merely non-open). A **`cancelled`** predecessor leaves dependents `blocker_unsatisfiable` (excluded from ready, surfaced in blocked) rather than spuriously ready
- `newly_unblocked_by` powers the `complete` unblock signal

**MCP tools (`server.py`)** — 29 → 33
- new: `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, `lithos_task_blocked`
- `lithos_task_create` gains `task_type` + `depends_on`; `lithos_task_complete` returns additive `unblocked`; `lithos_task_list` gains a `task_type` filter; `create`/`update` reject `metadata.depends_on`/`blocked_on`

**Docs** — `SPECIFICATION.md` §5.4/§7; proposal doc folded in the four decisions.

## Test plan

- [x] `make test` — 1412 passed
- [x] `make test-integration` — 385 passed
- [x] `make lint` / `make typecheck` — clean
- New `tests/test_task_graph.py` (35 cases): edge CRUD + validation, ready/blocked, **cancelled-blocker unsatisfiability**, cycle rejection on write + backfill-cycle surfacing, `depends_on`, forbidden-metadata rejection, `task_type` validation, ready-attaches-claims, newly-unblocked, and the one-time migration/backfill (dangling IDs + idempotency)
- Updated brittle `== {"success": True}` assertions in `test_task_complete_feedback.py` for the additive `unblocked` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)