### PR TITLE
feat(coordination): task graph Phase 3 — gates

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -751,7 +751,7 @@ Create a coordination task.
 | `tags` | string[] | No | Task tags |
 | `agent` | string | Yes | Creating agent identifier |
 | `metadata` | object | No | Arbitrary JSON metadata dict persisted on the task row at insert time. Omitted (or `null`) creates a task with empty metadata. This is an **initial set**, not a merge — the row does not yet exist, so there is nothing to merge into. Subsequent mutations go through `lithos_task_update`, which applies an additive per-key merge (see that tool's **Behavior** for the contract). Must **not** contain `depends_on`/`blocked_on` — dependencies are first-class task edges now (use `depends_on` below or `lithos_task_edge_upsert`); a write containing those keys is rejected with `invalid_metadata_key`. |
-| `task_type` | string | No | First-class task type: `task` or `epic` (`gate` arrives in Phase 3); any other value is rejected with `invalid_task_type`. Defaults to `task`. An `epic` is a roll-up container and is excluded from `lithos_task_ready`. |
+| `task_type` | string | No | First-class task type: `task`, `epic`, or `gate`; any other value is rejected with `invalid_task_type`. Defaults to `task`. An `epic` (roll-up container) and a `gate` (external wait) are both excluded from `lithos_task_ready`. A `gate` requires gate metadata (see Gates below) — invalid gate metadata is rejected with `invalid_input`. |
 | `depends_on` | string[] | No | Predecessor task IDs. Each creates a `blocks` edge `predecessor -> this task`, so this task is not ready until every predecessor is `completed`. Predecessors must already exist (else `task_not_found`). A brand-new task has no outgoing edges, so `depends_on` can never form a cycle. |
 | `parent_task_id` | string | No | Optional parent. Creates a `parent_child` edge `parent -> this task` (purely structural; never blocks the child). The parent must exist (else `task_not_found`) and may be any task type. |
 
@@ -892,7 +892,7 @@ Fetch a single task by ID. Returns the full task record without claims; use `lit
 
 #### Task Graph (Phase 1)
 
-The task graph makes dependencies first-class via a `task_edges` table (see §7) and a `task_type` column. Lithos remains **passive**: readiness is computed at query time from edges and task status; nothing polls external systems. The accepted edge types grow per delivery phase — Phase 1 ships `blocks` (blocking), `parent_child` (structural, non-blocking), and `discovered_from` (provenance, non-blocking); `waits_on_gate` and deferred relational types are rejected until later phases.
+The task graph makes dependencies first-class via a `task_edges` table (see §7) and a `task_type` column. Lithos remains **passive**: readiness is computed at query time from edges and task status; nothing polls external systems. The accepted edge types grow per delivery phase — Phase 1 ships `blocks` (blocking), `parent_child` (structural, non-blocking), and `discovered_from` (provenance, non-blocking); Phase 3 adds `waits_on_gate` (blocking, gate-resolved); deferred relational types are still rejected.
 
 **Readiness predicate.** A task is *ready* when it is `open`, is not a `gate`/`epic`, has no incoming blocking edge whose predecessor is unsatisfied (a `blocks` predecessor must be `completed` — a predecessor still `open`, or terminal-but-cancelled, leaves the edge unsatisfied), and is not held by an unresolved gate. A predecessor that ends `cancelled` leaves its dependents **permanently** blocked (`blocker_unsatisfiable`) rather than spuriously ready — Lithos refuses to call them ready and explains why, leaving re-open/re-route/cancel to the orchestrator.
 
@@ -941,7 +941,7 @@ Return open tasks that are not ready, each with structured blocker reasons.
 
 **Arguments:** same filter surface as `lithos_task_ready` (no `with_claims`).
 
-**Returns:** `{ tasks: [{ ..., blockers: [{ kind, task_id, type, status, message }] }] }`. `kind` is one of `task` (predecessor still `open` — just waiting), `blocker_unsatisfiable` (predecessor `cancelled` — needs intervention), or `cycle` (the blocking chain forms a dependency cycle; `message` names the members). Gate blocker kinds arrive in Phase 3.
+**Returns:** `{ tasks: [{ ..., blockers: [{ kind, task_id, type, status, message }] }] }`. `kind` is one of `task` (predecessor still `open` — just waiting), `gate` (waiting on an unresolved gate — see Gates below), `blocker_unsatisfiable` (predecessor or gate `cancelled` — needs intervention), or `cycle` (the blocking chain forms a dependency cycle; `message` names the members).
 
 #### Hierarchy & Spawn (Phase 2)
 
@@ -976,6 +976,26 @@ Create a follow-on task linked to an existing source task.
 | `metadata` | object | No | Extra metadata; overrides inherited keys. Must not contain `depends_on`/`blocked_on`. |
 
 **Returns:** `{ task_id: string }`, or `{ status: "error", code, message }` (codes: `invalid_relation_type`, `task_not_found`, `invalid_metadata_key`). The spawned task is always `task_type='task'`.
+
+#### Gates (Phase 3)
+
+A **gate** is an external wait modelled as an ordinary task with `task_type='gate'`. It is created via `lithos_task_create` (no dedicated tool) and a task waits on it via a `waits_on_gate` edge (`gate -> task`). Gates are excluded from `lithos_task_ready`.
+
+**Gate metadata** (validated at creation; invalid → `invalid_input`):
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `gate_type` | Yes | One of `human`, `timer`, `ci`, `pr`, `external_task` |
+| `ready_at` | `timer` only | ISO datetime; the gate auto-resolves once `ready_at <= now`. Normalized to a canonical UTC, second-precision ISO string at creation (a naive value is read as UTC). |
+
+Other type-specific keys (`approval_required_from`, `provider`, `run_id`, `repo`, `pr_number`, `external_id`, `required_state`, …) are advisory — they tell the resolving agent what to check; Lithos does not read them.
+
+**Resolution model — Lithos never polls.** A `waits_on_gate` edge blocks its waiter until the gate is **resolved**:
+
+- the gate task is `completed` (an agent observed the condition and completed it), **or**
+- the gate is an `open` `timer` gate whose `ready_at` has passed (evaluated at query time; no state change).
+
+A **cancelled** gate is **unsatisfiable** — its waiter is excluded from `ready` and surfaced in `lithos_task_blocked` with `kind="blocker_unsatisfiable"` (the awaited condition will not be met). "Proceed anyway" is expressed by *completing* the gate or removing the edge, not by cancelling it. An open, not-yet-resolved gate surfaces as a `kind="gate"` blocker. This mirrors `blocks` (`completed` = satisfied, `cancelled` = unsatisfiable) plus the `timer` auto-resolve. Completing a gate reports its newly-ready waiters in the completion's `unblocked` list.
 
 #### `lithos_finding_post`
 Post a finding to a task.
@@ -1700,7 +1720,7 @@ These are explicitly not part of the initial implementation but may be considere
 | LCMA (Phase 7 MVP 1) | `lithos_retrieve`, `lithos_edge_upsert`, `lithos_edge_list`, `lithos_conflict_resolve`, `lithos_node_stats` |
 | HTTP | `GET /health`, `GET /events`, `GET /audit` (not MCP tools; see §5.7 and §8.7) |
 
-**Total: 35 MCP tools + 3 HTTP endpoints** (task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
+**Total: 35 MCP tools + 3 HTTP endpoints** (task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; Phase 3 added the `gate` task type and `waits_on_gate` edge with no new tools — gates are created via `lithos_task_create` and resolved via `lithos_task_complete`; `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -908,7 +908,7 @@ Create or update a typed relation between two tasks.
 | `agent` | string | Yes | Agent creating the edge |
 | `metadata` | object | No | Optional edge metadata (replaced on conflict) |
 
-**Returns:** `{ success: true }`, or `{ status: "error", code, message }` (codes: `invalid_edge_type`, `self_edge`, `task_not_found`, `cycle`). Cycles in blocking edges are rejected on write via a bounded traversal over the `task_edges` indexes (never a full-table walk).
+**Returns:** `{ success: true }`, or `{ status: "error", code, message }` (codes: `invalid_edge_type`, `self_edge`, `task_not_found`, `cycle`, `not_a_gate`). Cycles in blocking edges are rejected on write via a bounded traversal over the `task_edges` indexes (never a full-table walk). A `waits_on_gate` edge requires its `from_task` to be a `gate` task (else `not_a_gate`).
 
 #### `lithos_task_edge_list`
 List edges touching a task.
@@ -996,6 +996,8 @@ Other type-specific keys (`approval_required_from`, `provider`, `run_id`, `repo`
 - the gate is an `open` `timer` gate whose `ready_at` has passed (evaluated at query time; no state change).
 
 A **cancelled** gate is **unsatisfiable** — its waiter is excluded from `ready` and surfaced in `lithos_task_blocked` with `kind="blocker_unsatisfiable"` (the awaited condition will not be met). "Proceed anyway" is expressed by *completing* the gate or removing the edge, not by cancelling it. An open, not-yet-resolved gate surfaces as a `kind="gate"` blocker. This mirrors `blocks` (`completed` = satisfied, `cancelled` = unsatisfiable) plus the `timer` auto-resolve. Completing a gate reports its newly-ready waiters in the completion's `unblocked` list.
+
+Two invariants keep this sound: a `waits_on_gate` blocker must be a `gate` task (enforced on edge write — `not_a_gate`), and a gate's metadata is re-validated on `lithos_task_update` so it can't be mutated invalid. The readiness predicate is additionally NULL-safe, so an unknown/missing gate state defaults to *blocked*, never spuriously ready.
 
 #### `lithos_finding_post`
 Post a finding to a task.

--- a/docs/plans/task-graph-coordination-extension.md
+++ b/docs/plans/task-graph-coordination-extension.md
@@ -233,7 +233,8 @@ Validation:
 - both tasks must exist
 - `type` must be an edge type accepted in the current phase (§5.2); deferred types and not-yet-shipped types (e.g. `waits_on_gate` before Phase 3) are rejected
 - self-edges are rejected
-- cycles in blocking edges are rejected via a bounded traversal at write time
+- a `waits_on_gate` edge requires its `from_task` to be a `gate` task (else `not_a_gate`) — the readiness predicate keys on gate metadata, so the blocker must actually be a gate
+- cycles in the dependency graph (`blocks` + `waits_on_gate`) are rejected via a bounded traversal at write time
 
 ### `lithos_task_edge_list`
 

--- a/docs/plans/task-graph-coordination-extension.md
+++ b/docs/plans/task-graph-coordination-extension.md
@@ -161,7 +161,7 @@ Accepted from Phase 1:
 Accepted from Phase 3 (alongside gate readiness semantics):
 
 - `waits_on_gate`
-  Meaning: `to_task_id` is blocked by the gate task `from_task_id` (same direction as `blocks`: `from_task_id` is the blocker). `to_task_id` cannot be ready until the gate is resolved — i.e. the gate task is closed, or for `timer` gates, `ready_at <= now` at query time. Blocking.
+  Meaning: `to_task_id` is blocked by the gate task `from_task_id` (same direction as `blocks`: `from_task_id` is the blocker). `to_task_id` cannot be ready until the gate is resolved — i.e. the gate is `completed`, or for an `open` `timer` gate, `ready_at <= now` at query time. A **cancelled** gate is *unsatisfiable* (it never resolves; the waiter is surfaced as `blocker_unsatisfiable`), mirroring the cancelled-`blocks` rule (§8/§12.4) — "proceed anyway" is expressed by *completing* the gate, not cancelling it. Blocking.
 
 Deferred edge types (add only when something concretely consumes them, since each carries implied semantics and validation — e.g. terminal-state behavior for duplicates):
 
@@ -199,10 +199,11 @@ Why gates as tasks:
 
 **Lithos never polls external systems.** It is a passive MCP server; gates are resolved as follows:
 
-- `timer` gates are evaluated at query time: the gate is considered resolved when `ready_at <= now`. No state change is required.
-- All other gate types (`human`, `ci`, `pr`, `external_task`) are resolved by an agent (or a hook/script acting as one) completing the gate task via `lithos_task_complete` when it observes the external condition is met.
+- An `open` `timer` gate is evaluated at query time: resolved once `ready_at <= now`. No state change is required. `ready_at` is validated and normalized to a canonical UTC second-precision ISO string at creation so the ready and blocked queries compare it identically.
+- All gate types are resolved by an agent (or a hook/script acting as one) **completing** the gate task via `lithos_task_complete` when it observes the external condition is met.
+- **Cancelling** a gate means the awaited condition will *not* be met: the gate is unsatisfiable and its waiters become `blocker_unsatisfiable` (not readied). complete = condition met → release; cancel = condition won't be met → intervene.
 
-The gate metadata (`provider`, `run_id`, `pr_number`, etc.) exists so that the resolving agent knows what to check — it does not imply Lithos watches those systems. Anything that polls CI or PR state lives outside Lithos.
+`gate_type ∈ {human, timer, ci, pr, external_task}` is required at creation (strict validation). The other gate metadata (`provider`, `run_id`, `pr_number`, etc.) exists so the resolving agent knows what to check — it does not imply Lithos watches those systems. Anything that polls CI or PR state lives outside Lithos.
 
 ---
 
@@ -405,7 +406,7 @@ A task is ready when all of the following are true:
 1. `status == "open"`
 2. the task is a directly-workable unit — i.e. not a `gate` (and, once Phase 2 ships the `epic` type, not an `epic`: you execute an epic's children, not the epic itself). The readiness predicate uses a forward-compatible `task_type NOT IN ('gate', 'epic')` guard from Phase 1; the excluded types simply cannot be created yet until their phase lands.
 3. every incoming blocking edge is **satisfied** — for a `blocks` edge that means the predecessor is `completed` (a predecessor still `open`, or terminal-but-not-`completed` i.e. `cancelled`, leaves the edge unsatisfied; see the blocker-failure policy below)
-4. it is not blocked by an unresolved gate
+4. every incoming `waits_on_gate` edge is **satisfied** — the gate is `completed`, or an `open` `timer` gate whose `ready_at <= now`. A `cancelled` gate (cancelled wins over any timer) leaves the edge unsatisfied → `blocker_unsatisfiable`. (Conditions 3 and 4 are one SQL predicate — see the implementation; `blocks` and `waits_on_gate` are the unified dependency set.)
 
 Claims do **not** enter the readiness predicate: a claimed task is still ready. `lithos_task_ready` *attaches* active claims (when `with_claims`) but never excludes by them — see §6.1 for why (atomic-claim correctness + per-aspect claims).
 
@@ -519,15 +520,16 @@ Exit criteria:
 
 - agents can decompose and extend work without losing parent/child relationships
 
-## Phase 3: Gates
+## Phase 3: Gates (delivered)
 
-- add `gate` task type semantics
-- add `waits_on_gate` to the accepted edge types in `lithos_task_edge_upsert` (it is rejected before this phase)
-- add unresolved-gate support in readiness (`waits_on_gate` edges, query-time `timer` evaluation)
+- accept `gate` task type with strict metadata validation (`gate_type`; `timer` requires a normalized `ready_at`)
+- accept `waits_on_gate` in `lithos_task_edge_upsert` (rejected before this phase); cycle detection spans the unified `blocks`+`waits_on_gate` dependency graph
+- gate-aware readiness via a single `_unsatisfied_blocker_sql` predicate shared by ready/blocked/`_is_task_ready` (completion + query-time `timer`; cancelled = unsatisfiable); `newly_unblocked_by` widened to gate waiters
+- **no new MCP tools** — gates are created via `lithos_task_create(task_type='gate')` and resolved via `lithos_task_complete`
 
 Exit criteria:
 
-- waiting states are explicit, and agents can resolve gates by completing gate tasks
+- waiting states are explicit; agents resolve gates by completing them (or `timer` gates auto-resolve at query time)
 
 ## Phase 4: Scheduling Refinements (all optional, motivated by observed need)
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -24,21 +24,33 @@ logger = logging.getLogger(__name__)
 # implemented. Phase 1 ships blocks/parent_child/discovered_from. Phase 3 adds
 # ``waits_on_gate``. Deferred types (caused_by, validates, relates_to,
 # duplicate_of, superseded_by) are added only when something consumes them.
-ACCEPTED_EDGE_TYPES: frozenset[str] = frozenset({"blocks", "parent_child", "discovered_from"})
+ACCEPTED_EDGE_TYPES: frozenset[str] = frozenset(
+    {"blocks", "parent_child", "discovered_from", "waits_on_gate"}
+)
 
-# Edge types that gate readiness. A task is not ready while it has an incoming
-# blocking edge whose predecessor is not ``completed``. Gains ``waits_on_gate``
-# in Phase 3.
+# Edge types resolved by predecessor ``completed`` status. A task is not ready
+# while it has an incoming ``blocks`` edge whose predecessor is not ``completed``.
 BLOCKING_EDGE_TYPES: frozenset[str] = frozenset({"blocks"})
+
+# Gate edges. A ``waits_on_gate`` edge blocks the dependent until the gate task
+# (the ``from`` end) is resolved — see _unsatisfied_blocker_sql for the rule.
+GATE_EDGE_TYPES: frozenset[str] = frozenset({"waits_on_gate"})
+
+# The full "X waits on Y" dependency graph (blocks + gates). Readiness and cycle
+# detection operate over this combined set so mixed cycles are rejected.
+DEPENDENCY_EDGE_TYPES: frozenset[str] = BLOCKING_EDGE_TYPES | GATE_EDGE_TYPES
 
 # Hierarchy edges. Purely structural (never block readiness), but must stay
 # acyclic — a task cannot be its own ancestor — so cycles are rejected on write.
 HIERARCHY_EDGE_TYPES: frozenset[str] = frozenset({"parent_child"})
 
 # Task types accepted on write this phase (see ACCEPTED_EDGE_TYPES rationale).
-# ``gate`` is accepted from Phase 3. The column itself defaults to 'task' and
-# physically holds any string; only the write-validation set is phase-gated.
-ACCEPTED_TASK_TYPES: frozenset[str] = frozenset({"task", "epic"})
+# The column defaults to 'task' and physically holds any string; only the
+# write-validation set is phase-gated.
+ACCEPTED_TASK_TYPES: frozenset[str] = frozenset({"task", "epic", "gate"})
+
+# Valid ``gate_type`` values for a ``task_type='gate'`` task.
+GATE_TYPES: frozenset[str] = frozenset({"human", "timer", "ci", "pr", "external_task"})
 
 # Task types that are never directly workable units and so are excluded from the
 # ready frontier. ``epic`` is a roll-up container (you execute its children, not
@@ -87,6 +99,37 @@ def _reject_scheduling_metadata(metadata: dict[str, Any] | None) -> None:
             "first-class task edges. Use depends_on on lithos_task_create, or "
             "lithos_task_edge_upsert.",
         )
+
+
+def _validate_gate_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """Validate + normalize the metadata of a ``task_type='gate'`` task.
+
+    Requires a valid ``gate_type``; ``timer`` gates require a parseable
+    ``ready_at``, which is rewritten to a canonical UTC second-precision ISO
+    string (a naive value is interpreted as UTC) so the ready/blocked timer
+    comparison is one consistent lexicographic check. Returns a new metadata dict
+    (the input is not mutated). Raises CoordinationError(invalid_input) on any
+    violation.
+    """
+    md = dict(metadata or {})
+    gate_type = md.get("gate_type")
+    if gate_type not in GATE_TYPES:
+        raise CoordinationError(
+            "invalid_input",
+            f"a gate task requires metadata.gate_type in {sorted(GATE_TYPES)}, got {gate_type!r}.",
+        )
+    if gate_type == "timer":
+        raw = md.get("ready_at")
+        parsed = _parse_datetime(raw) if raw is not None else None
+        if parsed is None:
+            raise CoordinationError(
+                "invalid_input",
+                f"a 'timer' gate requires a parseable metadata.ready_at (ISO datetime), got {raw!r}.",
+            )
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        md["ready_at"] = parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+    return md
 
 
 # SQL Schema
@@ -873,7 +916,10 @@ class CoordinationService:
             tags: Task tags
             metadata: Arbitrary JSON metadata dict (optional). Must not contain
                 ``depends_on``/``blocked_on`` — dependencies are task edges now.
-            task_type: First-class task type (``task`` or ``epic``).
+            task_type: First-class task type (``task``, ``epic`` or ``gate``). A
+                ``gate`` requires ``metadata.gate_type`` (human/timer/ci/pr/
+                external_task); a ``timer`` gate also requires a parseable
+                ``metadata.ready_at``.
             depends_on: Predecessor task ids. Each creates a ``blocks`` edge
                 ``predecessor -> this task``. Predecessors must already exist.
             parent_task_id: Optional parent. Creates a ``parent_child`` edge
@@ -884,8 +930,9 @@ class CoordinationService:
             Task ID
 
         Raises:
-            CoordinationError: invalid task_type, forbidden metadata key, or a
-                ``depends_on``/``parent_task_id`` reference to a nonexistent task.
+            CoordinationError: invalid task_type, forbidden metadata key, invalid
+                gate metadata, or a ``depends_on``/``parent_task_id`` reference to
+                a nonexistent task.
         """
         import json
 
@@ -896,6 +943,8 @@ class CoordinationService:
                 f"task_type '{task_type}' is not accepted in this phase "
                 f"(accepted: {sorted(ACCEPTED_TASK_TYPES)}).",
             )
+        if task_type == "gate":
+            metadata = _validate_gate_metadata(metadata)
 
         lithos_metrics.coordination_ops.add(1, {"op": "create_task"})
         await self.ensure_agent_known(agent)
@@ -1798,16 +1847,18 @@ class CoordinationService:
                     "task_not_found", f"edge references nonexistent task(s): {missing}"
                 )
 
-            if edge_type in BLOCKING_EDGE_TYPES:
+            if edge_type in DEPENDENCY_EDGE_TYPES:
                 # Adding from->to means "to depends on from"; reject if from
                 # already depends on to (reverse = up the depends-on chain).
+                # Traverses the whole dependency graph (blocks + waits_on_gate) so
+                # mixed cycles are caught.
                 cycle = await self._find_edge_path(
-                    db, from_task_id, to_task_id, BLOCKING_EDGE_TYPES, reverse=True
+                    db, from_task_id, to_task_id, DEPENDENCY_EDGE_TYPES, reverse=True
                 )
                 if cycle is not None:
                     raise CoordinationError(
                         "cycle",
-                        "blocking edge "
+                        f"{edge_type} edge "
                         f"{from_task_id} -> {to_task_id} would create a dependency cycle: "
                         f"{' -> '.join(cycle)} -> {from_task_id}",
                     )
@@ -1963,21 +2014,49 @@ class CoordinationService:
                 stack.append(neighbour)
         return None
 
+    @staticmethod
+    def _now_iso() -> str:
+        """Canonical UTC second-precision ISO 'now' — matches the normalized
+        ``ready_at`` stored on timer gates, so the comparison is exact."""
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    @staticmethod
+    def _unsatisfied_blocker_sql(now: str) -> tuple[str, list[Any]]:
+        """SQL fragment + params for "incoming edge ``e`` (predecessor ``p``) is
+        an unsatisfied blocker", the single source of truth for readiness.
+
+        A ``blocks`` edge is unsatisfied while its predecessor is not ``completed``.
+        A ``waits_on_gate`` edge is unsatisfied while the gate is not resolved —
+        resolved means the gate is ``completed``, or it is an ``open`` ``timer``
+        gate whose ``ready_at <= now``. A ``cancelled`` gate is therefore
+        unsatisfied (cancelled wins over a timer), surfaced as ``blocker_unsatisfiable``.
+        """
+        blocking = tuple(BLOCKING_EDGE_TYPES)
+        gate = tuple(GATE_EDGE_TYPES)
+        bph = ",".join("?" for _ in blocking)
+        gph = ",".join("?" for _ in gate)
+        fragment = (
+            f"( (e.type IN ({bph}) AND p.status != 'completed')"
+            f" OR (e.type IN ({gph}) AND p.status != 'completed'"
+            "      AND NOT (p.status = 'open'"
+            "               AND json_extract(p.metadata, '$.gate_type') = 'timer'"
+            "               AND json_extract(p.metadata, '$.ready_at') <= ?)) )"
+        )
+        return fragment, [*blocking, *gate, now]
+
     async def _is_task_ready(self, db: aiosqlite.Connection, task_id: str) -> bool:
         """Whether a single task currently satisfies the readiness predicate."""
-        blocking = tuple(BLOCKING_EDGE_TYPES)
-        placeholders = ",".join("?" for _ in blocking)
         non_workable = ",".join("?" for _ in NON_WORKABLE_TASK_TYPES)
+        frag, fparams = self._unsatisfied_blocker_sql(self._now_iso())
         cursor = await db.execute(
             f"""
             SELECT 1 FROM tasks t
             WHERE t.id = ? AND t.status = 'open' AND t.task_type NOT IN ({non_workable})
               AND NOT EXISTS (
                 SELECT 1 FROM task_edges e JOIN tasks p ON p.id = e.from_task_id
-                WHERE e.to_task_id = t.id AND e.type IN ({placeholders})
-                  AND p.status != 'completed')
+                WHERE e.to_task_id = t.id AND {frag})
             """,
-            (task_id, *NON_WORKABLE_TASK_TYPES, *blocking),
+            (task_id, *NON_WORKABLE_TASK_TYPES, *fparams),
         )
         return await cursor.fetchone() is not None
 
@@ -2066,19 +2145,18 @@ class CoordinationService:
             effective_match["project"] = project
         md_clause, md_params = _metadata_match_clause(effective_match or None, column="t.metadata")
 
-        blocking = tuple(BLOCKING_EDGE_TYPES)
-        bph = ",".join("?" for _ in blocking)
         non_workable = ",".join("?" for _ in NON_WORKABLE_TASK_TYPES)
+        frag, fparams = self._unsatisfied_blocker_sql(self._now_iso())
         exists_kw = "NOT EXISTS" if ready else "EXISTS"
         query = (
             "SELECT t.* FROM tasks t "
             f"WHERE t.status = 'open' AND t.task_type NOT IN ({non_workable}) "
             f"AND {exists_kw} ("
             "  SELECT 1 FROM task_edges e JOIN tasks p ON p.id = e.from_task_id"
-            f"  WHERE e.to_task_id = t.id AND e.type IN ({bph}) AND p.status != 'completed')"
+            f"  WHERE e.to_task_id = t.id AND {frag})"
             f"{md_clause} ORDER BY t.created_at DESC"
         )
-        params = [*NON_WORKABLE_TASK_TYPES, *blocking, *md_params]
+        params = [*NON_WORKABLE_TASK_TYPES, *fparams, *md_params]
         if sql_limit is not None:
             query += " LIMIT ?"
             params.append(sql_limit)
@@ -2117,22 +2195,27 @@ class CoordinationService:
         db: aiosqlite.Connection,
         task_id: str,
     ) -> list[dict[str, Any]]:
-        """Explain why ``task_id`` is blocked: one entry per unsatisfied predecessor."""
-        blocking = tuple(BLOCKING_EDGE_TYPES)
-        placeholders = ",".join("?" for _ in blocking)
+        """Explain why ``task_id`` is blocked: one entry per unsatisfied predecessor.
+
+        Uses the same ``_unsatisfied_blocker_sql`` predicate as readiness (one
+        source of truth), so only genuinely-unsatisfied edges are returned and a
+        timer-resolved gate never appears here. Each row is then classified.
+        """
+        frag, fparams = self._unsatisfied_blocker_sql(self._now_iso())
         cursor = await db.execute(
             f"""
-            SELECT e.from_task_id, e.type, p.status
+            SELECT e.from_task_id, e.type, p.status, p.metadata
             FROM task_edges e JOIN tasks p ON p.id = e.from_task_id
-            WHERE e.to_task_id = ? AND e.type IN ({placeholders})
+            WHERE e.to_task_id = ? AND {frag}
             """,
-            (task_id, *blocking),
+            (task_id, *fparams),
         )
         blockers: list[dict[str, Any]] = []
-        for pred_id, edge_type, pred_status in await cursor.fetchall():
-            if pred_status == "completed":
-                continue
+        for pred_id, edge_type, pred_status, pred_metadata in await cursor.fetchall():
+            is_gate = edge_type in GATE_EDGE_TYPES
             if pred_status == "cancelled":
+                noun = "Gate" if is_gate else "Blocking predecessor"
+                what = "gate" if is_gate else "predecessor"
                 blockers.append(
                     {
                         "kind": "blocker_unsatisfiable",
@@ -2140,14 +2223,28 @@ class CoordinationService:
                         "type": edge_type,
                         "status": "cancelled",
                         "message": (
-                            f"Blocking predecessor {pred_id} was cancelled; this task can "
-                            "never become ready without intervention (re-open or re-route "
-                            "the predecessor, or cancel this subtree)."
+                            f"{noun} {pred_id} was cancelled; this task can never become ready "
+                            f"without intervention (complete/re-open the {what}, re-route, or "
+                            "cancel this subtree)."
                         ),
                     }
                 )
                 continue
-            # predecessor is open: distinguish a genuine wait from a dependency cycle
+            if is_gate:
+                md = _decode_metadata(pred_metadata)
+                gate_type = md.get("gate_type")
+                detail = f" (ready_at={md.get('ready_at')})" if gate_type == "timer" else ""
+                blockers.append(
+                    {
+                        "kind": "gate",
+                        "task_id": pred_id,
+                        "type": edge_type,
+                        "status": pred_status,
+                        "message": f"Waiting on {gate_type} gate {pred_id}{detail}.",
+                    }
+                )
+                continue
+            # blocks edge, predecessor open: distinguish a genuine wait from a cycle
             cycle = await self._find_edge_path(
                 db, pred_id, task_id, BLOCKING_EDGE_TYPES, reverse=True
             )
@@ -2178,17 +2275,17 @@ class CoordinationService:
         """Return ids of tasks that ``task_id`` blocked and that are now ready.
 
         Called by the MCP layer right after a successful completion. Each
-        candidate is a ``blocks`` dependent of ``task_id``; it is reported only if
-        it now satisfies the readiness predicate (this completion may have cleared
-        its last blocker).
+        candidate is a ``blocks`` dependent or ``waits_on_gate`` waiter of
+        ``task_id`` (so completing a gate surfaces its now-ready waiters); it is
+        reported only if it now satisfies the readiness predicate.
         """
-        blocking = tuple(BLOCKING_EDGE_TYPES)
-        placeholders = ",".join("?" for _ in blocking)
+        dependency = tuple(DEPENDENCY_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in dependency)
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
                 f"SELECT DISTINCT to_task_id FROM task_edges "
                 f"WHERE from_task_id = ? AND type IN ({placeholders})",
-                (task_id, *blocking),
+                (task_id, *dependency),
             )
             candidates = [row[0] for row in await cursor.fetchall()]
             return [c for c in candidates if await self._is_task_ready(db, c)]

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1181,7 +1181,7 @@ class CoordinationService:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await db.execute(
-                    "SELECT metadata FROM tasks WHERE id = ? AND status = 'open'",
+                    "SELECT task_type, metadata FROM tasks WHERE id = ? AND status = 'open'",
                     (task_id,),
                 )
                 row = await cursor.fetchone()
@@ -1189,8 +1189,13 @@ class CoordinationService:
                     await db.execute("ROLLBACK")
                     return False
 
-                existing = _decode_metadata(row[0])
+                existing = _decode_metadata(row[1])
                 merged = merge_metadata(existing, metadata_patch)
+                # A gate's metadata must stay valid: revalidate (and re-normalize a
+                # timer ready_at) so a patch like {"gate_type": None} can't strip
+                # the gate invariants and spuriously ready its waiters.
+                if row[0] == "gate":
+                    merged = _validate_gate_metadata(merged)
                 merged_json = json.dumps(merged)
 
                 sets = [*non_metadata_sets, "metadata = ?"]
@@ -1837,14 +1842,24 @@ class CoordinationService:
 
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "SELECT id FROM tasks WHERE id IN (?, ?)",
+                "SELECT id, task_type FROM tasks WHERE id IN (?, ?)",
                 (from_task_id, to_task_id),
             )
-            found = {row[0] for row in await cursor.fetchall()}
-            missing = [t for t in (from_task_id, to_task_id) if t not in found]
+            type_by_id = {row[0]: row[1] for row in await cursor.fetchall()}
+            missing = [t for t in (from_task_id, to_task_id) if t not in type_by_id]
             if missing:
                 raise CoordinationError(
                     "task_not_found", f"edge references nonexistent task(s): {missing}"
+                )
+
+            if edge_type in GATE_EDGE_TYPES and type_by_id.get(from_task_id) != "gate":
+                # A waits_on_gate blocker must be a gate task — otherwise the
+                # readiness predicate (which keys on gate metadata) cannot reason
+                # about it and the waiter would never be released correctly.
+                raise CoordinationError(
+                    "not_a_gate",
+                    f"a {edge_type} edge requires the from_task ({from_task_id}) to be a "
+                    f"'gate' task, got task_type={type_by_id.get(from_task_id)!r}.",
                 )
 
             if edge_type in DEPENDENCY_EDGE_TYPES:
@@ -2030,6 +2045,13 @@ class CoordinationService:
         resolved means the gate is ``completed``, or it is an ``open`` ``timer``
         gate whose ``ready_at <= now``. A ``cancelled`` gate is therefore
         unsatisfied (cancelled wins over a timer), surfaced as ``blocker_unsatisfiable``.
+
+        The timer auto-resolve is wrapped in ``COALESCE(..., 0)`` so that a
+        predecessor with absent/invalid gate metadata (NULL ``json_extract``)
+        defaults to **0 = not auto-resolved**, i.e. the dependent stays blocked
+        rather than falling through as ready on SQLite NULL semantics. Combined
+        with the write-time rule that a ``waits_on_gate`` blocker must be a gate,
+        an unknown gate state never spuriously readies its waiter.
         """
         blocking = tuple(BLOCKING_EDGE_TYPES)
         gate = tuple(GATE_EDGE_TYPES)
@@ -2038,9 +2060,9 @@ class CoordinationService:
         fragment = (
             f"( (e.type IN ({bph}) AND p.status != 'completed')"
             f" OR (e.type IN ({gph}) AND p.status != 'completed'"
-            "      AND NOT (p.status = 'open'"
+            "      AND NOT COALESCE((p.status = 'open'"
             "               AND json_extract(p.metadata, '$.gate_type') = 'timer'"
-            "               AND json_extract(p.metadata, '$.ready_at') <= ?)) )"
+            "               AND json_extract(p.metadata, '$.ready_at') <= ?), 0)) )"
         )
         return fragment, [*blocking, *gate, now]
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -2522,8 +2522,13 @@ class LithosServer:
                 metadata: Arbitrary JSON metadata dict (optional). Must NOT contain
                     ``depends_on``/``blocked_on`` — dependencies are first-class task
                     edges now; pass ``depends_on`` instead.
-                task_type: First-class task type: ``task`` or ``epic`` (``gate``
-                    arrives in a later phase).
+                task_type: First-class task type: ``task``, ``epic``, or ``gate``.
+                    A ``gate`` is an external wait and requires
+                    ``metadata.gate_type`` in human/timer/ci/pr/external_task; a
+                    ``timer`` gate also requires a parseable ``metadata.ready_at``
+                    (ISO datetime). Link a task to a gate with a ``waits_on_gate``
+                    edge; resolve a gate by completing it (``timer`` gates resolve
+                    on their own once ``ready_at`` passes).
                 depends_on: Predecessor task IDs. Each creates a ``blocks`` edge so
                     this task is not ready until that predecessor is completed.
                     Predecessors must already exist.
@@ -3070,8 +3075,12 @@ class LithosServer:
 
             Edge types accepted in this phase: ``blocks`` (to_task is not ready
             until from_task is completed), ``parent_child`` (from_task is the
-            parent; purely structural, never blocks), and ``discovered_from``
-            (to_task was discovered while executing from_task; non-blocking).
+            parent; purely structural, never blocks), ``discovered_from`` (to_task
+            was discovered while executing from_task; non-blocking), and
+            ``waits_on_gate`` (to_task is not ready until the gate from_task is
+            resolved — the gate is completed, or a ``timer`` gate whose
+            ``ready_at`` has passed; a cancelled gate makes the waiter
+            unsatisfiable).
 
             Args:
                 from_task_id: Source task (blocker / parent / source).
@@ -3221,7 +3230,8 @@ class LithosServer:
             Same filter surface as ``lithos_task_ready``. Each returned task carries
             a ``blockers`` list; each blocker has ``kind``:
             ``task`` (predecessor still open — just waiting),
-            ``blocker_unsatisfiable`` (predecessor was cancelled — needs
+            ``gate`` (waiting on an unresolved gate),
+            ``blocker_unsatisfiable`` (predecessor or gate was cancelled — needs
             intervention), or ``cycle`` (the dependency chain forms a cycle).
 
             Args:

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -691,6 +691,63 @@ class TestGates:
             await coordination_service.upsert_task_edge(g, a, "waits_on_gate", "a")
         assert exc.value.code == "cycle"
 
+    async def test_waits_on_gate_requires_a_gate_blocker(
+        self, coordination_service: CoordinationService
+    ):
+        # The blocker (from) of a waits_on_gate edge must be a gate task, else the
+        # readiness predicate can't reason about it and the waiter would leak ready.
+        plain = await _mk(coordination_service, "Plain")
+        waiter = await _mk(coordination_service, "Waiter")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(plain, waiter, "waits_on_gate", "a")
+        assert exc.value.code == "not_a_gate"
+
+    async def test_update_cannot_strip_gate_invariants(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "human")
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+        assert task not in _ids(await coordination_service.list_ready())
+
+        # deleting gate_type via update is rejected; the waiter stays blocked
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.update_task(gate, "a", metadata={"gate_type": None})
+        assert exc.value.code == "invalid_input"
+        assert task not in _ids(await coordination_service.list_ready())
+
+        # a valid gate metadata update still works (and normalizes a timer ready_at)
+        timer = await _gate(coordination_service, "timer", ready_at=FUTURE)
+        ok = await coordination_service.update_task(
+            timer, "a", metadata={"ready_at": "2031-01-01T00:00:00Z"}
+        )
+        assert ok is True
+        row = await coordination_service.get_task(timer)
+        assert row is not None
+        assert row.metadata["ready_at"] == "2031-01-01T00:00:00+00:00"
+
+    async def test_corrupted_gate_metadata_defaults_to_blocked(
+        self, coordination_service: CoordinationService
+    ):
+        # Defense in depth: even if a gate ends up with no gate_type (e.g. a
+        # legacy/hand-edited row), the NULL-safe predicate keeps the waiter
+        # BLOCKED rather than letting it fall through as ready.
+        waiter = await _mk(coordination_service, "Waiter")
+        async with aiosqlite.connect(coordination_service.db_path) as db:
+            await db.execute(
+                "INSERT INTO tasks (id, title, status, task_type, created_by, metadata) "
+                "VALUES ('corrupt-gate', 'Corrupt', 'open', 'gate', 'a', '{}')",
+            )
+            await db.execute(
+                "INSERT INTO task_edges (from_task_id, to_task_id, type, created_by) "
+                "VALUES ('corrupt-gate', ?, 'waits_on_gate', 'a')",
+                (waiter,),
+            )
+            await db.commit()
+        assert waiter not in _ids(await coordination_service.list_ready())
+        b_row = next(t for t in await coordination_service.list_blocked() if t["id"] == waiter)
+        assert b_row["blockers"][0]["kind"] == "gate"
+
 
 # ==================== Backfill + migration ====================
 

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -86,7 +86,7 @@ class TestTaskEdges:
             await coordination_service.upsert_task_edge(a, "ghost", "blocks", "a")
         assert exc.value.code == "task_not_found"
 
-    @pytest.mark.parametrize("bad_type", ["waits_on_gate", "duplicate_of", "relates_to", "nope"])
+    @pytest.mark.parametrize("bad_type", ["duplicate_of", "relates_to", "superseded_by", "nope"])
     async def test_unaccepted_edge_types_rejected(
         self, coordination_service: CoordinationService, bad_type: str
     ):
@@ -296,8 +296,8 @@ class TestCreateConvenience:
         assert exc.value.code == "task_not_found"
 
     async def test_invalid_task_type_rejected(self, coordination_service: CoordinationService):
-        # 'gate' is Phase 3; 'subtask' was dropped entirely. ('epic' is accepted in Phase 2.)
-        for bad in ("gate", "subtask"):
+        # task/epic/gate are accepted; 'subtask' was dropped, others are nonsense.
+        for bad in ("subtask", "nonsense"):
             with pytest.raises(CoordinationError) as exc:
                 await coordination_service.create_task(title="T", agent="a", task_type=bad)
             assert exc.value.code == "invalid_task_type"
@@ -387,11 +387,6 @@ class TestEpicAndHierarchy:
         # but it is a real task, filterable by type
         epics = await coordination_service.list_tasks(task_type="epic")
         assert [t["id"] for t in epics] == [epic]
-
-    async def test_gate_type_still_rejected(self, coordination_service: CoordinationService):
-        with pytest.raises(CoordinationError) as exc:
-            await coordination_service.create_task(title="G", agent="a", task_type="gate")
-        assert exc.value.code == "invalid_task_type"
 
     async def test_parent_task_id_creates_parent_child_edge(
         self, coordination_service: CoordinationService
@@ -558,6 +553,145 @@ class TestSpawn:
         assert exc.value.code == "invalid_metadata_key"
 
 
+# ==================== Gates (Phase 3) ====================
+
+PAST = "2000-01-01T00:00:00+00:00"
+FUTURE = "2999-01-01T00:00:00+00:00"
+
+
+async def _gate(service: CoordinationService, gate_type: str, **md: Any) -> str:
+    """Create a gate task of the given gate_type and return its id."""
+    return await service.create_task(
+        title=f"{gate_type} gate",
+        agent="a",
+        task_type="gate",
+        metadata={"gate_type": gate_type, **md},
+    )
+
+
+class TestGates:
+    async def test_gate_accepted_and_excluded_from_ready(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "human")
+        task = await _mk(coordination_service, "Task")
+        ready_ids = _ids(await coordination_service.list_ready())
+        assert task in ready_ids
+        assert gate not in ready_ids  # a gate is not directly workable
+
+    async def test_gate_validation(self, coordination_service: CoordinationService):
+        # missing gate_type
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(title="G", agent="a", task_type="gate")
+        assert exc.value.code == "invalid_input"
+        # invalid gate_type
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(
+                title="G", agent="a", task_type="gate", metadata={"gate_type": "bogus"}
+            )
+        assert exc.value.code == "invalid_input"
+        # timer without ready_at
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(
+                title="G", agent="a", task_type="gate", metadata={"gate_type": "timer"}
+            )
+        assert exc.value.code == "invalid_input"
+        # timer with unparseable ready_at
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.create_task(
+                title="G",
+                agent="a",
+                task_type="gate",
+                metadata={"gate_type": "timer", "ready_at": "not-a-date"},
+            )
+        assert exc.value.code == "invalid_input"
+
+    async def test_timer_ready_at_normalized_to_utc(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "timer", ready_at="2030-06-01T12:00:00+02:00")
+        row = await coordination_service.get_task(gate)
+        assert row is not None
+        # +02:00 12:00 -> 10:00Z, second-precision, canonical UTC offset
+        assert row.metadata["ready_at"] == "2030-06-01T10:00:00+00:00"
+
+    async def test_waits_on_gate_blocks_until_completed(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "human")
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+
+        assert task not in _ids(await coordination_service.list_ready())
+        blocked = await coordination_service.list_blocked()
+        b_row = next(t for t in blocked if t["id"] == task)
+        assert b_row["blockers"][0]["kind"] == "gate"
+        assert b_row["blockers"][0]["task_id"] == gate
+
+        # resolving the gate (completion) readies the waiter and surfaces it
+        unblocked = await coordination_service.newly_unblocked_by(gate)
+        assert unblocked == []  # not yet completed
+        await coordination_service.complete_task(gate, "a")
+        assert task in _ids(await coordination_service.list_ready())
+        assert await coordination_service.newly_unblocked_by(gate) == [task]
+
+    async def test_cancelled_gate_is_unsatisfiable(self, coordination_service: CoordinationService):
+        gate = await _gate(coordination_service, "ci", provider="gha", run_id="1")
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+        await coordination_service.cancel_task(gate, "a")
+
+        assert task not in _ids(await coordination_service.list_ready())
+        blocked = await coordination_service.list_blocked()
+        b_row = next(t for t in blocked if t["id"] == task)
+        assert b_row["blockers"][0]["kind"] == "blocker_unsatisfiable"
+        assert b_row["blockers"][0]["status"] == "cancelled"
+
+    async def test_timer_gate_past_ready_at_auto_resolves(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "timer", ready_at=PAST)
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+        # past ready_at -> resolved at query time, no completion needed
+        assert task in _ids(await coordination_service.list_ready())
+        assert task not in _ids(await coordination_service.list_blocked())
+
+    async def test_timer_gate_future_ready_at_blocks(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "timer", ready_at=FUTURE)
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+        assert task not in _ids(await coordination_service.list_ready())
+        b_row = next(t for t in await coordination_service.list_blocked() if t["id"] == task)
+        assert b_row["blockers"][0]["kind"] == "gate"
+
+    async def test_cancelled_timer_past_ready_at_still_unsatisfiable(
+        self, coordination_service: CoordinationService
+    ):
+        # cancelled wins over the timer: a cancelled timer gate past ready_at does
+        # NOT resolve its waiter.
+        gate = await _gate(coordination_service, "timer", ready_at=PAST)
+        task = await _mk(coordination_service, "Task")
+        await coordination_service.upsert_task_edge(gate, task, "waits_on_gate", "a")
+        await coordination_service.cancel_task(gate, "a")
+        assert task not in _ids(await coordination_service.list_ready())
+        b_row = next(t for t in await coordination_service.list_blocked() if t["id"] == task)
+        assert b_row["blockers"][0]["kind"] == "blocker_unsatisfiable"
+
+    async def test_mixed_blocks_gate_cycle_rejected(
+        self, coordination_service: CoordinationService
+    ):
+        # A blocks G, G waits_on_gate A  ->  A depends on G and G depends on A.
+        a = await _mk(coordination_service, "A")
+        g = await _gate(coordination_service, "human")
+        await coordination_service.upsert_task_edge(a, g, "blocks", "a")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.upsert_task_edge(g, a, "waits_on_gate", "a")
+        assert exc.value.code == "cycle"
+
+
 # ==================== Backfill + migration ====================
 
 
@@ -693,8 +827,8 @@ class TestServerTaskGraphTools:
         assert res["unblocked"] == [b]
 
     async def test_create_bad_task_type_error_envelope(self, server: LithosServer):
-        # 'gate' is not accepted until Phase 3 ('epic' is now accepted in Phase 2)
-        res = await _call(server, "lithos_task_create", title="T", agent="a", task_type="gate")
+        # task/epic/gate are accepted; 'subtask' was dropped entirely
+        res = await _call(server, "lithos_task_create", title="T", agent="a", task_type="subtask")
         assert res["status"] == "error"
         assert res["code"] == "invalid_task_type"
 
@@ -740,3 +874,35 @@ class TestServerTaskGraphTools:
         )
         assert bad["status"] == "error"
         assert bad["code"] == "invalid_relation_type"
+
+    async def test_gate_create_validation_and_blocked_kind(self, server: LithosServer):
+        # invalid gate (no gate_type) -> error envelope
+        bad = await _call(server, "lithos_task_create", title="G", agent="a", task_type="gate")
+        assert bad["status"] == "error"
+        assert bad["code"] == "invalid_input"
+
+        # valid gate + waits_on_gate edge -> waiter shows up blocked with kind 'gate'
+        gate = await _call(
+            server,
+            "lithos_task_create",
+            title="Approval",
+            agent="a",
+            task_type="gate",
+            metadata={"gate_type": "human"},
+        )
+        gate_id = gate["task_id"]
+        task = await server.coordination.create_task(title="Task", agent="a")
+        await _call(
+            server,
+            "lithos_task_edge_upsert",
+            from_task_id=gate_id,
+            to_task_id=task,
+            type="waits_on_gate",
+            agent="a",
+        )
+        blocked = await _call(server, "lithos_task_blocked")
+        b_row = next(t for t in blocked["tasks"] if t["id"] == task)
+        assert b_row["blockers"][0]["kind"] == "gate"
+        # completing the gate reports the waiter as unblocked
+        done = await _call(server, "lithos_task_complete", task_id=gate_id, agent="a")
+        assert done["unblocked"] == [task]


### PR DESCRIPTION
## Context

Phase 3 of `docs/plans/task-graph-coordination-extension.md`, building on Phases 1–2 (#342/#343). Makes **external waits explicit**: a task can wait on a `gate` (human approval, a timer, CI, a PR, an external task) instead of that being represented as prose. Lithos stays **passive** — it never polls; gates are resolved by an agent *completing* the gate task, except `timer` gates which auto-resolve at query time once `ready_at <= now`. **No new MCP tools** — gates are `lithos_task_create(task_type='gate')` and resolved via `lithos_task_complete`.

## Two decisions (agreed before coding)

1. **Cancelled gate → `blocker_unsatisfiable`**, uniform with the cancelled-`blocks` rule (§12.4). The model that dissolves the ambiguity: **complete = condition met → release waiters; cancel = condition won't be met → intervene**. "Proceed anyway" is expressed by *completing* the gate (or removing the edge), not by cancelling it.
2. **Strict gate validation:** require `gate_type ∈ {human, timer, ci, pr, external_task}`; a `timer` gate requires a parseable `ready_at`, **normalized to canonical UTC second-precision ISO at creation** so the ready and blocked queries compare the timer identically (naive → UTC).

## Gate resolution (the core rule)

A `waits_on_gate` edge `gate → task` blocks `task` until the gate is **satisfied**: `gate.status == 'completed'`, **or** an `open` `timer` gate whose `ready_at <= now`. A **cancelled** gate is **unsatisfiable** (cancelled wins over a timer). Mirrors `blocks` (`completed` = satisfied, `cancelled` = unsatisfiable) plus the timer auto-resolve — kept as **one SQL predicate** (`_unsatisfied_blocker_sql`) shared by `ready` / `blocked` / `_is_task_ready`, so they can never disagree.

## What's in this PR

**Service (`coordination.py`)**
- accept `gate` + `waits_on_gate`; add `GATE_EDGE_TYPES` / `DEPENDENCY_EDGE_TYPES` / `GATE_TYPES`
- `_validate_gate_metadata` (strict `gate_type` + `timer` `ready_at` normalization)
- `_unsatisfied_blocker_sql(now)` — single source of truth for "is this incoming edge an unsatisfied blocker"
- `_compute_blockers` classifies gate waits: cancelled → `blocker_unsatisfiable`, open → `kind='gate'`
- cycle detection spans `DEPENDENCY_EDGE_TYPES` (mixed `blocks`+`waits_on_gate` cycles rejected)
- `newly_unblocked_by` widened to gate waiters (completing a gate surfaces them in `complete`'s `unblocked`)

**MCP (`server.py`)** — doc-only: `task_type` now `task`/`epic`/`gate` with the gate metadata schema; `waits_on_gate` on edge upsert; `gate` blocker kind on `lithos_task_blocked`. Stays 35 tools.

**Docs** — `SPECIFICATION.md` §5.4 "Gates (Phase 3)" + Appendix B; proposal §5.2/§5.3/§8/§11.

## Test plan

- [x] `make check` (lint + format + typecheck + unit) — 1446 passed
- [x] `make test-integration` — 385 passed
- New `tests/test_task_graph.py` cases: gate accept + ready-exclusion; strict validation (missing/invalid `gate_type`, `timer` without/with-unparseable `ready_at`, UTC normalization); `waits_on_gate` blocking + completion + newly-unblocked; **cancelled gate unsatisfiable** (incl. a cancelled `timer` past `ready_at` — cancelled wins); `timer` past → auto-resolves / future → blocks; mixed `blocks`+`waits_on_gate` cycle rejected; server-level gate envelopes + `gate` blocker kind
- Updated Phase 1/2 tests that asserted `gate` was rejected (now accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)