### PR TITLE
fix(agent-skills): unblock plugin publish — verbatim manifest versions, both plugins to 0.1.2

### DIFF
--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -19,8 +19,11 @@ jobs:
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
+      # Publishes the version committed in each plugin manifest verbatim.
+      # Changing a plugin means bumping its manifest version in the same PR;
+      # an already-published version fails loudly here as the reminder.
       - name: Publish plugins
         working-directory: agent-skills
         run: |
-          tessl plugin publish ./plugins/lithos --bump patch
-          tessl plugin publish ./plugins/influx-inbox --bump patch
+          tessl plugin publish ./plugins/lithos
+          tessl plugin publish ./plugins/influx-inbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## [0.4.0] — 2026-07-06
 
 ### BREAKING — MCP error envelopes normalized (0.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.0] — 2026-07-06
 
 ### BREAKING — MCP error envelopes normalized (0.4.0)
 

--- a/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/influx-inbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use when an agent needs to submit a URL or PDF to the Influx inbox for ingestion into the Lithos knowledge base. Covers creating the required influx:inbox task, mandatory metadata fields (kind, url/local_path, submitted_by, source_tag), validation rules, and how to check ingestion results.",
   "private": true
 }

--- a/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/influx-inbox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Use when an agent needs to submit a URL or PDF to the Influx inbox for ingestion into the Lithos knowledge base. Covers creating the required influx:inbox task, mandatory metadata fields (kind, url/local_path, submitted_by, source_tag), validation rules, and how to check ingestion results.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/lithos",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle, project conventions, and tagging.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/lithos",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle, project conventions, and tagging.",
   "private": true
 }


### PR DESCRIPTION
## Summary

The **Publish Agent Skills** workflow failed on the #371 merge commit ([run 28826952634](https://github.com/agent-lore/lithos/actions/runs/28826952634)):

```
✘ Bumped version 0.1.1 also already exists. Manually set the version in the manifest.
```

**Cause.** The workflow published with `tessl plugin publish --bump patch`, deriving the target version by incrementing the committed manifest on every trigger — the bump was never written back to the repo. The registry already holds `agent-lore/lithos` 0.1.0 and 0.1.1 (the 2026-06-08 run bumped 0.1.0 → 0.1.1), so every subsequent trigger re-derived 0.1.1 and collided. `influx-inbox` is in the identical state and escaped the failure only because the step aborted on the lithos command first. Structurally, `--bump` kept the committed manifest permanently one version behind the registry, and any two publishes without an interleaved manifest bump collided.

**Fix.** Publish the manifest version verbatim (drop `--bump patch`) and set both manifests to `0.1.2` — the next free version in both registries. This makes the manifest truthful, makes the workflow idempotent per commit, and turns the failure mode into a clear convention: changing a plugin means bumping its manifest version in the same PR; forgetting it fails loudly on the publish run (a comment in the workflow documents this). The 0.1.2 publish ships the 0.4.0 error-contract updates to `references/error-handling.md` that failed to publish with #371.

Also included (offered alongside): stamp the CHANGELOG `## Unreleased` heading as `## [0.4.0] — 2026-07-06` to match the cut release.

## Test plan

- [x] `make check` green locally (JSON/YAML/markdown-only change)
- [ ] Post-merge: **Publish Agent Skills** run publishes `agent-lore/lithos` 0.1.2 and `agent-lore/influx-inbox` 0.1.2 (the real verification — `tessl publish` needs the CI token, so it can't be exercised locally)
