### PR TITLE
docs(agent-skills): update lithos skill for task graph, reopen, metadata, and 0.4.0 envelopes

### DIFF
--- a/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/influx-inbox/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/influx-inbox",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Use when an agent needs to submit a URL or PDF to the Influx inbox for ingestion into the Lithos knowledge base. Covers creating the required influx:inbox task, mandatory metadata fields (kind, url/local_path, submitted_by, source_tag), validation rules, and how to check ingestion results.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/lithos",
-  "version": "0.1.2",
-  "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle, project conventions, and tagging.",
+  "version": "0.2.0",
+  "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, model task dependencies with the task graph (blocking edges, subtasks/epics, gates), claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle and task graph, project conventions, and tagging.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/skills/lithos/SKILL.md
+++ b/agent-skills/plugins/lithos/skills/lithos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lithos
 description: |
-  Use when working with Lithos via MCP for agent coordination, shared knowledge base access, or work queue management. Covers searching or writing knowledge, creating or coordinating tasks, claiming work before starting, posting findings, and multi-agent collaboration. Full workflow: register, search-before-work, knowledge read/write, task lifecycle, project conventions, and tagging.
+  Use when working with Lithos via MCP for agent coordination, shared knowledge base access, or work queue management. Covers searching or writing knowledge, creating or coordinating tasks, task dependencies and task graphs (blocking edges, subtasks/epics, gates), claiming work before starting, posting findings, and multi-agent collaboration. Full workflow: register, search-before-work, knowledge read/write, task lifecycle and task graph, project conventions, and tagging.
 ---
 
 # Lithos
@@ -13,7 +13,8 @@ Lithos is a shared knowledge base and task coordination system for multi-agent w
 Load this skill when you need to:
 - Search for existing knowledge before starting work
 - Read or write knowledge documents
-- Create, claim, complete, or cancel tasks
+- Create, claim, complete, cancel, or reopen tasks
+- Model dependencies between tasks, or find what's ready to work on (task graph)
 - Post findings during task execution
 - Coordinate with other agents (check who's active, what's claimed)
 - Work within a project using `project:<slug>` conventions
@@ -41,7 +42,7 @@ Do not re-research or re-solve something another agent already documented. If yo
 lithos_task_list(status="open", with_claims=True)
 lithos_agent_list()
 ```
-Check before starting a task — someone may already be working on it.
+Check before starting a task — someone may already be working on it. Look up a specific agent with `lithos_agent_info(id="...")`.
 
 ## Core Workflows
 
@@ -53,11 +54,12 @@ Check before starting a task — someone may already be working on it.
 5. `lithos_edge_upsert(...)` — link to source docs if applicable
 
 ### Task Execution
-1. `lithos_task_list(status="open", with_claims=True)` — find unclaimed tasks
+1. `lithos_task_ready()` — find tasks that are unblocked and workable (filter with `project=` or `tags=`). Ready ≠ unclaimed — check the attached claims
 2. `lithos_task_claim(task_id=..., aspect="<aspect>", agent="<id>", ttl_minutes=60)` — claim before starting
 3. `lithos_retrieve(query="<topic>", task_id=...)` — retrieve relevant knowledge
 4. Do the work, posting interim results with `lithos_finding_post(...)`
-5. `lithos_task_complete(task_id=..., agent="<id>", outcome="...", cited_nodes=[...])` — complete with feedback
+5. `lithos_task_spawn(source_task_id=..., title="...", agent="<id>")` — capture follow-up work discovered along the way
+6. `lithos_task_complete(task_id=..., agent="<id>", outcome="...", cited_nodes=[...])` — complete with feedback; returns `unblocked` (tasks made ready)
 
 ### Create a New Task
 ```
@@ -66,10 +68,14 @@ lithos_task_create(
     agent="<your-id>",
     description="...",
     tags=["project:<slug>"],
-    metadata={"project": "<slug>", "priority": "medium"}
+    metadata={"project": "<slug>", "priority": "medium"},
+    depends_on=["<prereq-task-id>"],   # optional — creates blocking edges
+    parent_task_id="<epic-id>"         # optional — creates a hierarchy edge
 )
 ```
 Always set **both** `tags=["project:<slug>"]` and `metadata={"project": "<slug>"}` — different agents query by each convention.
+
+`task_type` defaults to `"task"`; use `"epic"` for roll-up containers and `"gate"` for external waits — see `references/task-graph.md`.
 
 ### Capture a Finding or Idea
 - **Finding** (during a task): `lithos_finding_post(task_id=..., agent="<id>", summary="...")`
@@ -85,6 +91,10 @@ Always set **both** `tags=["project:<slug>"]` and `metadata={"project": "<slug>"
 | Find docs about X in project Y | `lithos_list(content_query="X", tags=["project:Y"])` |
 | Best knowledge for task Z | `lithos_retrieve(query="...", task_id="Z")` |
 | What's related to this doc? | `lithos_related(id="<uuid>")` |
+| What can I work on right now? | `lithos_task_ready(project="<slug>")` |
+| Why is this task stuck? | `lithos_task_blocked(project="<slug>")` |
+| Found follow-up work mid-task | `lithos_task_spawn(source_task_id=..., title="...", agent="<id>")` |
+| Fix a note's tags/metadata without resending the body | `lithos_note_update(id=..., agent="<id>", ...)` |
 
 Use `lithos_retrieve` (not `lithos_search`) when quality matters — it runs multi-scout retrieval with reranking. Use `lithos_search` for quick exploration.
 
@@ -112,6 +122,8 @@ Use `lithos_retrieve` (not `lithos_search`) when quality matters — it runs mul
 | `concept` | Project contexts, definitions, stable reference |
 | `task_record` | Task logs (ranked lowest — noisy by nature) |
 
+**Maintaining existing notes:** to change only tags, metadata, title, or status on a note, use `lithos_note_update(id=..., agent=..., ...)` — no need to resend the body via `lithos_write` (avoids the read–reconstruct–write round-trip). Remove a note entirely with `lithos_delete(id=..., agent=...)`.
+
 ## Project Conventions
 
 Lithos has no first-class project entity. Projects are represented through conventions:
@@ -132,16 +144,17 @@ Run both task queries and union results — no single query covers all agents' c
 
 - **Claim before acting** — `lithos_task_claim(...)`, then do the work
 - **Renew before expiry** — claims expire (default 60 min, max 480). Use `lithos_task_renew(...)` if work runs long
-- **Terminal states are final** — no reopen primitive. Post `[ReopenRequested]` finding if a task needs revisiting
+- **Reopen when needed** — `lithos_task_reopen(task_id=..., agent=...)` moves a completed/cancelled task back to open (clears the outcome, auto-posts a `[Reopened]` finding). Post a `[ReopenRequested]` finding instead when the decision belongs to the task owner
 - **Always provide feedback on complete** — `cited_nodes` and `misleading_nodes` improve the KB over time
-- **Claim denied = `{success: false}`** — not an error; another agent holds it. Try another task or wait
+- **Claim denied = `{status: "error", code: "claim_failed"}`** — normal contention, not a fault; another agent holds it or the task is closed. Try another task or wait
 
 ## Pitfalls
 
 - **Don't skip the search step** — the most common mistake. Always `lithos_cache_lookup` or `lithos_search` before writing new knowledge
 - **Don't use `lithos_search` when quality matters** — it doesn't enforce access scopes or track salience. Use `lithos_retrieve` for actual work
 - **Don't set only tags OR only metadata on tasks** — set both. Loom queries by `metadata.project`; Agent Zero queries by tag
-- **`metadata` reserved keys** — don't use: `id, title, author, created_at, updated_at, tags, confidence, source_url, version, status`. They'll return `invalid_input`
+- **Don't put `depends_on` or `blocked_on` in task metadata** — rejected with `invalid_metadata_key`. Dependencies are first-class: use the `depends_on` parameter on `lithos_task_create`, or `lithos_task_edge_upsert`
+- **`metadata` reserved keys** — free-form note metadata keys must not collide with reserved frontmatter fields (`id`, `title`, `tags`, `status`, `note_type`, ...) or they return `invalid_input`. Full list in `references/error-handling.md`
 - **Shell escaping** — if using a CLI wrapper, content with backticks or JSON breaks arg parsing. Write to a temp file instead
 - **Optimistic concurrency** — use `expected_version` on updates when concurrent edits are possible. On conflict, re-read and retry
 
@@ -168,5 +181,6 @@ For deeper detail, load these references on demand:
 
 - `references/search-and-retrieval.md` — full decision matrix, LCMA scout weights, retrieval tuning
 - `references/task-coordination.md` — claim patterns, finding conventions, feedback mechanics
+- `references/task-graph.md` — dependencies, ready/blocked frontier, epics and subtasks, spawning, gates
 - `references/project-conventions.md` — project context docs, slug format, idea lifecycle, tagging
 - `references/error-handling.md` — all error codes, collision types, retry patterns

--- a/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
@@ -15,16 +15,21 @@ errors (MCP `ToolError`) occur only when a request is rejected by schema
 validation before the handler runs, or on unexpected internal exceptions.
 
 Common codes (illustrative, not exhaustive — any tool may return other codes,
-always in the same shape; e.g. `invalid_mode`, `invalid_metadata_key`,
-`self_edge`, `cycle`):
+always in the same shape; task-graph tools also emit `invalid_edge_type`,
+`self_edge`, `cycle`, `not_a_gate`, `parent_exists`, `invalid_relation_type`,
+`invalid_task_type` — see `task-graph.md`):
 
 | Code | Meaning | Action |
 |------|---------|--------|
 | `invalid_input` | Field validation failed | Check error message for specifics |
+| `invalid_metadata_key` | Task metadata contains `depends_on`/`blocked_on`, or note metadata collides with a reserved key | Use the `depends_on` param or task edges; rename the note key |
 | `content_too_large` | Content exceeds the size limit | Trim or split the document |
 | `doc_not_found` | ID doesn't exist | Verify the UUID |
 | `note_not_found` | `lithos_note_update` id doesn't exist | Verify the UUID |
 | `task_not_found` | Task doesn't exist or is closed | Verify the task id |
+| `task_not_resolved` | `lithos_task_reopen` on a task that is already open | Nothing to do |
+| `claim_failed` | Claim denied — aspect held by another agent, or task closed/missing | Normal contention; try another task or wait |
+| `claim_not_found` | Renew/release with no matching active claim | Claim expired or not yours; re-claim if still needed |
 | `search_backend_error` | Tantivy/ChromaDB down | Retry or fall back to a different search mode |
 | `lcma_disabled` | LCMA not enabled | Fall back to `lithos_search` |
 | `internal_error` | Unexpected write failure | Retry; report if persistent |
@@ -99,8 +104,8 @@ On `version_conflict`, the response includes `current_version` — re-read the d
 | Response | Meaning |
 |----------|---------|
 | `{success: true}` | Operation succeeded |
-| `{success: false}` (on claim) | Another agent holds the claim — not an error |
-| `{success: false}` (on release/renew) | Claim expired or not owned |
+| `{status: "error", code: "claim_failed"}` (on claim) | Another agent holds the aspect, or the task is closed/missing — normal contention, not a fault |
+| `{status: "error", code: "claim_not_found"}` (on release/renew) | Claim expired or not owned |
 | `{status: "error", code: "task_not_found"}` | Task doesn't exist or is already closed |
 
 ---
@@ -129,7 +134,8 @@ These are inconsistent across fields — know them:
 | `derived_from_ids` | Preserve existing | `[]` clears | Replaces entirely |
 | `expires_at` | Preserve existing | `""` clears | Sets new value |
 | `confidence` | Preserve existing | — | Sets new value |
-| `metadata` | Preserve existing | `{}` is a no-op | Per-key merge (null value deletes key) |
+| `metadata` (`lithos_write`) | Preserve existing | `{}` clears ALL free-form metadata | Per-key merge (null value deletes key) |
+| `metadata` (`lithos_note_update`, `lithos_task_update`) | Preserve existing | `{}` is a no-op | Per-key merge (null value deletes key) |
 
 ---
 

--- a/agent-skills/plugins/lithos/skills/lithos/references/project-conventions.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/project-conventions.md
@@ -50,6 +50,8 @@ All tasks and documents belonging to a project should carry **both**:
 | All docs for a project | `lithos_list(path_prefix="projects/<slug>/")` |
 | All tasks (Agent Zero) | `lithos_task_list(tags=["project:<slug>"])` |
 | All tasks (Loom) | `lithos_task_list(metadata_match={"project": "<slug>"})` |
+| Ready (workable) tasks for a project | `lithos_task_ready(project="<slug>")` — matches `metadata.project`; run `tags=["project:<slug>"]` too (union caveat below) |
+| Blocked tasks and why | `lithos_task_blocked(project="<slug>")` |
 | Search within a project | `lithos_search(query="...", path_prefix="projects/<slug>/")` |
 | All project contexts | `lithos_list(path_prefix="projects/", tags=["project-context"])` |
 | Recently closed tasks | `lithos_task_list(resolved_since="2026-06-01T00:00:00Z")` |

--- a/agent-skills/plugins/lithos/skills/lithos/references/search-and-retrieval.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/search-and-retrieval.md
@@ -51,6 +51,9 @@ Four modes:
 | `semantic` | Meaning matters more than exact words |
 | `graph` | Discover related docs by following wiki-links |
 
+- `graph` mode takes `seed_ids=[...]` (starting documents) and `graph_depth` (1–3)
+- `entities=["..."]` filters results to docs whose extracted entities contain every listed value (exact match)
+
 **Important**: `lithos_search` does NOT enforce LCMA access scopes and does NOT track retrieval for salience scoring. Use only for exploration.
 
 ---
@@ -65,9 +68,9 @@ lithos_retrieve(query="inbox error handling patterns", task_id="...", limit=10)
 
 - Runs 10 scouts across multiple backends with Terrace 1 reranking
 - Enforces access scopes (`agent_private`, `task` visibility)
-- Writes audit receipts — enables cited/misleading feedback loops
+- Writes audit receipts — the returned `receipt_id` can be passed to `lithos_task_complete(receipt_id=...)` to bind cited/misleading feedback to this exact retrieval
 - `task_id` activates the task_context scout (extra retrieval dimension)
-- **Requires LCMA enabled** — falls back to `lithos_search` if LCMA is off
+- **Requires LCMA enabled** — returns `{status: "error", code: "lcma_disabled"}` when off; fall back to `lithos_search` yourself
 
 ### Scout Weights (for tuning queries)
 
@@ -106,6 +109,8 @@ lithos_list(
 
 - `tags`, `author`, `path_prefix` are pushed down into the Tantivy query
 - `since`, `title_contains` applied as post-filters
+- `metadata_match={...}` filters on free-form note metadata — AND across keys; a key matches when the stored value equals it, or is a list containing it (scalar query values only)
+- `entities=["..."]` exact-match entity filter
 - More efficient than `lithos_search` + manual filtering for constrained queries
 
 ---
@@ -121,3 +126,11 @@ Returns three relationship types:
 - **provenance**: `derived_from_ids` chains
 - **edges**: typed LCMA edges (flat)
 - Plus `related_ids` — deduped union of all referenced IDs
+
+For edge queries **not** centred on one document (e.g. all `contradicts` edges in a namespace), use `lithos_edge_list(from_id=..., to_id=..., type=..., namespace=...)` — all filters optional, AND semantics.
+
+Resolve a `contradicts` edge with:
+```
+lithos_conflict_resolve(edge_id="...", resolution="accepted_dual|superseded|refuted|merged", resolver="<id>")
+```
+(`winner_id` required when `resolution="superseded"`.)

--- a/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
@@ -1,15 +1,18 @@
 # Task Coordination Reference
 
+> Dependencies, hierarchy, spawning, and gates are covered in `task-graph.md`.
+
 ## Task Lifecycle
 
 ```
-open → completed   (lithos_task_complete)
-open → cancelled   (lithos_task_cancel)
+open → completed                (lithos_task_complete)
+open → cancelled                (lithos_task_cancel)
+completed/cancelled → open      (lithos_task_reopen)
 ```
 
-Terminal states are final. No reopen primitive. If a task needs revisiting, post a `[ReopenRequested]` finding.
+`lithos_task_reopen(task_id=..., agent=...)` moves a terminal task back to open — it clears `resolved_at` and `outcome`, auto-posts a `[Reopened]` finding, and returns `reblocked` (dependent tasks that lose readiness). Reopening a task that is already open returns `task_not_resolved`.
 
-Only open tasks can be updated, completed, or cancelled — operations on closed tasks return errors.
+Complete and cancel require the task to be open (`task_not_found` otherwise). `lithos_task_update` also works on **terminal** tasks — annotate closed tasks without reviving them.
 
 ---
 
@@ -25,11 +28,15 @@ lithos_task_create(
         "project": "influx",
         "priority": "medium",
         "scheduled_for": "2026-06-15"
-    }
+    },
+    depends_on=["<prereq-task-id>"],   # optional — creates blocking edges (see task-graph.md)
+    parent_task_id="<epic-id>"         # optional — creates a hierarchy edge
 )
 ```
 
 **Required fields**: `title`, `agent`
+
+`task_type` defaults to `"task"`. `"epic"` (roll-up container) and `"gate"` (external wait) are graph concepts — see `task-graph.md`.
 
 ### Key Metadata Fields
 
@@ -38,8 +45,10 @@ lithos_task_create(
 | `project` | string | Project slug — used by Loom for project association |
 | `priority` | string | `highest\|high\|medium\|low\|lowest` |
 | `scheduled_for` | string | `YYYY-MM-DD` |
-| `depends_on` | list[str] | Prerequisite task IDs |
 | `parallelizable` | bool | Whether siblings can execute concurrently |
+| `phase` | string | Scheduling phase — inherited by `lithos_task_spawn` |
+
+**Forbidden keys**: `depends_on` and `blocked_on` are rejected with `invalid_metadata_key` — dependencies are first-class edges, not metadata. Use the `depends_on` parameter or `lithos_task_edge_upsert` (see `task-graph.md`).
 
 ### Tag Conventions
 
@@ -54,6 +63,20 @@ lithos_task_create(
 
 ---
 
+## Updating Tasks
+
+```
+lithos_task_update(task_id="...", agent="<id>", title=..., description=..., tags=[...], metadata={...})
+```
+
+- At least one of `title` / `description` / `tags` / `metadata` is required
+- Works on **terminal** tasks — annotate completed/cancelled tasks without reviving them
+- `metadata` is an additive per-key merge: a value overwrites that key, `null` deletes it, unmentioned keys are preserved, `{}` is a no-op
+- `tags` replaces the whole list
+- Same forbidden keys as create: `depends_on` / `blocked_on` → `invalid_metadata_key`
+
+---
+
 ## Claiming Tasks
 
 ```
@@ -65,7 +88,8 @@ lithos_task_claim(task_id="...", aspect="research", agent="<id>", ttl_minutes=60
 - Renew before expiry: `lithos_task_renew(task_id="...", aspect="...", agent="<id>", ttl_minutes=60)`
 - Release when done or aborting: `lithos_task_release(task_id="...", aspect="...", agent="<id>")`
 - `lithos_task_complete` and `lithos_task_cancel` auto-release claims
-- **Claim denied**: returns `{success: false}` — NOT an error envelope. Try another task or wait
+- **Claim denied**: returns `{status: "error", code: "claim_failed"}` — normal contention (another agent holds the aspect, or the task is closed/missing), not a fault. Try another task or wait
+- **Renew/release with no matching claim**: returns `{status: "error", code: "claim_not_found"}` — the claim expired or isn't yours
 
 ---
 
@@ -82,12 +106,15 @@ lithos_finding_post(
 )
 ```
 
+Read a task's findings back with `lithos_finding_list(task_id="...", since="<ISO>")`.
+
 ### Conventional Finding Prefixes
 
 | Prefix | Meaning |
 |--------|---------|
 | `[Friction]` | Operational difficulty needing attention |
-| `[ReopenRequested]` | Task needs revisiting (no reopen primitive) |
+| `[ReopenRequested]` | Request that the task owner reopen — use `lithos_task_reopen` directly when the decision is yours |
+| `[Reopened]` | Auto-posted by `lithos_task_reopen` |
 | `[BlockerFailed]` | Plugin execution failed |
 
 ---
@@ -103,6 +130,8 @@ lithos_task_complete(
     misleading_nodes=["uuid3"]           # docs that were misleading
 )
 ```
+
+Returns `{success: true, unblocked: [...]}` — `unblocked` lists tasks this completion made ready (see `task-graph.md`).
 
 ### How Feedback Works
 
@@ -120,13 +149,17 @@ lithos_task_complete(
 
 - `lithos_task_get(task_id="...")` — returns task directly; use when you know the ID and don't need claims
 - `lithos_task_status(task_id="...")` — returns task with its active claims
-- `lithos_task_list(status="open", with_claims=True)` — list with claim info; avoids N+1 queries
+- `lithos_task_list(status="open", with_claims=True)` — list with claim info; avoids N+1 queries. Filter by `task_type` (`task|epic|gate`), `tags`, `metadata_match`, `resolved_since`
+- `lithos_task_ready()` / `lithos_task_blocked()` — the workable frontier, and why the rest is stuck (see `task-graph.md`)
+- `lithos_task_children(task_id="...", recursive=True)` — subtasks via hierarchy edges
+- `lithos_task_edge_list(task_id="...")` — dependency/hierarchy edges on a task
 
 ---
 
 ## Tool Responses
 
 - **Success**: `{success: true}` or status envelope with created ID
-- **Claim denied**: `{success: false}` — NOT an error envelope
-- **Release/renew no match**: `{success: false}` — claim expired or not owned
+- **Claim denied**: `{status: "error", code: "claim_failed"}` — normal contention, not a fault
+- **Release/renew no match**: `{status: "error", code: "claim_not_found"}` — claim expired or not owned
 - **Task not found / already closed**: `{status: "error", code: "task_not_found"}`
+- **Reopen on an open task**: `{status: "error", code: "task_not_resolved"}`

--- a/agent-skills/plugins/lithos/skills/lithos/references/task-graph.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/task-graph.md
@@ -1,0 +1,147 @@
+# Task Graph Reference
+
+Tasks can be linked into a dependency graph: blocking edges control **readiness** (what can be worked on now), hierarchy edges organise work under epics, and gates model waits on the outside world.
+
+> **Two different graphs.** `lithos_task_edge_*` links **tasks** (coordination). `lithos_edge_upsert` / `lithos_edge_list` link **knowledge documents** (typed LCMA edges — see `search-and-retrieval.md`). Don't mix them up.
+
+---
+
+## Edge Types
+
+| Type | Meaning | Blocks readiness? |
+|------|---------|-------------------|
+| `blocks` | `from` must complete before `to` is ready | Yes |
+| `waits_on_gate` | `to` is not ready until gate `from` resolves | Yes |
+| `parent_child` | `from` is the parent of `to` (hierarchy) | No |
+| `discovered_from` | `to` was discovered while working `from` (provenance) | No |
+
+---
+
+## Declaring Dependencies
+
+At creation (preferred):
+
+```
+lithos_task_create(
+    title="Deploy service",
+    agent="<id>",
+    depends_on=["<build-task-id>", "<test-task-id>"],  # each creates a blocks edge
+    parent_task_id="<epic-id>"                          # creates a parent_child edge
+)
+```
+
+After creation:
+
+```
+lithos_task_edge_upsert(
+    from_task_id="<prerequisite>",
+    to_task_id="<dependent>",
+    type="blocks",
+    agent="<id>"
+)
+```
+
+Rules:
+
+- **Never put `depends_on` or `blocked_on` in task metadata** — rejected with `invalid_metadata_key`. Dependencies are first-class edges, not metadata
+- Referenced tasks must already exist (`task_not_found`); self-edges are rejected (`self_edge`)
+- Blocking and hierarchy edges are cycle-checked on write — an edge that would close a cycle is rejected with `cycle`
+- A task can have at most one parent (`parent_exists`)
+- `waits_on_gate` requires the `from` task to be a gate (`not_a_gate`)
+
+---
+
+## Finding Work: Ready and Blocked
+
+```
+lithos_task_ready(project="<slug>", limit=20)
+```
+
+**Ready** = open AND not an epic/gate AND every `blocks` predecessor is `completed` AND not held by an unresolved gate.
+
+- **Ready ≠ unclaimed.** Claims are attached to results (`with_claims=True` by default) but never filter them — still `lithos_task_claim` before working
+- Filters: `project` (shorthand for `metadata.project`), `tags`, `metadata_match`, `limit`
+
+Diagnose stuck tasks:
+
+```
+lithos_task_blocked(project="<slug>")
+```
+
+Each blocked task carries a `blockers` list:
+
+| `kind` | Meaning | Action |
+|--------|---------|--------|
+| `task` | Predecessor still open | Work/complete the predecessor first |
+| `gate` | Gate not yet resolved | Resolve the gate (complete the gate task, or wait for a timer) |
+| `blocker_unsatisfiable` | Predecessor or gate was **cancelled** — permanently blocked | `lithos_task_reopen` the cancelled blocker, or re-route the edges |
+| `cycle` | Dependency chain forms a cycle | Remove an edge to break the cycle |
+
+Ripple effects: `lithos_task_complete` returns `unblocked` (task IDs this completion made ready); `lithos_task_reopen` returns `reblocked` (dependents that lost readiness).
+
+---
+
+## Hierarchy: Epics and Children
+
+- `task_type="epic"` marks a roll-up container. Epics are **excluded from ready** — never claim an epic; work its children
+- Attach children with `parent_task_id` on create, or a `parent_child` edge later
+- List children:
+
+```
+lithos_task_children(task_id="<epic-id>", recursive=False, include_closed=False)
+```
+
+`recursive=True` walks the full descendant subtree; `include_closed=True` includes completed/cancelled children.
+
+---
+
+## Spawning Follow-On Work
+
+When work uncovers new work mid-task:
+
+```
+lithos_task_spawn(
+    source_task_id="<current-task>",
+    title="Fix flaky auth test discovered during deploy",
+    agent="<id>",
+    relation_type="discovered_from"   # or "blocks" if the new task must finish before the source
+)
+```
+
+- The edge always runs source → spawned; the spawned task is always `task_type="task"`
+- Inherits from the source by default: `metadata.project` (`inherit_project`), tags (`inherit_tags`), and the scheduling keys `priority` / `parallelizable` / `phase` (`inherit_context`) — pass `metadata={...}` to override inherited keys
+
+---
+
+## Gates: Waiting on the Outside World
+
+A gate is a task (`task_type="gate"`) representing an external condition:
+
+```
+gate = lithos_task_create(
+    title="Wait for PR approval",
+    agent="<id>",
+    task_type="gate",
+    metadata={"gate_type": "pr", "repo": "agent-lore/lithos", "pr_number": 123}
+)
+lithos_task_edge_upsert(
+    from_task_id=gate["task_id"], to_task_id="<waiting-task>",
+    type="waits_on_gate", agent="<id>"
+)
+```
+
+- `metadata.gate_type` is **required**: `human | timer | ci | pr | external_task`. Timer gates also require `metadata.ready_at` (ISO timestamp); other keys (`approval_required_from`, `provider`, `run_id`, ...) are advisory
+- A gate resolves when its task is **completed** — or automatically for an open `timer` gate whose `ready_at` has passed
+- A **cancelled** gate leaves waiters permanently blocked (`blocker_unsatisfiable`)
+- Gates are excluded from ready — resolve them, don't work them
+
+---
+
+## Inspecting the Graph
+
+```
+lithos_task_edge_list(task_id="...", direction="both", types=["blocks"])
+```
+
+- `direction` ∈ `incoming | outgoing | both` (relative to `task_id`)
+- Returns edges with `from_task_id`, `to_task_id`, `type`, `direction`, `metadata`, and provenance (`created_by`, `created_at`)


### PR DESCRIPTION
## Summary

The lithos skill (plugin v0.1.2) documented **24 of the server's 37 MCP tools** and predated four feature waves: task graph Phases 1–3 (#342/#343/#356), `lithos_task_reopen` + terminal task updates (#357/#303), the note metadata patch (#363, #305, #306), and the 0.4.0 error-envelope normalization (#371). Some guidance was actively wrong — it taught patterns that now return errors.

### Corrections (guidance that misled agents)
- **"No reopen primitive"** → `lithos_task_reopen` exists (clears outcome, auto-posts `[Reopened]`, returns `reblocked`)
- **`depends_on` as task metadata** → now hard-rejected with `invalid_metadata_key`; documented as the first-class `depends_on` param / task edges instead
- **"Claim denied = `{success: false}`, not an error"** → claim/renew/release failures now return canonical envelopes (`claim_failed` / `claim_not_found`)
- **"Only open tasks can be updated"** → `lithos_task_update` works on terminal tasks
- **`metadata={}` "is a no-op"** → true for `lithos_note_update`/`lithos_task_update`, but clears all free-form metadata on `lithos_write`

### Additions
- New `references/task-graph.md`: edge types, declaring dependencies, ready/blocked frontier and blocker kinds, epics/children, spawn inheritance, gates, cycle rules
- All 37 `lithos_*` tools now covered (previously missing: the six task-graph tools, `lithos_task_update`, `lithos_task_reopen`, `lithos_note_update`, `lithos_delete`, `lithos_finding_list`, `lithos_edge_list`, `lithos_conflict_resolve`, `lithos_agent_info`)
- SKILL.md workflows now start from `lithos_task_ready`, mention spawn, and document `depends_on`/`parent_task_id`/`task_type` on create

### Version bumps
- `agent-lore/lithos` 0.1.2 → **0.2.0**, description updated to mention the task graph
- `agent-lore/influx-inbox` 0.1.2 → **0.1.3** — content unchanged; bumped because the publish workflow publishes both manifests verbatim and an already-published version fails the job

## Test plan

- [x] Coverage check: every one of the 37 `lithos_*` tools appears in the skill; no stale phrases (`no reopen`, `{success: false}`) remain
- [x] Live spot-check against a running Lithos server (scratch tasks, cancelled afterwards): `metadata={"depends_on": []}` → `invalid_metadata_key`; double-claim → `claim_failed`; reopen open task → `task_not_resolved`; `depends_on` → blocked with `kind: "task"`; complete → `unblocked: [dependent]`; reopen completed blocker → `reblocked: [dependent]`; spawn round-trip
- [x] Parameter lists cross-checked against `src/lithos/server.py`, `src/lithos/tools/*.py`, `coordination.py`, `knowledge.py`, and `docs/SPECIFICATION.md`
- [x] Both `plugin.json` manifests parse (`python -m json.tool`)
- [x] `make check` green (1479 passed)