### PR TITLE
Add a note metadata/tags patch (lithos_note_update) — parity with lithos_task_update

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -487,6 +487,37 @@ The error code is the canonical top-level `status` value (e.g. `status="slug_col
 
 **Update semantics:** Omitted optional fields preserve existing values. Some fields support explicit clear. At the MCP boundary, FastMCP cannot distinguish omitted from `null`, so clearable string fields use `""` (empty string) as the clear signal (e.g., `source_url: ""`). See `unified-write-contract.md` for the full MCP boundary convention.
 
+#### `lithos_note_update`
+Patch a note's frontmatter (tags / metadata / title / status) **without resending its body** — the note counterpart to `lithos_task_update`. Use this instead of `lithos_write` whenever only frontmatter changes: it removes the read → reconstruct-body → write round-trip (and the lost-update risk of reproducing the body), because the body is never read into the request. Internally it reuses the same update pipeline as `lithos_write` (the `_write_lock` atomicity and `expected_version` check, the search/graph view sync, and the `note.updated` event), passing the body through untouched.
+
+**Arguments:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | string | Yes | UUID of the note to patch. |
+| `agent` | string | Yes | Your agent identifier. |
+| `title` | string | No | New title. Omit/`null` preserves. Renaming may change the slug; a collision with another note's slug returns `status="slug_collision"`. |
+| `tags` | string[] | No | Omit/`null` preserves; `[]` clears all tags; a non-empty list replaces them. |
+| `status` | enum | No | `active` \| `archived` \| `quarantined`. Omit/`null` preserves. An out-of-enum value returns `status="invalid_input"`. |
+| `metadata` | object | No | Additive per-key merge into existing frontmatter metadata: a key whose value is `null` deletes it, other keys are set, keys not mentioned are preserved. There is no wholesale-clear affordance — `metadata={}` makes no metadata change (mirroring `lithos_task_update`). Keys must be strings and must not collide with reserved frontmatter fields, else `status="invalid_input"`. |
+| `expected_version` | int | No | Optimistic-locking guard; reject with `version_conflict` when the note's current version differs. Omit to skip. |
+
+At least one mutable field (`title`, `tags`, `status`, or a non-empty `metadata`) must be provided; otherwise — including `metadata={}` with no other field — the call returns `status="invalid_input"` and writes no revision.
+
+**Returns (status envelope):**
+
+`{ status: "updated", id: string, path: string, version: int, warnings: string[] }`
+
+`{ status: "invalid_input", message: string, warnings: string[] }`
+
+`{ status: "slug_collision", message: string, existing_id: string, warnings: string[] }`
+
+`{ status: "duplicate", duplicate_of: { id, title, source_url }, message: string, warnings: string[] }`
+
+`{ status: "version_conflict", message: string, current_version: int, warnings: string[] }`
+
+`{ status: "error", code: "note_not_found", message: string }`  *(unknown `id`)*
+
 #### `lithos_read`
 Read a knowledge file by ID or path.
 
@@ -1423,7 +1454,7 @@ Lithos includes an in-memory event bus that emits `LithosEvent` on all write, de
 | Type Constant | Emitted By | Payload Fields |
 |---------------|-----------|----------------|
 | `note.created` | `lithos_write` (create) | `id`, `title`, `path` |
-| `note.updated` | `lithos_write` (update), file watcher (create/modify) | `id`, `title`, `path` (tool); `path` (watcher) |
+| `note.updated` | `lithos_write` (update), `lithos_note_update` (frontmatter patch), file watcher (create/modify) | `id`, `title`, `path` (tool); `path` (watcher) |
 | `note.deleted` | `lithos_delete`, file watcher (delete) | `id`, `path` (tool); `path` (watcher) |
 | `note.renamed` | `WatchIntake.rename_on_disk` (in-corpus rename detected by the watcher) | `id`, `src_path`, `dest_path` |
 | `edge.upserted` | `lithos_edge_upsert` via `CorpusIntake.assert_edge`; also `lithos_conflict_resolve` when it updates a `contradicts` edge | `edge_id`, `from_id`, `to_id`, `type`, `namespace` (assert_edge); `edge_id`, `from_id`, `to_id`, `type`, `conflict_state` (conflict_resolve) |
@@ -1729,7 +1760,7 @@ These are explicitly not part of the initial implementation but may be considere
 
 | Category | Tools |
 |----------|-------|
-| Knowledge | `lithos_write`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup` |
+| Knowledge | `lithos_write`, `lithos_note_update`, `lithos_read`, `lithos_delete`, `lithos_search`, `lithos_list`, `lithos_cache_lookup` |
 | Graph | `lithos_tags`, `lithos_related` |
 | Agent | `lithos_agent_register`, `lithos_agent_info`, `lithos_agent_list` |
 | Coordination | `lithos_task_create`, `lithos_task_update`, `lithos_task_claim`, `lithos_task_renew`, `lithos_task_release`, `lithos_task_complete`, `lithos_task_cancel`, `lithos_task_reopen`, `lithos_task_list`, `lithos_task_status`, `lithos_task_get`, `lithos_finding_post`, `lithos_finding_list` |
@@ -1738,7 +1769,7 @@ These are explicitly not part of the initial implementation but may be considere
 | LCMA (Phase 7 MVP 1) | `lithos_retrieve`, `lithos_edge_upsert`, `lithos_edge_list`, `lithos_conflict_resolve`, `lithos_node_stats` |
 | HTTP | `GET /health`, `GET /events`, `GET /audit` (not MCP tools; see §5.7 and §8.7) |
 
-**Total: 36 MCP tools + 3 HTTP endpoints** (task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; Phase 3 added the `gate` task type and `waits_on_gate` edge with no new tools — gates are created via `lithos_task_create` and resolved via `lithos_task_complete`; `lithos_task_reopen` completes the lifecycle (terminal → open, the remediation for stranded dependents) and `lithos_task_update` now accepts terminal tasks (#303); `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
+**Total: 37 MCP tools + 3 HTTP endpoints** (`lithos_note_update` adds a frontmatter-only note patch — tags/metadata/title/status without the body — at parity with `lithos_task_update` (#362); task graph Phase 1 added `lithos_task_edge_upsert`, `lithos_task_edge_list`, `lithos_task_ready`, and `lithos_task_blocked`; Phase 2 added `lithos_task_children` and `lithos_task_spawn` plus `parent_task_id`/`epic` on create; Phase 3 added the `gate` task type and `waits_on_gate` edge with no new tools — gates are created via `lithos_task_create` and resolved via `lithos_task_complete`; `lithos_task_reopen` completes the lifecycle (terminal → open, the remediation for stranded dependents) and `lithos_task_update` now accepts terminal tasks (#303); `lithos_task_get` is in the coordination surface; LCMA gained `lithos_conflict_resolve` and `lithos_node_stats` to surface contradiction resolution and per-node retrieval stats; the SSE delivery surface at `/events` and the read-access audit log at `/audit` are now first-class HTTP endpoints alongside `/health`)
 
 ---
 

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -114,8 +114,9 @@ class NoteUpdateRequest:
     ``_UNSET`` means preserve, ``None`` means clear (for fields that support
     clearing), and a value means set. ``metadata`` is an additive per-key
     merge (a key whose value is ``None`` deletes it); unlike ``lithos_write``
-    there is no wholesale-clear affordance — ``metadata={}`` is a no-op,
-    matching ``lithos_task_update``.
+    there is no wholesale-clear affordance — ``metadata={}`` carries no change,
+    matching ``lithos_task_update`` (the boundary rejects it when no other
+    field is set rather than writing a no-op revision).
     """
 
     id: str

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -106,6 +106,27 @@ class WriteRequest:
 
 
 @dataclass(frozen=True)
+class NoteUpdateRequest:
+    """Validated input for a metadata/tags-only note patch (no body).
+
+    Mirrors :class:`WriteRequest`'s *update* semantics but deliberately omits
+    ``content`` — the body is never touched. As with the write boundary,
+    ``_UNSET`` means preserve, ``None`` means clear (for fields that support
+    clearing), and a value means set. ``metadata`` is an additive per-key
+    merge (a key whose value is ``None`` deletes it); unlike ``lithos_write``
+    there is no wholesale-clear affordance — ``metadata={}`` is a no-op,
+    matching ``lithos_task_update``.
+    """
+
+    id: str
+    title: str | None = None
+    tags: list[str] | _UnsetType = _UNSET
+    lcma_status: str | None | _UnsetType = _UNSET
+    metadata: dict | _UnsetType = _UNSET
+    expected_version: int | None = None
+
+
+@dataclass(frozen=True)
 class EdgeRequest:
     """Validated input for an asserted edge upsert (ADR-0006 Slice 1).
 
@@ -404,6 +425,99 @@ class CorpusIntake:
             await self._emit(
                 LithosEvent(
                     type=NOTE_UPDATED if request.id else NOTE_CREATED,
+                    agent=agent,
+                    payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
+                    tags=list(doc.metadata.tags),
+                )
+            )
+
+            return WriteOutcome(
+                status=result.status,
+                document=doc,
+                warnings=list(result.warnings),
+            )
+
+    async def note_update(self, agent: str, request: NoteUpdateRequest) -> WriteOutcome:
+        """Patch a note's metadata/tags/title/status without touching its body.
+
+        The metadata-only counterpart to :meth:`write`. The body is preserved
+        by passing ``content=None`` to :meth:`KnowledgeManager.update`, so no
+        full round-trip of the markdown is required to flip a frontmatter key.
+        Otherwise the pipeline matches :meth:`write` exactly — the same
+        ``_write_lock`` atomicity (including ``expected_version`` checks),
+        the same Search/graph view sync in ADR-0003 order, and the same
+        ``NOTE_UPDATED`` event afterwards.
+
+        Raises ``FileNotFoundError`` if the id is unknown — the handler maps it
+        to a ``note_not_found`` envelope. ``SlugCollisionError`` (a title
+        rename onto an existing slug) is translated into a
+        ``WriteOutcome(status="slug_collision")``; all other non-success
+        ``WriteResult`` statuses are forwarded verbatim. ``ensure_agent_known``
+        runs for every call.
+        """
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.intake.note_update") as span:
+            span.set_attribute("lithos.intake.op", "note_update")
+            span.set_attribute("lithos.agent", agent)
+            span.set_attribute("lithos.id", request.id)
+
+            await self._coordination.ensure_agent_known(agent)
+
+            try:
+                result = await self._knowledge.update(
+                    id=request.id,
+                    agent=agent,
+                    content=None,  # body untouched — this is a frontmatter patch
+                    title=request.title,
+                    tags=request.tags,
+                    lcma_status=request.lcma_status,
+                    expected_version=request.expected_version,
+                    extra=request.metadata,
+                )
+            except SlugCollisionError as exc:
+                logger.info(
+                    "lithos_note_update slug_collision: agent=%s id=%s slug=%s existing_id=%s",
+                    agent,
+                    request.id,
+                    exc.slug,
+                    exc.existing_id,
+                )
+                span.set_attribute("lithos.write_status", "slug_collision")
+                return WriteOutcome(
+                    status="slug_collision",
+                    slug_collision_existing_id=exc.existing_id,
+                    message=str(exc),
+                )
+
+            if result.status != "updated":
+                span.set_attribute("lithos.write_status", result.status)
+                return WriteOutcome(
+                    status=result.status,
+                    document=result.document,
+                    duplicate_of=result.duplicate_of,
+                    current_version=result.current_version,
+                    path_collision_existing_id=result.path_collision_existing_id,
+                    message=result.message,
+                    warnings=list(result.warnings),
+                )
+
+            doc = result.document
+            assert doc is not None
+
+            # Sync derived views in the ADR-0003 order, exactly as write():
+            # search index (await), then graph (sync), then emit the event.
+            indexable = KnowledgeManager.to_indexable(doc)
+            await asyncio.to_thread(self._search.index, indexable)
+            self._graph.add_document(doc)
+
+            span.set_attribute("lithos.doc_id", doc.id)
+            span.set_attribute("lithos.write_status", result.status)
+            if result.warnings:
+                span.set_attribute("lithos.provenance.warning_count", len(result.warnings))
+
+            await self._emit(
+                LithosEvent(
+                    type=NOTE_UPDATED,
                     agent=agent,
                     payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
                     tags=list(doc.metadata.tags),

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -1499,9 +1499,11 @@ class LithosServer:
                     frontmatter metadata. A key whose value is null deletes it;
                     other keys are set; keys not mentioned are preserved. As with
                     ``lithos_task_update`` there is no wholesale-clear affordance —
-                    ``metadata={}`` is a no-op. Keys must be strings and must not
-                    collide with reserved frontmatter fields (e.g. title, tags,
-                    version) — such patches are rejected as invalid_input.
+                    ``metadata={}`` makes no metadata change (and, with no other
+                    field set, is rejected as invalid_input). Keys must be strings
+                    and must not collide with reserved frontmatter fields (e.g.
+                    title, tags, version) — such patches are rejected as
+                    invalid_input.
                 expected_version: If provided, reject with version_conflict when
                     the note's current version differs. Omit to skip the check.
 
@@ -1510,10 +1512,15 @@ class LithosServer:
                 invalid_input / version_conflict / slug_collision / duplicate /
                 error (with code ``note_not_found`` for an unknown id).
             """
-            if title is None and tags is None and status is None and metadata is None:
+            # An empty metadata dict carries no change (it maps to _UNSET below),
+            # so it does not count as a provided field — `metadata={}` alone is
+            # rejected rather than producing a version-bumping, event-emitting no-op.
+            has_metadata_change = metadata is not None and metadata != {}
+            if title is None and tags is None and status is None and not has_metadata_change:
                 return {
                     "status": "invalid_input",
-                    "message": "At least one of title, tags, status, or metadata must be provided.",
+                    "message": "At least one of title, tags, status, or metadata must be provided "
+                    "(an empty metadata dict makes no change).",
                     "warnings": [],
                 }
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -37,7 +37,7 @@ from lithos.events import (
     LithosEvent,
 )
 from lithos.graph import KnowledgeGraph
-from lithos.intake import CorpusIntake, DeleteRequest, WriteRequest
+from lithos.intake import CorpusIntake, DeleteRequest, NoteUpdateRequest, WriteRequest
 from lithos.knowledge import (
     _UNSET,
     VALID_ACCESS_SCOPES,
@@ -1455,6 +1455,166 @@ class LithosServer:
                 if outcome.warnings:
                     span.set_attribute("lithos.provenance.warning_count", len(outcome.warnings))
                 logger.info("lithos_write completed doc_id=%s status=%s", doc.id, outcome.status)
+                return {
+                    "status": outcome.status,
+                    "id": doc.id,
+                    "path": str(doc.path),
+                    "version": doc.metadata.version,
+                    "warnings": list(outcome.warnings),
+                }
+
+        @self.mcp.tool()
+        @tool_metrics()
+        async def lithos_note_update(
+            id: str,
+            agent: str,
+            title: str | None = None,
+            tags: list[str] | None = None,
+            status: str | None = None,
+            metadata: dict | None = None,
+            expected_version: int | None = None,
+        ) -> dict[str, Any]:
+            """Patch a note's frontmatter (tags/metadata/title/status) without resending its body.
+
+            The note counterpart to ``lithos_task_update``: a per-field patch
+            that leaves the markdown body untouched. Use this instead of
+            ``lithos_write`` whenever you only need to change frontmatter — it
+            removes the read → reconstruct-body → write round-trip (and the
+            lost-update risk that comes with reproducing the body), since the
+            body is never read into the request at all.
+
+            At least one of ``title``, ``tags``, ``status``, or ``metadata`` must
+            be provided.
+
+            Args:
+                id: UUID of the note to patch.
+                agent: Your agent identifier.
+                title: New title. null/omit preserves existing. Renaming may
+                    change the note's slug; a collision with another note's
+                    slug is rejected as ``slug_collision``.
+                tags: null/omit preserves existing; ``[]`` clears all tags; a
+                    non-empty list replaces them.
+                status: active|archived|quarantined. null/omit preserves existing.
+                metadata: Additive per-key merge into the note's existing
+                    frontmatter metadata. A key whose value is null deletes it;
+                    other keys are set; keys not mentioned are preserved. As with
+                    ``lithos_task_update`` there is no wholesale-clear affordance —
+                    ``metadata={}`` is a no-op. Keys must be strings and must not
+                    collide with reserved frontmatter fields (e.g. title, tags,
+                    version) — such patches are rejected as invalid_input.
+                expected_version: If provided, reject with version_conflict when
+                    the note's current version differs. Omit to skip the check.
+
+            Returns:
+                Dict with status envelope: updated on success; otherwise
+                invalid_input / version_conflict / slug_collision / duplicate /
+                error (with code ``note_not_found`` for an unknown id).
+            """
+            if title is None and tags is None and status is None and metadata is None:
+                return {
+                    "status": "invalid_input",
+                    "message": "At least one of title, tags, status, or metadata must be provided.",
+                    "warnings": [],
+                }
+
+            logger.info("lithos_note_update agent=%s id=%s", agent, id)
+            tracer = get_tracer()
+            with tracer.start_as_current_span("lithos.tool.note_update") as span:
+                span.set_attribute("lithos.tool", "lithos_note_update")
+                span.set_attribute("lithos.agent", agent)
+                span.set_attribute("lithos.doc_id", id)
+
+                # Validate status enum at the boundary for a fast, clean envelope.
+                if status is not None and status not in VALID_STATUSES:
+                    return {
+                        "status": "invalid_input",
+                        "message": f"Invalid status: {status!r}. "
+                        f"Must be one of {sorted(VALID_STATUSES)}",
+                        "warnings": [],
+                    }
+
+                # Validate metadata shape at the boundary. The same rule is
+                # enforced in KnowledgeManager so the invariant holds for every
+                # caller; checking here gives a fast, clean envelope.
+                if metadata is not None:
+                    try:
+                        validate_extra_metadata(metadata)
+                    except ValueError as e:
+                        return {
+                            "status": "invalid_input",
+                            "message": str(e),
+                            "warnings": [],
+                        }
+
+                # Translate the MCP wire shape into KnowledgeManager semantics:
+                #   None (omitted) → _UNSET (preserve)
+                #   tags=[]        → clear all tags
+                #   metadata={}    → _UNSET (no-op, mirroring lithos_task_update)
+                tags_arg: list[str] | _UnsetType = _UNSET if tags is None else tags
+                st_arg: str | None | _UnsetType = _UNSET if status is None else status
+                meta_arg: dict | _UnsetType = (
+                    _UNSET if metadata is None or metadata == {} else metadata
+                )
+
+                request = NoteUpdateRequest(
+                    id=id,
+                    title=title,
+                    tags=tags_arg,
+                    lcma_status=st_arg,
+                    metadata=meta_arg,
+                    expected_version=expected_version,
+                )
+
+                try:
+                    outcome = await self.intake.note_update(agent, request)
+                except FileNotFoundError:
+                    span.set_attribute("lithos.write_status", "note_not_found")
+                    return {
+                        "status": "error",
+                        "code": "note_not_found",
+                        "message": f"Note {id} not found",
+                    }
+
+                if outcome.status == "slug_collision":
+                    span.set_attribute("lithos.write_status", "slug_collision")
+                    return {
+                        "status": "slug_collision",
+                        "message": outcome.message,
+                        "existing_id": outcome.slug_collision_existing_id,
+                        "warnings": [],
+                    }
+                if outcome.status == "duplicate":
+                    span.set_attribute("lithos.write_status", "duplicate")
+                    dup = outcome.duplicate_of
+                    return {
+                        "status": "duplicate",
+                        "duplicate_of": {
+                            "id": dup.id,
+                            "title": dup.title,
+                            "source_url": dup.source_url,
+                        }
+                        if dup
+                        else None,
+                        "message": outcome.message,
+                        "warnings": list(outcome.warnings),
+                    }
+                if outcome.status in ("invalid_input", "version_conflict", "error"):
+                    span.set_attribute("lithos.write_status", outcome.status)
+                    error_response: dict[str, Any] = {
+                        "status": outcome.status,
+                        "message": outcome.message,
+                        "warnings": list(outcome.warnings),
+                    }
+                    if outcome.current_version is not None:
+                        error_response["current_version"] = outcome.current_version
+                    return error_response
+
+                doc = outcome.document
+                assert doc is not None
+                span.set_attribute("lithos.write_status", outcome.status)
+                logger.info(
+                    "lithos_note_update completed doc_id=%s status=%s", doc.id, outcome.status
+                )
                 return {
                     "status": outcome.status,
                     "id": doc.id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1581,8 +1581,10 @@ class TestNoteUpdateTool:
         assert updated.metadata.extra == {"b": 2}
 
     @pytest.mark.asyncio
-    async def test_empty_metadata_dict_is_noop(self, server: LithosServer):
-        """metadata={} is a no-op preserve, mirroring lithos_task_update."""
+    async def test_empty_metadata_dict_with_other_field_preserves_metadata(
+        self, server: LithosServer
+    ):
+        """metadata={} alongside another field makes no metadata change (preserve)."""
         doc = (
             await server.knowledge.create(
                 title="Keepable",
@@ -1599,6 +1601,21 @@ class TestNoteUpdateTool:
         assert result["status"] == "updated"
         updated = (await server.knowledge.read(id=doc.id))[0]
         assert updated.metadata.extra == {"keep": "this"}
+
+    @pytest.mark.asyncio
+    async def test_empty_metadata_dict_alone_is_invalid_input(self, server: LithosServer):
+        """metadata={} with no other field is rejected — not a version-bumping no-op."""
+        doc = (
+            await server.knowledge.create(title="NoNoop", content="Body.", agent="agent")
+        ).document
+        assert doc is not None
+        v0 = doc.metadata.version
+
+        result = await self._call_note_update(server, id=doc.id, agent="editor", metadata={})
+        assert result["status"] == "invalid_input"
+        # No revision was written: version is unchanged.
+        unchanged = (await server.knowledge.read(id=doc.id))[0]
+        assert unchanged.metadata.version == v0
 
     @pytest.mark.asyncio
     async def test_tags_and_status_and_title(self, server: LithosServer):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1530,6 +1530,168 @@ class TestWriteUpdateSentinel:
         assert updated.metadata.confidence == pytest.approx(0.95)
 
 
+class TestNoteUpdateTool:
+    """Tests for lithos_note_update — the metadata/tags-only note patch."""
+
+    async def _call_note_update(self, server: LithosServer, **kwargs) -> dict:
+        tool = await server.mcp.get_tool("lithos_note_update")
+        return await tool.fn(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_metadata_merge_leaves_body_untouched(self, server: LithosServer):
+        """A metadata patch merges per-key and never touches the body."""
+        doc = (
+            await server.knowledge.create(
+                title="Policy Doc",
+                content="The original body.",
+                agent="agent",
+                extra={"a": 1},
+            )
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(
+            server,
+            id=doc.id,
+            agent="editor",
+            metadata={"b": 2},
+        )
+
+        assert result["status"] == "updated"
+        assert result["version"] == doc.metadata.version + 1
+        updated = (await server.knowledge.read(id=doc.id))[0]
+        assert updated.metadata.extra == {"a": 1, "b": 2}
+        assert updated.content == "The original body."
+
+    @pytest.mark.asyncio
+    async def test_metadata_null_value_deletes_key(self, server: LithosServer):
+        """A per-key null deletes that key (mirrors lithos_task_update)."""
+        doc = (
+            await server.knowledge.create(
+                title="Deletable",
+                content="Body.",
+                agent="agent",
+                extra={"a": 1, "b": 2},
+            )
+        ).document
+        assert doc is not None
+
+        await self._call_note_update(server, id=doc.id, agent="editor", metadata={"a": None})
+        updated = (await server.knowledge.read(id=doc.id))[0]
+        assert updated.metadata.extra == {"b": 2}
+
+    @pytest.mark.asyncio
+    async def test_empty_metadata_dict_is_noop(self, server: LithosServer):
+        """metadata={} is a no-op preserve, mirroring lithos_task_update."""
+        doc = (
+            await server.knowledge.create(
+                title="Keepable",
+                content="Body.",
+                agent="agent",
+                extra={"keep": "this"},
+            )
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(
+            server, id=doc.id, agent="editor", metadata={}, tags=["t"]
+        )
+        assert result["status"] == "updated"
+        updated = (await server.knowledge.read(id=doc.id))[0]
+        assert updated.metadata.extra == {"keep": "this"}
+
+    @pytest.mark.asyncio
+    async def test_tags_and_status_and_title(self, server: LithosServer):
+        """tags replace, status sets, title renames — body preserved throughout."""
+        doc = (
+            await server.knowledge.create(
+                title="Original",
+                content="Body stays.",
+                agent="agent",
+                tags=["old"],
+            )
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(
+            server,
+            id=doc.id,
+            agent="editor",
+            title="Renamed",
+            tags=["new", "shiny"],
+            status="archived",
+        )
+        assert result["status"] == "updated"
+        updated = (await server.knowledge.read(id=doc.id))[0]
+        assert updated.title == "Renamed"
+        assert updated.metadata.tags == ["new", "shiny"]
+        assert updated.metadata.status == "archived"
+        assert updated.content == "Body stays."
+
+    @pytest.mark.asyncio
+    async def test_no_fields_returns_invalid_input(self, server: LithosServer):
+        """At least one mutable field must be provided."""
+        doc = (await server.knowledge.create(title="Doc", content="Body.", agent="agent")).document
+        assert doc is not None
+
+        result = await self._call_note_update(server, id=doc.id, agent="editor")
+        assert result["status"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_returns_note_not_found(self, server: LithosServer):
+        """An unknown id maps to a clean note_not_found envelope, not an exception."""
+        result = await self._call_note_update(
+            server,
+            id="99999999-9999-4999-8999-999999999999",
+            agent="editor",
+            tags=["x"],
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "note_not_found"
+
+    @pytest.mark.asyncio
+    async def test_version_conflict(self, server: LithosServer):
+        """A stale expected_version is rejected with version_conflict and current_version."""
+        doc = (
+            await server.knowledge.create(title="Versioned", content="Body.", agent="agent")
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(
+            server,
+            id=doc.id,
+            agent="editor",
+            metadata={"k": "v"},
+            expected_version=doc.metadata.version + 5,
+        )
+        assert result["status"] == "version_conflict"
+        assert result["current_version"] == doc.metadata.version
+
+    @pytest.mark.asyncio
+    async def test_reserved_metadata_key_rejected(self, server: LithosServer):
+        """A reserved frontmatter key in metadata is rejected as invalid_input."""
+        doc = (
+            await server.knowledge.create(title="Reserved", content="Body.", agent="agent")
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(
+            server, id=doc.id, agent="editor", metadata={"version": 99}
+        )
+        assert result["status"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_rejected(self, server: LithosServer):
+        """An out-of-enum status is rejected at the boundary."""
+        doc = (
+            await server.knowledge.create(title="StatusDoc", content="Body.", agent="agent")
+        ).document
+        assert doc is not None
+
+        result = await self._call_note_update(server, id=doc.id, agent="editor", status="bogus")
+        assert result["status"] == "invalid_input"
+
+
 class TestCacheLookup:
     """Integration tests for lithos_cache_lookup tool."""
 


### PR DESCRIPTION
## What

Add a note metadata/tags patch (lithos_note_update) — parity with lithos_task_update

## Summary

There is no way to patch a **note's** tags or metadata without re-sending its entire body. `lithos_write` requires `content`, so changing one frontmatter key means reading the note, holding its full body, and writing it all back. **Tasks** already have the affordance notes lack: `lithos_task_update` patches `title` / `description` / `tags` / `metadata` per-key with no body. Notes should have the same.

## Why it matters

- **Clobber / lost-update risk.** A metadata-only change forces a full-body round-trip. Any drift between read and write (a concurrent edit, an imperfect body reproduction) silently rewrites the body. `expected_version` guards against a stale base but still requires re-sending the whole body correctly.
- **Awkward for automation.** Agents that only want to flip a flag or add a config key (e.g. setting `develop_*` / `github_watch_enabled` on a project-context doc) must marshal the entire markdown body just to touch frontmatter.
- **Asymmetry.** `lithos_task_update` proves the pattern is wanted and already designed — notes are the outlier.

## Concrete motivating case

Setting story-develop policy on a `*-project-context.md` doc (add `develop_reviewers` / `develop_coder` / `develop_default_reviewers` keys) during lithos-loom operation. Today this needs a `lithos_read` → reconstruct `body` → `lithos_write(id, content=body, metadata={…}, expected_version=…)`. The metadata merge itself is already per-key and clean; the only friction is the mandatory `content`.

## Proposal

Either of:

1. **New tool `lithos_note_update(id, *, tags?, metadata?, title?, status?, expected_version?)`** — mirrors `lithos_task_update`: at least one mutable field required; `metadata` is an additive per-key merge (null value deletes a key); body untouched. Cleanest and most discoverable.
2. **Make `content` optional on `lithos_write` when `id` is present and only metadata/tags/status change** — a metadata/tags-only update path. Smaller surface, but overloads `lithos_write`'s create-or-replace semantics; the contract that `content` is authoritative for the body gets murkier.

Recommend (1) — a dedicated `note_update` with the same per-key merge contract as `task_update`, so the two surfaces are symmetric.

## Refs

- `lithos_task_update` (the existing per-key tag/metadata patch for tasks — the model to mirror).
- `lithos_write` metadata contract (already an additive per-key merge on update; only `content` being required is the gap).
- Surfaced 2026-06 while setting story-develop project policy from lithos-loom.

Closes #362

## Review

- verdicts: [code-quality]=FINDINGS
- rounds: 1
- test gate: RED
- agent cost: $2.88
- Lithos task: `46ebc886-aedf-4e10-8314-c04da80cd663`

Per-round commits are intentional (the dialogue history); squash-merge keeps main clean.

🤖 Generated by lithos-loom story-develop