### PR TITLE
feat: complete the task lifecycle — lithos_task_reopen (#243) + terminal task_update (#303)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -775,7 +775,7 @@ Update mutable task fields.
 **Behavior:**
 - At least one of `title`, `description`, `tags`, or `metadata` must be provided.
 - A `metadata` patch containing `depends_on`/`blocked_on` (any value, including a `null` delete) is rejected — those keys are no longer read, and closing the write path prevents stale scheduler-invisible dependency state being recreated.
-- Only `open` tasks can be updated. Completed and cancelled tasks are treated as not found at the MCP boundary.
+- **Terminal tasks are updatable (#303).** `task_update` works on `completed`/`cancelled` tasks too — useful for annotating an archived task (e.g. a `metadata` snapshot) without reviving it. `task_not_found` now means the task genuinely does not exist. To bring a task back to active work, use `lithos_task_reopen`.
 - `metadata` is applied as an **additive per-key merge**: keys with non-null values overwrite the existing value, keys whose value is `null` are deleted from the existing metadata, and keys not mentioned are preserved. `metadata={}` is a no-op (preserves all existing keys); there is no wholesale-clear affordance. To clear a specific key, pass `{"key": null}`. The merge is performed atomically (single `BEGIN IMMEDIATE` transaction) so concurrent writers updating different keys never clobber each other.
 
 #### `lithos_task_claim`
@@ -848,6 +848,19 @@ Cancel a task and release all claims.
 **Returns:** `{ success: true }` on success, or `{ status: "error", code: "task_not_found", message }` on failure.
 
 **Behavior:** Marks an open task as `cancelled`, persists `resolved_at = now` (dual-write with `lithos_task_complete` so both terminal transitions populate the same timestamp), and deletes all claims on that task. The optional `reason` is accepted by the MCP surface but is not persisted in SQLite.
+
+#### `lithos_task_reopen`
+Move a terminal (`completed`/`cancelled`) task back to `open` — the inverse of complete/cancel.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `task_id` | string | Yes | Task ID to reopen |
+| `agent` | string | Yes | Agent performing the reopen |
+
+**Returns:** `{ success: true, reblocked: string[] }` on success, or `{ status: "error", code, message }` on failure (codes: `task_not_found`, `task_not_resolved` — the task is already `open`).
+
+**Behavior:** Sets `status` back to `open`, clears `resolved_at` and `outcome`, posts a durable `[Reopened]` finding recording the prior terminal status, and emits a `task.reopened` event. Claims were already released on complete/cancel, so none are restored. `reblocked` lists the open dependents this reopen put back under the task's block (via `blocks`/`waits_on_gate` edges) — non-empty only when reopening a **completed** blocker/gate (a dependent that was ready is blocked again); reopening a **cancelled** blocker/gate instead *un-strands* its dependents (`blocker_unsatisfiable` → waiting) and re-blocks no one, so `reblocked` is `[]`. This is the remediation for dependents stranded by a cancelled blocker/gate (see Gates / readiness).
 
 #### `lithos_task_list`
 List tasks with optional filters.
@@ -1420,6 +1433,7 @@ Lithos includes an in-memory event bus that emits `LithosEvent` on all write, de
 | `task.released` | `lithos_task_release` | `task_id`, `agent`, `aspect` |
 | `task.completed` | `lithos_task_complete` | `task_id`, `agent`, `outcome`, `cited_nodes`, `misleading_nodes`, `receipt_id` |
 | `task.cancelled` | `lithos_task_cancel` | `task_id`, `agent`, `reason` |
+| `task.reopened` | `lithos_task_reopen` | `task_id`, `agent`, `prior_status`, `prior_outcome` |
 | `finding.posted` | `lithos_finding_post` | `finding_id`, `task_id`, `agent` |
 | `agent.registered` | `lithos_agent_register` | `agent_id`, `name` |
 
@@ -1623,7 +1637,9 @@ Tools indicate routine domain failures through return values, and unexpected bac
 | Claim release with no matching claim | `lithos_task_release` returns `{ status: "error", code: "claim_not_found" }` |
 | Completing unknown or non-open task | `lithos_task_complete` returns `{ status: "error", code: "task_not_found" }` |
 | Updating task with no fields provided | `lithos_task_update` returns `{ status: "error", code: "invalid_input" }` |
-| Updating or cancelling unknown/closed task | `lithos_task_update` / `lithos_task_cancel` returns `{ status: "error", code: "task_not_found" }` |
+| Updating an unknown task | `lithos_task_update` returns `{ status: "error", code: "task_not_found" }` (terminal tasks are updatable — #303; only genuinely-missing ids error) |
+| Cancelling unknown/closed task | `lithos_task_cancel` returns `{ status: "error", code: "task_not_found" }` |
+| Reopening unknown task / already-open task | `lithos_task_reopen` returns `{ status: "error", code: "task_not_found" }` / `{ code: "task_not_resolved" }` |
 | Fetching unknown task via `lithos_task_get` | Returns `{ status: "error", code: "task_not_found" }` |
 | Invalid arguments | FastMCP validation rejects the call |
 | Ambiguous wiki-link | Link treated as unresolved (no error raised) |
@@ -1716,13 +1732,13 @@ These are explicitly not part of the initial implementation but may be considere
 | Knowledge | `lithos_write`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup` |
 | Graph | `lithos_tags`, `lithos_related` |
 | Agent | `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list` |
-| Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_list`, `lithos_task_status`, `lithos_task_get`, `lithos_finding_post`, `lithos_finding_list` |
+| Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_reopen`, `lithos_task_list`, `lithos_task_status`, `lithos_task_get`, `lithos_finding_post`, `lithos_finding_list` |
 | Task Graph | `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, `lithos_task_blocked`, `lithos_task_children`, `lithos_task_spawn` |
 | System | `lithos_stats` |
 | LCMA (Phase 7 MVP 1) | `lithos_retrieve`, `lithos_edge_upsert`, `lithos_edge_list`, `lithos_conflict_resolve`, `lithos_node_stats` |
 | HTTP | `GET /health`, `GET /events`, `GET /audit` (not MCP tools; see §5.7 and §8.7) |
 
-**Total: 35 MCP tools + 3 HTTP endpoints** (task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; Phase 3 added the `gate` task type and `waits_on_gate` edge with no new tools — gates are created via `lithos_task_create` and resolved via `lithos_task_complete`; `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
+**Total: 36 MCP tools + 3 HTTP endpoints** (task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; Phase 3 added the `gate` task type and `waits_on_gate` edge with no new tools — gates are created via `lithos_task_create` and resolved via `lithos_task_complete`; `lithos_task_reopen` completes the lifecycle (terminal → open, the remediation for stranded dependents) and `lithos_task_update` now accepts terminal tasks (#303); `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
 
 ---
 

--- a/docs/plans/task-graph-coordination-extension.md
+++ b/docs/plans/task-graph-coordination-extension.md
@@ -421,7 +421,7 @@ A task is blocked when:
 Blocker-failure policy:
 
 - a `blocks` predecessor that ends `cancelled` (terminal but not `completed`) leaves every dependent **permanently** blocked — the awaited work will never complete. Such dependents are excluded from `ready` and surfaced via `lithos_task_blocked` with a `blocker_unsatisfiable` blocker carrying the cancelled predecessor's id + status, so an agent can decide to re-open/re-route the predecessor or cancel the stranded subtree. The edge is retained (never silently dropped) — exactly as for backfill cycles below — because dropping it would make the dependent spuriously `ready`.
-- this keeps Lithos **passive**: it does not auto-cancel or auto-reroute the stranded dependents; it refuses to call them ready and explains why, leaving the policy decision to the agent/orchestrator.
+- this keeps Lithos **passive**: it does not auto-cancel or auto-reroute the stranded dependents; it refuses to call them ready and explains why, leaving the policy decision to the agent/orchestrator. The concrete remediation is `lithos_task_reopen` (#243): reopening the cancelled blocker/gate moves its dependents from `blocker_unsatisfiable` back to a waiting state (`task`/`gate`) without spuriously readying them.
 
 Cycle policy:
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1382,9 +1382,15 @@ class CoordinationService:
         placeholders = ",".join("?" for _ in dependency)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            # Restrict to *open* dependents: a terminal dependent is not active work
+            # and was never "ready", so reporting it as reblocked would mislead an
+            # orchestrator (the reopened task can be the sole blocker of a long-since
+            # completed dependent — _compute_blockers ignores the dependent's status).
             cursor = await db.execute(
-                f"SELECT DISTINCT to_task_id FROM task_edges "
-                f"WHERE from_task_id = ? AND type IN ({placeholders})",
+                f"SELECT DISTINCT e.to_task_id FROM task_edges e "
+                f"JOIN tasks t ON t.id = e.to_task_id "
+                f"WHERE e.from_task_id = ? AND e.type IN ({placeholders}) "
+                f"AND t.status = 'open'",
                 (task_id, *dependency),
             )
             candidates = [row[0] for row in await cursor.fetchall()]

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -1077,8 +1077,9 @@ class CoordinationService:
         """Update mutable task metadata.
 
         Only updates fields that are not None (partial update pattern).
-        Only open tasks can be updated; completed or cancelled tasks are
-        treated as not found (consistent with complete_task behaviour).
+        Terminal tasks (completed/cancelled) are updatable too (#303) — useful for
+        annotating an archived task (e.g. a metadata snapshot) without reviving it;
+        use ``lithos_task_reopen`` to bring a task back to active work.
 
         ``metadata`` is applied as an additive per-key merge: keys with
         non-null values overwrite, keys whose value is ``None`` are deleted,
@@ -1086,7 +1087,7 @@ class CoordinationService:
         There is no wholesale-clear affordance (#290).
 
         Returns:
-            True if task was found, is open, and was updated; False otherwise
+            True if task was found and updated; False if no such task exists
 
         Raises:
             CoordinationError: ``metadata`` contains a forbidden scheduling key
@@ -1130,20 +1131,18 @@ class CoordinationService:
 
         Single UPDATE, no SELECT needed. When ``sets`` is empty the caller
         passed only no-op arguments — we still return True/False based on
-        whether the task exists and is open, matching the contract of the
-        merge path.
+        whether the task exists, matching the contract of the merge path.
+        Terminal tasks (completed/cancelled) are updatable too (#303).
         """
         if not sets:
             async with aiosqlite.connect(self.db_path) as db:
-                cursor = await db.execute(
-                    "SELECT id FROM tasks WHERE id = ? AND status = 'open'", (task_id,)
-                )
+                cursor = await db.execute("SELECT id FROM tasks WHERE id = ?", (task_id,))
                 return await cursor.fetchone() is not None
 
         params_with_id = [*params, task_id]
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'open'",
+                f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",
                 params_with_id,
             )
             await db.commit()
@@ -1181,7 +1180,7 @@ class CoordinationService:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await db.execute(
-                    "SELECT task_type, metadata FROM tasks WHERE id = ? AND status = 'open'",
+                    "SELECT task_type, metadata FROM tasks WHERE id = ?",
                     (task_id,),
                 )
                 row = await cursor.fetchone()
@@ -1201,7 +1200,7 @@ class CoordinationService:
                 sets = [*non_metadata_sets, "metadata = ?"]
                 params = [*non_metadata_params, merged_json, task_id]
                 await db.execute(
-                    f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'open'",
+                    f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",
                     params,
                 )
                 await db.commit()
@@ -1320,6 +1319,81 @@ class CoordinationService:
                 extra={"task_id": task_id, "agent": agent, "reason": reason},
             )
             return True
+
+    @traced("lithos.coordination.reopen_task")
+    async def reopen_task(self, task_id: str, agent: str) -> tuple[str, str | None]:
+        """Move a terminal task back to ``open`` (the inverse of complete/cancel).
+
+        Clears ``resolved_at`` and ``outcome`` — a reopened task is no longer
+        resolved. Claims were already released on complete/cancel, so there is
+        nothing to restore. Returns ``(prior_status, prior_outcome)`` so the
+        caller can record the reopen in an event/finding.
+
+        Raises:
+            CoordinationError: ``task_not_found`` (unknown id) or
+                ``task_not_resolved`` (the task is already ``open``).
+        """
+        lithos_metrics.coordination_ops.add(1, {"op": "reopen"})
+        await self.ensure_agent_known(agent)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT status, outcome FROM tasks WHERE id = ?",
+                (task_id,),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                raise CoordinationError("task_not_found", f"Task '{task_id}' not found.")
+            prior_status, prior_outcome = row[0], row[1]
+            if prior_status == "open":
+                raise CoordinationError(
+                    "task_not_resolved", f"Task '{task_id}' is already open; nothing to reopen."
+                )
+            await db.execute(
+                "UPDATE tasks SET status = 'open', resolved_at = NULL, outcome = NULL WHERE id = ?",
+                (task_id,),
+            )
+            await db.commit()
+
+        logger.info(
+            "Task reopened: task_id=%s agent=%s prior_status=%s",
+            task_id,
+            agent,
+            prior_status,
+            extra={"task_id": task_id, "agent": agent, "prior_status": prior_status},
+        )
+        return prior_status, prior_outcome
+
+    @traced("lithos.coordination.newly_reblocked_by")
+    async def newly_reblocked_by(self, task_id: str, prior_status: str) -> list[str]:
+        """Return ids of open dependents this reopen just put back under a block.
+
+        The inverse of :meth:`newly_unblocked_by`. Only a ``completed``-task
+        reopen newly blocks anyone: a ``cancelled``-task reopen *un-strands* its
+        dependents (``blocker_unsatisfiable`` -> waiting) without newly blocking
+        them, so it returns ``[]``. For a completed reopen, a dependent is
+        reported iff its *only* current blocker is the reopened task (it was ready
+        before and is now blocked solely by this), so the report stays honest and
+        does not include dependents that were already blocked by something else.
+        """
+        if prior_status != "completed":
+            return []
+        dependency = tuple(DEPENDENCY_EDGE_TYPES)
+        placeholders = ",".join("?" for _ in dependency)
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                f"SELECT DISTINCT to_task_id FROM task_edges "
+                f"WHERE from_task_id = ? AND type IN ({placeholders})",
+                (task_id, *dependency),
+            )
+            candidates = [row[0] for row in await cursor.fetchall()]
+            reblocked: list[str] = []
+            for cand in candidates:
+                blockers = await self._compute_blockers(db, cand)
+                if blockers and all(b["task_id"] == task_id for b in blockers):
+                    reblocked.append(cand)
+            return reblocked
 
     async def list_tasks(
         self,

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -38,6 +38,7 @@ TASK_CLAIMED = "task.claimed"
 TASK_RELEASED = "task.released"
 TASK_COMPLETED = "task.completed"
 TASK_CANCELLED = "task.cancelled"
+TASK_REOPENED = "task.reopened"
 
 FINDING_POSTED = "finding.posted"
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -31,6 +31,7 @@ from lithos.events import (
     TASK_COMPLETED,
     TASK_CREATED,
     TASK_RELEASED,
+    TASK_REOPENED,
     TASK_UPDATED,
     EventBus,
     LithosEvent,
@@ -2583,6 +2584,10 @@ class LithosServer:
             """Update mutable task fields (title, description, tags, metadata).
 
             At least one of title, description, tags, or metadata must be provided.
+            Works on terminal (completed/cancelled) tasks too — useful for annotating
+            an archived task (e.g. a metadata snapshot) without reviving it; use
+            ``lithos_task_reopen`` to bring a task back to active work. ``task_not_found``
+            now means the task genuinely does not exist.
 
             ``metadata`` is applied as an additive per-key merge: keys with non-null
             values overwrite the existing value, keys whose value is ``None`` are
@@ -2959,6 +2964,69 @@ class LithosServer:
                     "code": "task_not_found",
                     "message": f"Task {task_id} not found or already closed",
                 }
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_task_reopen(
+            task_id: str,
+            agent: str,
+        ) -> dict[str, Any]:
+            """Reopen a terminal (completed/cancelled) task back to ``open``.
+
+            The inverse of complete/cancel — use it to revive a task to active work
+            (e.g. an accidental completion) and to remediate dependents stranded as
+            ``blocker_unsatisfiable`` by a cancelled blocker/gate: reopening that
+            blocker/gate returns its dependents to a waiting state. Clears
+            ``resolved_at``/``outcome``, records the reopen as a ``[Reopened]``
+            finding, and emits a ``task.reopened`` event.
+
+            Args:
+                task_id: Task ID to reopen
+                agent: Agent performing the reopen
+
+            Returns:
+                ``{"success": true, "reblocked": [...]}`` — ``reblocked`` lists open
+                dependents this reopen put back under the task's block (non-empty
+                only when reopening a *completed* blocker/gate; a cancelled-task
+                reopen un-strands dependents and re-blocks no one). On failure,
+                ``{"status": "error", "code": "task_not_found" | "task_not_resolved",
+                "message": ...}``.
+            """
+            logger.info("lithos_task_reopen task=%s agent=%s", task_id, agent)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.task_reopen") as span:
+                span.set_attribute("lithos.tool", "lithos_task_reopen")
+                span.set_attribute("lithos.agent", agent)
+                span.set_attribute("lithos.task_id", task_id)
+                try:
+                    prior_status, prior_outcome = await self.coordination.reopen_task(
+                        task_id=task_id, agent=agent
+                    )
+                except CoordinationError as exc:
+                    span.set_attribute("lithos.success", False)
+                    return {"status": "error", "code": exc.code, "message": exc.message}
+
+                # Durable audit: a queryable finding recording the prior terminal state.
+                summary = f"[Reopened] task reopened (was {prior_status})"
+                if prior_outcome:
+                    summary += f"; prior outcome: {prior_outcome}"
+                await self.coordination.post_finding(task_id=task_id, agent=agent, summary=summary)
+
+                await self._emit(
+                    LithosEvent(
+                        type=TASK_REOPENED,
+                        agent=agent,
+                        payload={
+                            "task_id": task_id,
+                            "agent": agent,
+                            "prior_status": prior_status,
+                            "prior_outcome": prior_outcome,
+                        },
+                    )
+                )
+                reblocked = await self.coordination.newly_reblocked_by(task_id, prior_status)
+                span.set_attribute("lithos.reblocked_count", len(reblocked))
+                return {"success": True, "reblocked": reblocked}
 
         @self.mcp.tool()
         @tool_metrics()

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -7,7 +7,7 @@ import aiosqlite
 import pytest
 
 from lithos.config import LithosConfig, StorageConfig
-from lithos.coordination import CoordinationService
+from lithos.coordination import CoordinationError, CoordinationService
 
 
 class TestAgentRegistry:
@@ -303,6 +303,80 @@ class TestTaskLifecycle:
         # slack to absorb clock skew under heavy CI load.
         after = datetime.now(timezone.utc)
         assert before - timedelta(seconds=5) <= task.resolved_at <= after + timedelta(seconds=5)
+
+    @pytest.mark.asyncio
+    async def test_reopen_completed_task(self, coordination_service: CoordinationService):
+        """reopen_task moves completed -> open, clearing resolved_at + outcome."""
+        task_id = await coordination_service.create_task(title="Done", agent="agent")
+        await coordination_service.complete_task(task_id, "agent", outcome="shipped")
+
+        prior_status, prior_outcome = await coordination_service.reopen_task(task_id, "agent")
+        assert prior_status == "completed"
+        assert prior_outcome == "shipped"
+
+        task = await coordination_service.get_task(task_id)
+        assert task is not None
+        assert task.status == "open"
+        assert task.resolved_at is None
+        assert task.outcome is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_cancelled_task(self, coordination_service: CoordinationService):
+        task_id = await coordination_service.create_task(title="Gone", agent="agent")
+        await coordination_service.cancel_task(task_id, "agent")
+        prior_status, _ = await coordination_service.reopen_task(task_id, "agent")
+        assert prior_status == "cancelled"
+        task = await coordination_service.get_task(task_id)
+        assert task is not None and task.status == "open" and task.resolved_at is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_open_task_rejected(self, coordination_service: CoordinationService):
+        task_id = await coordination_service.create_task(title="Still open", agent="agent")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.reopen_task(task_id, "agent")
+        assert exc.value.code == "task_not_resolved"
+
+    @pytest.mark.asyncio
+    async def test_reopen_missing_task_rejected(self, coordination_service: CoordinationService):
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.reopen_task("ghost", "agent")
+        assert exc.value.code == "task_not_found"
+
+    @pytest.mark.asyncio
+    async def test_update_works_on_terminal_tasks(self, coordination_service: CoordinationService):
+        """#303: task_update accepts completed/cancelled tasks (metadata + fields)."""
+        done = await coordination_service.create_task(
+            title="Done", agent="agent", metadata={"a": 1}
+        )
+        await coordination_service.complete_task(done, "agent")
+        ok = await coordination_service.update_task(
+            done, "agent", title="Done (renamed)", metadata={"b": 2}
+        )
+        assert ok is True
+        task = await coordination_service.get_task(done)
+        assert task is not None
+        assert task.title == "Done (renamed)"
+        assert task.metadata == {"a": 1, "b": 2}  # additive merge survives terminal state
+
+        cancelled = await coordination_service.create_task(title="Gone", agent="agent")
+        await coordination_service.cancel_task(cancelled, "agent")
+        assert await coordination_service.update_task(cancelled, "agent", metadata={"x": 1}) is True
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_still_rejects_forbidden_metadata(
+        self, coordination_service: CoordinationService
+    ):
+        done = await coordination_service.create_task(title="Done", agent="agent")
+        await coordination_service.complete_task(done, "agent")
+        with pytest.raises(CoordinationError) as exc:
+            await coordination_service.update_task(done, "agent", metadata={"depends_on": ["x"]})
+        assert exc.value.code == "invalid_metadata_key"
+
+    @pytest.mark.asyncio
+    async def test_update_missing_task_returns_false(
+        self, coordination_service: CoordinationService
+    ):
+        assert await coordination_service.update_task("ghost", "agent", title="x") is False
 
     @pytest.mark.asyncio
     async def test_get_task_status(self, coordination_service: CoordinationService):
@@ -1849,10 +1923,8 @@ class TestTaskUpdateMetadataMerge:
         assert task.metadata == {"a": 1}
 
     @pytest.mark.asyncio
-    async def test_merge_on_completed_task_returns_false(
-        self, coordination_service: CoordinationService
-    ):
-        """Completed tasks are treated as not-found; metadata is not mutated."""
+    async def test_merge_on_completed_task_merges(self, coordination_service: CoordinationService):
+        """#303: completed tasks are now updatable; the metadata merge applies."""
         task_id = await coordination_service.create_task(
             title="Completed Task",
             agent="agent",
@@ -1863,11 +1935,12 @@ class TestTaskUpdateMetadataMerge:
         updated = await coordination_service.update_task(
             task_id=task_id, agent="agent", metadata={"b": 2}
         )
-        assert updated is False
+        assert updated is True
 
         task = await coordination_service.get_task(task_id)
         assert task is not None
-        assert task.metadata == {"a": 1}
+        assert task.metadata == {"a": 1, "b": 2}
+        assert task.status == "completed"  # annotated, not revived
 
     @pytest.mark.asyncio
     async def test_merge_preserves_other_columns(self, coordination_service: CoordinationService):

--- a/tests/test_event_emission.py
+++ b/tests/test_event_emission.py
@@ -15,6 +15,7 @@ from lithos.events import (
     TASK_COMPLETED,
     TASK_CREATED,
     TASK_RELEASED,
+    TASK_REOPENED,
     TASK_UPDATED,
     LithosEvent,
 )
@@ -242,6 +243,22 @@ class TestTaskEventEmission:
         assert event.payload["task_id"] == task_id
         # outcome is surfaced in the event payload; None when not supplied.
         assert event.payload["outcome"] is None
+        server.event_bus.unsubscribe(queue)
+
+    @pytest.mark.asyncio
+    async def test_lithos_task_reopen_emits_task_reopened(self, server: LithosServer) -> None:
+        result = await _call_tool(server, "lithos_task_create", {"title": "T", "agent": "a"})
+        task_id = result["task_id"]
+        await _call_tool(server, "lithos_task_complete", {"task_id": task_id, "agent": "a"})
+
+        queue = server.event_bus.subscribe(event_types=[TASK_REOPENED])
+        reopen = await _call_tool(server, "lithos_task_reopen", {"task_id": task_id, "agent": "a"})
+        assert reopen["success"] is True
+
+        event = queue.get_nowait()
+        assert event.type == TASK_REOPENED
+        assert event.payload["task_id"] == task_id
+        assert event.payload["prior_status"] == "completed"
         server.event_bus.unsubscribe(queue)
 
     @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2321,8 +2321,8 @@ class TestTaskUpdateTool:
         assert "nonexistent-task-id" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_update_completed_task_returns_error(self, server: LithosServer):
-        """lithos_task_update: returns error envelope for completed tasks (status guard)."""
+    async def test_update_completed_task_succeeds(self, server: LithosServer):
+        """#303: lithos_task_update now works on terminal tasks (annotate, don't revive)."""
         task_id = await server.coordination.create_task(
             title="Will Complete",
             agent="test-agent",
@@ -2333,11 +2333,14 @@ class TestTaskUpdateTool:
             server,
             task_id=task_id,
             agent="test-agent",
-            title="Too Late",
+            title="Archived title",
         )
 
-        assert result["status"] == "error"
-        assert result["code"] == "task_not_found"
+        assert result.get("success") is True
+        task = await server.coordination.get_task(task_id)
+        assert task is not None
+        assert task.title == "Archived title"
+        assert task.status == "completed"  # updated in place, not revived
 
     @pytest.mark.asyncio
     async def test_update_task_no_fields_returns_error(self, server: LithosServer):

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -749,6 +749,77 @@ class TestGates:
         assert b_row["blockers"][0]["kind"] == "gate"
 
 
+# ==================== Reopen + cascade (#243) ====================
+
+
+def _blocker(rows, tid):
+    row = next((t for t in rows if t["id"] == tid), None)
+    return row["blockers"][0] if row and row.get("blockers") else None
+
+
+class TestReopen:
+    async def test_reopen_completed_blocker_reblocks_dependent(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B", depends_on=[a])
+        await coordination_service.complete_task(a, "a")
+        assert b in _ids(await coordination_service.list_ready())  # A done -> B ready
+
+        prior, _ = await coordination_service.reopen_task(a, "a")
+        assert prior == "completed"
+        reblocked = await coordination_service.newly_reblocked_by(a, prior)
+        assert reblocked == [b]
+        assert b not in _ids(await coordination_service.list_ready())  # B blocked again
+        assert _blocker(await coordination_service.list_blocked(), b)["kind"] == "task"
+
+    async def test_reopen_cancelled_blocker_unstrands_without_reblock(
+        self, coordination_service: CoordinationService
+    ):
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B", depends_on=[a])
+        await coordination_service.cancel_task(a, "a")
+        # B is stranded: blocker_unsatisfiable
+        assert (
+            _blocker(await coordination_service.list_blocked(), b)["kind"]
+            == "blocker_unsatisfiable"
+        )
+
+        prior, _ = await coordination_service.reopen_task(a, "a")
+        assert prior == "cancelled"
+        # cancelled-reopen newly-blocks no one (B was already blocked)
+        assert await coordination_service.newly_reblocked_by(a, prior) == []
+        # but B is now recoverable: blocker_unsatisfiable -> waiting (kind=task), still not ready
+        assert b not in _ids(await coordination_service.list_ready())
+        assert _blocker(await coordination_service.list_blocked(), b)["kind"] == "task"
+
+    async def test_reopen_completed_gate_reblocks_waiter(
+        self, coordination_service: CoordinationService
+    ):
+        gate = await _gate(coordination_service, "human")
+        w = await _mk(coordination_service, "W")
+        await coordination_service.upsert_task_edge(gate, w, "waits_on_gate", "a")
+        await coordination_service.complete_task(gate, "a")
+        assert w in _ids(await coordination_service.list_ready())
+
+        prior, _ = await coordination_service.reopen_task(gate, "a")
+        assert await coordination_service.newly_reblocked_by(gate, prior) == [w]
+        assert _blocker(await coordination_service.list_blocked(), w)["kind"] == "gate"
+
+    async def test_reblocked_excludes_dependent_with_other_blocker(
+        self, coordination_service: CoordinationService
+    ):
+        # B depends on both A and X. Completing only A never readied B, so reopening
+        # A must NOT report B as reblocked (B was already blocked by X).
+        a = await _mk(coordination_service, "A")
+        x = await _mk(coordination_service, "X")
+        b = await _mk(coordination_service, "B", depends_on=[a, x])
+        await coordination_service.complete_task(a, "a")
+        assert b not in _ids(await coordination_service.list_ready())  # X still blocks
+        prior, _ = await coordination_service.reopen_task(a, "a")
+        assert await coordination_service.newly_reblocked_by(a, prior) == []
+
+
 # ==================== Backfill + migration ====================
 
 
@@ -963,3 +1034,37 @@ class TestServerTaskGraphTools:
         # completing the gate reports the waiter as unblocked
         done = await _call(server, "lithos_task_complete", task_id=gate_id, agent="a")
         assert done["unblocked"] == [task]
+
+    async def test_reopen_tool_envelope_finding_and_reblocked(self, server: LithosServer):
+        a = await server.coordination.create_task(title="A", agent="a")
+        b = await server.coordination.create_task(title="B", agent="a", depends_on=[a])
+        await server.coordination.complete_task(a, "a", outcome="done")
+
+        res = await _call(server, "lithos_task_reopen", task_id=a, agent="a")
+        assert res["success"] is True
+        assert res["reblocked"] == [b]  # reopening completed A re-blocks B
+
+        # durable [Reopened] finding records the prior terminal status
+        findings = await _call(server, "lithos_finding_list", task_id=a)
+        assert any(
+            "[Reopened]" in fnd["summary"] and "completed" in fnd["summary"]
+            for fnd in findings["findings"]
+        )
+        # A is open again, off the resolved surface
+        got = await _call(server, "lithos_task_get", task_id=a)
+        assert got["task"]["status"] == "open" and got["task"]["resolved_at"] is None
+
+    async def test_reopen_tool_error_envelopes(self, server: LithosServer):
+        missing = await _call(server, "lithos_task_reopen", task_id="ghost", agent="a")
+        assert missing["code"] == "task_not_found"
+        open_task = await server.coordination.create_task(title="Open", agent="a")
+        already = await _call(server, "lithos_task_reopen", task_id=open_task, agent="a")
+        assert already["code"] == "task_not_resolved"
+
+    async def test_update_tool_works_on_terminal_task(self, server: LithosServer):
+        t = await server.coordination.create_task(title="T", agent="a")
+        await server.coordination.complete_task(t, "a")
+        res = await _call(server, "lithos_task_update", task_id=t, agent="a", metadata={"k": "v"})
+        assert res.get("success") is True
+        got = await _call(server, "lithos_task_get", task_id=t)
+        assert got["task"]["metadata"]["k"] == "v" and got["task"]["status"] == "completed"

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -819,6 +819,19 @@ class TestReopen:
         prior, _ = await coordination_service.reopen_task(a, "a")
         assert await coordination_service.newly_reblocked_by(a, prior) == []
 
+    async def test_reblocked_excludes_terminal_dependent(
+        self, coordination_service: CoordinationService
+    ):
+        # A blocks B; both complete; reopen A. B is terminal (completed), not active
+        # work, so it must NOT appear in reblocked even though A is its only blocker.
+        a = await _mk(coordination_service, "A")
+        b = await _mk(coordination_service, "B", depends_on=[a])
+        await coordination_service.complete_task(a, "a")
+        await coordination_service.complete_task(b, "b")
+        prior, _ = await coordination_service.reopen_task(a, "a")
+        assert prior == "completed"
+        assert await coordination_service.newly_reblocked_by(a, prior) == []
+
 
 # ==================== Backfill + migration ====================
 


### PR DESCRIPTION
## Summary

Completes the task lifecycle, which was previously one-way (`open → {completed, cancelled}`) with no path back and no way to mutate a terminal task. Two complementary pieces:

- **`lithos_task_reopen` (#243)** — revive a terminal task to active work. This is the remediation the task graph already points users to: a cancelled `blocks`/`waits_on_gate` predecessor strands its dependents as `blocker_unsatisfiable`, and the live error text says *"re-open the predecessor"* — but until now no reopen tool existed.
- **Terminal `task_update` (#303)** — `task_update` returned a misleading `task_not_found` for completed/cancelled tasks, breaking a `task_get`-then-`task_update` drift-sync. Terminal tasks are now annotatable without reviving them.

Task-graph Phase 4 is deferred — nothing there has a waiting consumer; these do.

## `lithos_task_reopen` (#243)

- `reopen_task(task_id, agent)` clears `resolved_at` + `outcome`, sets `status=open`, returns `(prior_status, prior_outcome)`. Missing → `task_not_found`; already open → `task_not_resolved`.
- Returns **`reblocked`** (symmetric to `complete`'s `unblocked`):
  - reopening a **completed** blocker/gate re-blocks dependents that were ready → listed in `reblocked`;
  - reopening a **cancelled** one **un-strands** them (`blocker_unsatisfiable` → waiting) and newly-blocks no one → `reblocked` is `[]`.
  - `newly_reblocked_by` only reports dependents whose **sole** current blocker is the reopened task.
- **Audit:** emits a `task.reopened` event (prior status + outcome in payload) and auto-posts a durable `[Reopened]` finding (queryable via `lithos_finding_list`).

## Terminal `task_update` (#303)

- Dropped the `AND status = 'open'` filter from both update paths. All fields (title / description / tags / metadata) are updatable on terminal tasks with the same additive merge + validations.
- Gate revalidation and forbidden-key (`depends_on`/`blocked_on`) rejection still apply regardless of status. Genuinely-missing still returns `task_not_found`.

Tool count 35 → 36.

## Docs

- `docs/SPECIFICATION.md`: §5.4 (reopen tool + revised update behavior), §8.2 (`task.reopened` event), §10.2 (error scenarios), Appendix B (count bump).
- `docs/plans/task-graph-coordination-extension.md`: §8 notes reopen as the remediation for stranded dependents.

## Test plan

- [x] `make check` — **1463 passed**, lint/format/typecheck clean
- [x] `make test-integration` — **386 passed**
- [x] Reopen: completed / cancelled / already-open (`task_not_resolved`) / missing (`task_not_found`)
- [x] Terminal `task_update`: metadata merge + title edit on completed & cancelled; forbidden `depends_on` still rejected; missing → `False`
- [x] Reopen-cascade: completed blocker reblocks dependent; cancelled blocker un-strands without reblock; completed gate reblocks waiter; dependent with another blocker excluded from `reblocked`
- [x] Server-level: tool envelopes, `[Reopened]` finding, `task.reopened` event emission, terminal update via tool
- [ ] End-to-end against staging (port 8766) after merge + restart

## Issues

Closes #243, closes #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)