### PR TITLE
refactor: fold CoordinationError into errors.py, add canonical envelope constructors

### DIFF
--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -24,7 +24,7 @@ LCMA            = ["lithos.lcma"]
 Events          = ["lithos.events"]
 Config          = ["lithos.config"]
 Telemetry       = ["lithos.telemetry"]
-Errors          = ["lithos.errors"]
+Errors          = ["lithos.errors", "lithos.envelopes"]
 Logging         = ["lithos.logging_config"]
 
 # Tiers are for diagram grouping + documentation of the forbidden-import contract.

--- a/docs/generated/architecture.md
+++ b/docs/generated/architecture.md
@@ -37,6 +37,7 @@ graph TD
   CognitiveMemory --> Search
   CognitiveMemory --> Telemetry
   Coordination --> Config
+  Coordination --> Errors
   Coordination --> Knowledge
   Coordination --> Telemetry
   Entrypoints --> CognitiveMemory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ source_modules = [
     "lithos.config",
     "lithos.telemetry",
     "lithos.errors",
+    "lithos.envelopes",
     "lithos.events",
     "lithos._merge",
     "lithos.edge_store",

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -14,6 +14,11 @@ import aiosqlite
 
 from lithos._merge import merge_metadata
 from lithos.config import LithosConfig, get_config
+
+# CoordinationError lives in lithos.errors (the shared taxonomy); this import
+# exists because this module raises it. That incidentally keeps
+# ``from lithos.coordination import CoordinationError`` working — that path is
+# not a maintained contract; import from ``lithos.errors``.
 from lithos.errors import CoordinationError
 from lithos.telemetry import lithos_metrics, traced
 

--- a/src/lithos/coordination.py
+++ b/src/lithos/coordination.py
@@ -14,6 +14,7 @@ import aiosqlite
 
 from lithos._merge import merge_metadata
 from lithos.config import LithosConfig, get_config
+from lithos.errors import CoordinationError
 from lithos.telemetry import lithos_metrics, traced
 
 logger = logging.getLogger(__name__)
@@ -66,20 +67,6 @@ INHERITABLE_CONTEXT_KEYS: tuple[str, ...] = ("priority", "parallelizable", "phas
 # is rejected so stale, scheduler-invisible dependency state cannot be recreated
 # through the additive metadata write path (see SPECIFICATION migration notes).
 FORBIDDEN_METADATA_KEYS: tuple[str, ...] = ("depends_on", "blocked_on")
-
-
-class CoordinationError(Exception):
-    """A coordination operation failed validation.
-
-    Carries a stable ``code`` and human ``message`` so the MCP layer can map it
-    onto the standard ``{"status": "error", "code", "message"}`` envelope without
-    re-deriving the reason.
-    """
-
-    def __init__(self, code: str, message: str):
-        self.code = code
-        self.message = message
-        super().__init__(message)
 
 
 def _reject_scheduling_metadata(metadata: dict[str, Any] | None) -> None:

--- a/src/lithos/envelopes.py
+++ b/src/lithos/envelopes.py
@@ -1,0 +1,41 @@
+"""Canonical MCP error-envelope constructors.
+
+Every MCP tool failure is expressed as one wire shape, built here and nowhere
+else::
+
+    {"status": "error", "code": "<stable_snake_case>", "message": "<sentence>"}
+
+``code`` is machine-stable — agents branch on it and never parse ``message``.
+Key order is part of the wire contract (dicts serialise in insertion order);
+do not reorder.
+
+Success envelopes remain per-tool: they are the tool's result shape, not a
+shared failure contract. Actionable write *outcomes* (``duplicate``,
+``slug_collision``, ``path_collision``, ``version_conflict``) are also not
+errors — they carry payloads agents act on and keep their own top-level
+statuses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lithos.errors import CoordinationError
+
+
+def error_envelope(code: str, message: str, **extra: Any) -> dict[str, Any]:
+    """Build the canonical error envelope.
+
+    ``extra`` allows documented code-specific supplementary keys; they are
+    appended after the three canonical keys.
+    """
+    return {"status": "error", "code": code, "message": message, **extra}
+
+
+def coordination_error_envelope(exc: CoordinationError) -> dict[str, Any]:
+    """Map a :class:`~lithos.errors.CoordinationError` onto the canonical envelope.
+
+    The single construction point for the mapping the exception was designed
+    for — handlers must not restate the dict.
+    """
+    return error_envelope(exc.code, exc.message)

--- a/src/lithos/envelopes.py
+++ b/src/lithos/envelopes.py
@@ -22,13 +22,18 @@ from typing import Any
 
 from lithos.errors import CoordinationError
 
+_CANONICAL_KEYS = frozenset({"status", "code", "message"})
+
 
 def error_envelope(code: str, message: str, **extra: Any) -> dict[str, Any]:
     """Build the canonical error envelope.
 
     ``extra`` allows documented code-specific supplementary keys; they are
-    appended after the three canonical keys.
+    appended after the three canonical keys and may not override them.
     """
+    overridden = _CANONICAL_KEYS & extra.keys()
+    if overridden:
+        raise ValueError(f"extra must not override canonical envelope keys: {sorted(overridden)}")
     return {"status": "error", "code": code, "message": message, **extra}
 
 

--- a/src/lithos/envelopes.py
+++ b/src/lithos/envelopes.py
@@ -1,13 +1,16 @@
 """Canonical MCP error-envelope constructors.
 
-Every MCP tool failure is expressed as one wire shape, built here and nowhere
-else::
+The canonical failure shape is built here::
 
     {"status": "error", "code": "<stable_snake_case>", "message": "<sentence>"}
 
 ``code`` is machine-stable — agents branch on it and never parse ``message``.
 Key order is part of the wire contract (dicts serialise in insertion order);
 do not reorder.
+
+Legacy divergent shapes (the ``status: "invalid_input"`` + ``warnings``
+dialect in the write family) still exist at some handlers until the envelope
+normalization lands; new error paths must use these constructors.
 
 Success envelopes remain per-tool: they are the tool's result shape, not a
 shared failure contract. Actionable write *outcomes* (``duplicate``,

--- a/src/lithos/errors.py
+++ b/src/lithos/errors.py
@@ -68,6 +68,20 @@ class IndexingError(LithosError):
         return f"{super().__str__()} [{detail}]"
 
 
+class CoordinationError(LithosError):
+    """A coordination operation failed validation.
+
+    Carries a stable ``code`` and human ``message`` so the MCP layer can map it
+    onto the standard ``{"status": "error", "code", "message"}`` envelope without
+    re-deriving the reason.
+    """
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
 class CognitiveMemoryError(LithosError):
     """Base error for any failure originating inside CognitiveMemory.
 

--- a/src/lithos/errors.py
+++ b/src/lithos/errors.py
@@ -76,7 +76,7 @@ class CoordinationError(LithosError):
     re-deriving the reason.
     """
 
-    def __init__(self, code: str, message: str):
+    def __init__(self, code: str, message: str) -> None:
         self.code = code
         self.message = message
         super().__init__(message)

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -20,9 +20,10 @@ from starlette.responses import Response, StreamingResponse
 
 from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig, get_config, set_config
-from lithos.coordination import CoordinationError, CoordinationService, Task, TaskStatus
+from lithos.coordination import CoordinationService, Task, TaskStatus
 from lithos.edge_store import EdgeStore
-from lithos.errors import SearchBackendError
+from lithos.envelopes import coordination_error_envelope, error_envelope
+from lithos.errors import CoordinationError, SearchBackendError
 from lithos.events import (
     AGENT_REGISTERED,
     FINDING_POSTED,
@@ -307,14 +308,10 @@ class LithosServer:
             receipt = await self.memory.get_receipt(receipt_id, task_id)
             if receipt is None:
                 return (
-                    {
-                        "status": "error",
-                        "code": "receipt_not_found",
-                        "message": (
-                            f"Receipt '{receipt_id}' not found or does not "
-                            f"belong to task '{task_id}'."
-                        ),
-                    },
+                    error_envelope(
+                        "receipt_not_found",
+                        f"Receipt '{receipt_id}' not found or does not belong to task '{task_id}'.",
+                    ),
                     None,
                 )
         else:
@@ -1576,11 +1573,7 @@ class LithosServer:
                     outcome = await self.intake.note_update(agent, request)
                 except FileNotFoundError:
                     span.set_attribute("lithos.write_status", "note_not_found")
-                    return {
-                        "status": "error",
-                        "code": "note_not_found",
-                        "message": f"Note {id} not found",
-                    }
+                    return error_envelope("note_not_found", f"Note {id} not found")
 
                 if outcome.status == "slug_collision":
                     span.set_attribute("lithos.write_status", "slug_collision")
@@ -1664,11 +1657,7 @@ class LithosServer:
                         max_length=max_length,
                     )
                 except FileNotFoundError as e:
-                    return {
-                        "status": "error",
-                        "code": "doc_not_found",
-                        "message": str(e),
-                    }
+                    return error_envelope("doc_not_found", str(e))
 
                 # Audit log — awaited so the write is committed before we query
                 # retrieval_count (avoids TOCTOU off-by-one). lithos_search uses
@@ -1728,11 +1717,7 @@ class LithosServer:
 
                 outcome = await self.intake.delete(agent, DeleteRequest(id=id))
                 if outcome.status == "not_found":
-                    return {
-                        "status": "error",
-                        "code": "doc_not_found",
-                        "message": f"Document not found: {id}",
-                    }
+                    return error_envelope("doc_not_found", f"Document not found: {id}")
                 return {"success": True}
 
         @self.mcp.tool()
@@ -1801,11 +1786,10 @@ class LithosServer:
 
                 valid_modes = {"hybrid", "fulltext", "semantic", "graph"}
                 if mode not in valid_modes:
-                    return {
-                        "status": "error",
-                        "code": "invalid_mode",
-                        "message": f"Unknown search mode {mode!r}. Valid values: hybrid, fulltext, semantic, graph.",
-                    }
+                    return error_envelope(
+                        "invalid_mode",
+                        f"Unknown search mode {mode!r}. Valid values: hybrid, fulltext, semantic, graph.",
+                    )
 
                 # Entities are not a per-backend filter: resolve the candidate
                 # set once from the knowledge inverted index (#316) and
@@ -1970,11 +1954,7 @@ class LithosServer:
                 # itself stays free of envelope concerns.
                 if not self._config.lcma.enabled:
                     logger.warning("lithos_retrieve: LCMA is disabled")
-                    return {
-                        "status": "error",
-                        "code": "lcma_disabled",
-                        "message": "LCMA is disabled via configuration",
-                    }
+                    return error_envelope("lcma_disabled", "LCMA is disabled via configuration")
 
                 result = await self.memory.retrieve(
                     query=query,
@@ -2040,19 +2020,14 @@ class LithosServer:
                 span.set_attribute("lithos.tool", "lithos_edge_upsert")
 
                 if not namespace:
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": "namespace is required",
-                    }
+                    return error_envelope("invalid_input", "namespace is required")
 
                 # Validate evidence type
                 if evidence is not None and not isinstance(evidence, (dict, list)):
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": "evidence must be a dict, list, or null — scalars are not accepted",
-                    }
+                    return error_envelope(
+                        "invalid_input",
+                        "evidence must be a dict, list, or null — scalars are not accepted",
+                    )
 
                 evidence_str = json.dumps(evidence) if evidence is not None else None
 
@@ -2257,11 +2232,9 @@ class LithosServer:
                             path_prefix=path_prefix,
                         )
                     except SearchBackendError as exc:
-                        return {
-                            "status": "error",
-                            "code": "search_backend_error",
-                            "message": f"Full-text search failed: {exc}",
-                        }
+                        return error_envelope(
+                            "search_backend_error", f"Full-text search failed: {exc}"
+                        )
 
                     # Apply the filters Tantivy doesn't handle: ``since``,
                     # ``title_contains`` and ``metadata_match``. Consult the
@@ -2444,11 +2417,7 @@ class LithosServer:
                 span.set_attribute("lithos.id", id)
 
                 if not self.knowledge.has_document(id):
-                    return {
-                        "status": "error",
-                        "code": "doc_not_found",
-                        "message": f"Document not found: {id}",
-                    }
+                    return error_envelope("doc_not_found", f"Document not found: {id}")
 
                 requested = include if include is not None else list(_RELATED_INCLUDES)
                 selected = [k for k in _RELATED_INCLUDES if k in requested]
@@ -2725,7 +2694,7 @@ class LithosServer:
                     )
                 except CoordinationError as exc:
                     span.set_attribute("lithos.success", False)
-                    return {"status": "error", "code": exc.code, "message": exc.message}
+                    return coordination_error_envelope(exc)
                 span.set_attribute("lithos.task_id", task_id)
 
                 await self._emit(
@@ -2776,11 +2745,10 @@ class LithosServer:
                 Dict with success and message
             """
             if title is None and description is None and tags is None and metadata is None:
-                return {
-                    "status": "error",
-                    "code": "invalid_input",
-                    "message": "At least one of title, description, tags, or metadata must be provided",
-                }
+                return error_envelope(
+                    "invalid_input",
+                    "At least one of title, description, tags, or metadata must be provided",
+                )
 
             logger.info("lithos_task_update task=%s agent=%s", task_id, agent)
             tracer = get_tracer()
@@ -2799,7 +2767,7 @@ class LithosServer:
                     )
                 except CoordinationError as exc:
                     span.set_attribute("lithos.success", False)
-                    return {"status": "error", "code": exc.code, "message": exc.message}
+                    return coordination_error_envelope(exc)
                 span.set_attribute("lithos.success", updated)
 
                 if updated:
@@ -2811,11 +2779,7 @@ class LithosServer:
                         )
                     )
                     return {"success": True, "message": f"Task {task_id} updated"}
-                return {
-                    "status": "error",
-                    "code": "task_not_found",
-                    "message": f"Task {task_id} not found",
-                }
+                return error_envelope("task_not_found", f"Task {task_id} not found")
 
         @self.mcp.tool()
         @tool_metrics()
@@ -2852,14 +2816,11 @@ class LithosServer:
                 span.set_attribute("lithos.success", success)
 
                 if not success:
-                    return {
-                        "status": "error",
-                        "code": "claim_failed",
-                        "message": (
-                            f"Could not claim aspect '{aspect}' on task '{task_id}': "
-                            "task not found, not open, or aspect already claimed by another agent."
-                        ),
-                    }
+                    return error_envelope(
+                        "claim_failed",
+                        f"Could not claim aspect '{aspect}' on task '{task_id}': "
+                        "task not found, not open, or aspect already claimed by another agent.",
+                    )
 
                 await self._emit(
                     LithosEvent(
@@ -2909,14 +2870,11 @@ class LithosServer:
                 span.set_attribute("lithos.success", success)
 
                 if not success:
-                    return {
-                        "status": "error",
-                        "code": "claim_not_found",
-                        "message": (
-                            f"No active claim found for task '{task_id}', "
-                            f"aspect '{aspect}', agent '{agent}'."
-                        ),
-                    }
+                    return error_envelope(
+                        "claim_not_found",
+                        f"No active claim found for task '{task_id}', "
+                        f"aspect '{aspect}', agent '{agent}'.",
+                    )
 
                 return {
                     "success": True,
@@ -2955,14 +2913,11 @@ class LithosServer:
                 span.set_attribute("lithos.success", success)
 
                 if not success:
-                    return {
-                        "status": "error",
-                        "code": "claim_not_found",
-                        "message": (
-                            f"No matching claim found for task '{task_id}', "
-                            f"aspect '{aspect}', agent '{agent}'."
-                        ),
-                    }
+                    return error_envelope(
+                        "claim_not_found",
+                        f"No matching claim found for task '{task_id}', "
+                        f"aspect '{aspect}', agent '{agent}'.",
+                    )
 
                 await self._emit(
                     LithosEvent(
@@ -3044,11 +2999,9 @@ class LithosServer:
                 span.set_attribute("lithos.success", success)
 
                 if not success:
-                    return {
-                        "status": "error",
-                        "code": "task_not_found",
-                        "message": f"Task '{task_id}' not found or not in an open state.",
-                    }
+                    return error_envelope(
+                        "task_not_found", f"Task '{task_id}' not found or not in an open state."
+                    )
 
                 # -- Apply reinforcement side-effects after task is completed --
                 if validated is not None:
@@ -3126,11 +3079,9 @@ class LithosServer:
                     )
                     return {"success": True}
 
-                return {
-                    "status": "error",
-                    "code": "task_not_found",
-                    "message": f"Task {task_id} not found or already closed",
-                }
+                return error_envelope(
+                    "task_not_found", f"Task {task_id} not found or already closed"
+                )
 
         @self.mcp.tool()
         @tool_metrics()
@@ -3171,7 +3122,7 @@ class LithosServer:
                     )
                 except CoordinationError as exc:
                     span.set_attribute("lithos.success", False)
-                    return {"status": "error", "code": exc.code, "message": exc.message}
+                    return coordination_error_envelope(exc)
 
                 # Durable audit: a queryable finding recording the prior terminal state.
                 summary = f"[Reopened] task reopened (was {prior_status})"
@@ -3351,7 +3302,7 @@ class LithosServer:
                     )
                 except CoordinationError as exc:
                     span.set_attribute("lithos.success", False)
-                    return {"status": "error", "code": exc.code, "message": exc.message}
+                    return coordination_error_envelope(exc)
                 return {"success": True}
 
         @self.mcp.tool()
@@ -3378,14 +3329,10 @@ class LithosServer:
                 span.set_attribute("lithos.tool", "lithos_task_edge_list")
                 span.set_attribute("lithos.task_id", task_id)
                 if direction not in ("incoming", "outgoing", "both"):
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": (
-                            f"direction must be 'incoming', 'outgoing', or 'both', got "
-                            f"{direction!r}."
-                        ),
-                    }
+                    return error_envelope(
+                        "invalid_input",
+                        f"direction must be 'incoming', 'outgoing', or 'both', got {direction!r}.",
+                    )
                 edges = await self.coordination.list_task_edges(
                     task_id=task_id,
                     direction=direction,
@@ -3432,11 +3379,7 @@ class LithosServer:
             with tracer.start_as_current_span("lithos.tool.task_ready") as span:
                 span.set_attribute("lithos.tool", "lithos_task_ready")
                 if limit < 1:
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": f"limit must be >= 1, got {limit}.",
-                    }
+                    return error_envelope("invalid_input", f"limit must be >= 1, got {limit}.")
                 if metadata_match is not None:
                     try:
                         validate_metadata_match(metadata_match)
@@ -3483,11 +3426,7 @@ class LithosServer:
             with tracer.start_as_current_span("lithos.tool.task_blocked") as span:
                 span.set_attribute("lithos.tool", "lithos_task_blocked")
                 if limit < 1:
-                    return {
-                        "status": "error",
-                        "code": "invalid_input",
-                        "message": f"limit must be >= 1, got {limit}.",
-                    }
+                    return error_envelope("invalid_input", f"limit must be >= 1, got {limit}.")
                 if metadata_match is not None:
                     try:
                         validate_metadata_match(metadata_match)
@@ -3604,7 +3543,7 @@ class LithosServer:
                     )
                 except CoordinationError as exc:
                     span.set_attribute("lithos.success", False)
-                    return {"status": "error", "code": exc.code, "message": exc.message}
+                    return coordination_error_envelope(exc)
                 span.set_attribute("lithos.task_id", task_id)
                 await self._emit(
                     LithosEvent(
@@ -3686,11 +3625,7 @@ class LithosServer:
 
                 task = await self.coordination.get_task(task_id)
                 if task is None:
-                    return {
-                        "status": "error",
-                        "code": "task_not_found",
-                        "message": f"Task '{task_id}' not found.",
-                    }
+                    return error_envelope("task_not_found", f"Task '{task_id}' not found.")
 
                 return {"task": _serialize_task_record(task)}
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -7,7 +7,8 @@ import aiosqlite
 import pytest
 
 from lithos.config import LithosConfig, StorageConfig
-from lithos.coordination import CoordinationError, CoordinationService
+from lithos.coordination import CoordinationService
+from lithos.errors import CoordinationError
 
 
 class TestAgentRegistry:

--- a/tests/test_envelope_boundary.py
+++ b/tests/test_envelope_boundary.py
@@ -1,0 +1,64 @@
+"""Server-boundary regression tests for exact error-envelope payloads.
+
+The envelope constructors are unit-tested in ``test_envelopes.py``; these
+tests pin the *wire* result — exact keys, key order, and values — for
+representative handlers that adopted the constructors, proving the adoption
+changed no bytes at the MCP boundary.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from lithos.server import LithosServer
+
+pytestmark = pytest.mark.integration
+
+
+async def _call_tool(server: LithosServer, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Call an MCP tool and return its JSON payload."""
+    result = await server.mcp._call_tool_mcp(name, arguments)
+    if isinstance(result, tuple):
+        payload = result[1]
+        if isinstance(payload, dict):
+            return payload
+    content = getattr(result, "content", []) if hasattr(result, "content") else result
+    if isinstance(content, list) and content:
+        text = getattr(content[0], "text", None)
+        if isinstance(text, str):
+            return json.loads(text)
+    raise AssertionError(f"Unable to decode MCP result for tool {name!r}: {result!r}")
+
+
+class TestCanonicalEnvelopeAtBoundary:
+    async def test_task_get_not_found_exact_payload_and_key_order(self, server: LithosServer):
+        result = await _call_tool(server, "lithos_task_get", {"task_id": "ghost"})
+
+        assert result == {
+            "status": "error",
+            "code": "task_not_found",
+            "message": "Task 'ghost' not found.",
+        }
+        assert list(result) == ["status", "code", "message"]
+
+    async def test_task_create_invalid_type_maps_coordination_error(self, server: LithosServer):
+        result = await _call_tool(
+            server,
+            "lithos_task_create",
+            {"title": "t", "agent": "a", "task_type": "bogus"},
+        )
+
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_task_type"
+        assert list(result) == ["status", "code", "message"]
+
+    async def test_task_ready_invalid_limit_exact_payload(self, server: LithosServer):
+        result = await _call_tool(server, "lithos_task_ready", {"limit": 0})
+
+        assert result == {
+            "status": "error",
+            "code": "invalid_input",
+            "message": "limit must be >= 1, got 0.",
+        }
+        assert list(result) == ["status", "code", "message"]

--- a/tests/test_envelopes.py
+++ b/tests/test_envelopes.py
@@ -1,0 +1,44 @@
+"""Unit tests for the canonical error-envelope constructors."""
+
+from lithos.envelopes import coordination_error_envelope, error_envelope
+from lithos.errors import CoordinationError, LithosError
+
+
+class TestErrorEnvelope:
+    def test_canonical_shape_and_key_order(self):
+        envelope = error_envelope("doc_not_found", "Document not found: abc")
+
+        assert envelope == {
+            "status": "error",
+            "code": "doc_not_found",
+            "message": "Document not found: abc",
+        }
+        # Key order is wire contract: dicts serialise in insertion order.
+        assert list(envelope) == ["status", "code", "message"]
+
+    def test_supplementary_keys_appended_after_canonical_keys(self):
+        envelope = error_envelope("version_conflict", "stale write", current_version=7)
+
+        assert envelope["current_version"] == 7
+        assert list(envelope) == ["status", "code", "message", "current_version"]
+
+
+class TestCoordinationErrorEnvelope:
+    def test_maps_code_and_message(self):
+        exc = CoordinationError("task_not_found", "Task 'x' not found.")
+
+        assert coordination_error_envelope(exc) == {
+            "status": "error",
+            "code": "task_not_found",
+            "message": "Task 'x' not found.",
+        }
+
+
+class TestCoordinationErrorTaxonomy:
+    def test_is_a_lithos_error(self):
+        exc = CoordinationError("cycle", "edge would create a cycle")
+
+        assert isinstance(exc, LithosError)
+        assert exc.code == "cycle"
+        assert exc.message == "edge would create a cycle"
+        assert str(exc) == "edge would create a cycle"

--- a/tests/test_envelopes.py
+++ b/tests/test_envelopes.py
@@ -1,5 +1,7 @@
 """Unit tests for the canonical error-envelope constructors."""
 
+import pytest
+
 from lithos.envelopes import coordination_error_envelope, error_envelope
 from lithos.errors import CoordinationError, LithosError
 
@@ -21,6 +23,14 @@ class TestErrorEnvelope:
 
         assert envelope["current_version"] == 7
         assert list(envelope) == ["status", "code", "message", "current_version"]
+
+    def test_extra_cannot_override_canonical_keys(self):
+        # "status" is only reachable through **extra — the guard rejects it.
+        with pytest.raises(ValueError, match="canonical envelope keys"):
+            error_envelope("some_code", "msg", status="ok")
+        # "code"/"message" collide with the named parameters before **extra.
+        with pytest.raises(TypeError):
+            error_envelope("some_code", "msg", code="other")  # type: ignore[call-arg]
 
 
 class TestCoordinationErrorEnvelope:

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -11,7 +11,8 @@ import aiosqlite
 import pytest
 
 from lithos.config import LithosConfig
-from lithos.coordination import CoordinationError, CoordinationService
+from lithos.coordination import CoordinationService
+from lithos.errors import CoordinationError
 from lithos.server import LithosServer
 
 pytestmark = pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR 1 of 6 from the 2026-07 architecture review (issue #200 / tracker task `9f2be54f`): the no-wire-change groundwork for the MCP tool-handler extraction.

- **`CoordinationError` → `lithos.errors`**, now a `LithosError` subclass. It was the one exception designed for the MCP envelope seam (`.code`/`.message`) yet sat outside the taxonomy. No deliberate aliases or re-exports; the three importers are updated. (`from lithos.coordination import CoordinationError` still resolves — coordination.py legitimately imports the class to raise it — but that path is incidental, not a maintained contract; a comment on the import says so.) Safe: nothing anywhere catches `LithosError`, so no isinstance behaviour changes.
- **New Foundation module `lithos.envelopes`** — `error_envelope(code, message, **extra)` and `coordination_error_envelope(exc)` become the single construction point for the canonical `{"status": "error", "code", "message"}` shape. Foundation placement so Core modules (e.g. `cognitive_memory`) can adopt it later without violating the layering contract.
- **`server.py` adopts the constructors** at every already-canonical error site (~21 literal dicts + the 5 verbatim `except CoordinationError` mappings). Net −65 lines.
- **Guardrails**: `lithos.envelopes` added to the import-linter Foundation contract and `docs/architecture.toml` (Errors component); component diagram regenerated via `make diagrams`.

**Zero wire change** — key order and envelope bytes are identical. The breaking normalization of the divergent `invalid_input`/`warnings` shapes is PR 2, deliberately separate.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — 0 errors
- [x] `make test` — 1472 passed
- [x] `make test-integration` — 395/396 passed; the single failure (`test_start_and_stop_watch_intake_is_idempotent`) is local-environment inotify exhaustion (`OSError: [Errno 24] inotify instance limit reached`; the dev box sits at 149/128 `max_user_instances` from desktop apps), unrelated to this diff — expecting green in CI
- [x] New `tests/test_envelopes.py` covers envelope shape, key order, supplementary keys, and the `LithosError` taxonomy membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)
