### PR TITLE
fix(guardrail): review follow-ups for the architecture tooling kit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ metrics-history:
 	uv run python scripts/metrics_history.py --format $(or $(FORMAT),csv)
 
 # Show the metrics delta between BASE (default origin/main) and the working tree.
+# `set -e` + `trap` so the recipe exits with metrics_diff.py's status, not rm's.
 metrics-diff:
-	@tmp=$$(mktemp); \
+	@set -e; tmp=$$(mktemp); trap 'rm -f $$tmp' EXIT; \
 	git show $(or $(BASE),origin/main):docs/generated/metrics.json > $$tmp 2>/dev/null || echo '{}' > $$tmp; \
-	uv run python scripts/metrics_diff.py $$tmp docs/generated/metrics.json; \
-	rm -f $$tmp
+	uv run python scripts/metrics_diff.py $$tmp docs/generated/metrics.json
 
 check: lint typecheck test

--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -78,6 +78,12 @@ Foundation  = ["Events", "Config", "Telemetry", "Errors", "Logging"]
 # CI fails if a measured value exceeds its budget. Raising a budget is allowed
 # but must be an explicit, reviewed edit to this file; lower a budget after
 # improving the code to lock in the gain.
+#
+# Most budgets below are tight ratchets pinned at today's value (any regression
+# fails CI). max_module_lines is the exception: it is a STOP-LOSS ceiling set a
+# little above today's largest module so a big module can't quietly balloon — it
+# is deliberately NOT pinned to the exact current high-water mark. Ratchet the
+# *count* of oversized modules down via modules_over_800_lines instead.
 [budgets]
 cross_component_edges  = 63    # measured 2026-07; direction: down
 component_cycles       = 1    # one 6-component SCC in Core (Coordination/Graph/Knowledge/LCMA/Provenance/Search); goal: shrink it

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -404,8 +404,8 @@
     "total_sloc": 18762
   },
   "tests": {
-    "ratio": 1.8,
+    "ratio": 1.81,
     "src_lines": 23203,
-    "test_lines": 41855
+    "test_lines": 41975
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -87,4 +87,4 @@ Top 10 most complex functions:
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.80** (41855 test lines / 23203 source lines)
+- Test-to-source line ratio: **1.81** (41975 test lines / 23203 source lines)

--- a/scripts/metrics_diff.py
+++ b/scripts/metrics_diff.py
@@ -92,6 +92,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"metrics_diff: cannot read snapshots: {exc}", file=sys.stderr)
         return 2
 
+    # No base snapshot (e.g. the port's own first PR, before metrics.json exists
+    # on the base branch): a full "— -> value" table for every metric is noise.
+    if not old:
+        sys.stdout.write(
+            "### Architecture metrics: first snapshot (no base to diff)\n"
+            if args.markdown
+            else "First metrics snapshot — no base to diff.\n"
+        )
+        return 0
+
     sys.stdout.write(render(diff_metrics(old, new), markdown=args.markdown))
     return 0
 

--- a/scripts/metrics_history.py
+++ b/scripts/metrics_history.py
@@ -46,10 +46,12 @@ def iter_snapshots() -> list[tuple[str, str, dict]]:
     for line in log:
         sha, date = line.split(maxsplit=1)
         try:
-            raw = _git("show", f"{sha}:{SNAPSHOT}")
+            metrics = json.loads(_git("show", f"{sha}:{SNAPSHOT}"))
         except subprocess.CalledProcessError:
             continue  # commit removed the file (or predates it)
-        snapshots.append((sha, date, json.loads(raw)))
+        except json.JSONDecodeError:
+            continue  # snapshot at this commit is malformed; skip, don't crash the walk
+        snapshots.append((sha, date, metrics))
     return snapshots
 
 

--- a/tests/guardrail/AGENTS.md
+++ b/tests/guardrail/AGENTS.md
@@ -53,6 +53,13 @@ accounted for in `_index.all_expected_paths()`. `test_generated_manifest`
 asserts the directory equals the registry, so an orphaned or renamed artifact is
 a failure, not a silently rotting file.
 
+**First-run ordering gotcha:** on a *fresh* port with an empty `docs/generated/`,
+pytest runs `test_generated_index` / `test_generated_manifest` before the
+generators that create the files (files run in alphabetical order), so the
+*first* `make diagrams` can fail on missing artifacts; a second run passes. A
+committed repo never hits this (the files already exist) — it only matters the
+very first time you generate on a new project.
+
 ## Adding a new artifact
 
 1. Write a pure `render_*() -> str` in a `_*.py` helper. Wrap the body in

--- a/tests/guardrail/_common.py
+++ b/tests/guardrail/_common.py
@@ -19,9 +19,11 @@ ARCH_TOML = REPO_ROOT / "docs" / "architecture.toml"
 
 # Project identity comes from the [project] table in architecture.toml so this
 # guardrail kit ports to another src-layout repo by editing only that file.
-# For a flat layout (package directly at the repo root) set src_layout = "".
+# root_package is required (no fallback — a missing/typo'd [project] must fail
+# loudly rather than silently scan the wrong package). For a flat layout
+# (package directly at the repo root) set src_layout = "".
 _PROJECT = tomllib.loads(ARCH_TOML.read_text(encoding="utf-8")).get("project", {})
-ROOT_PACKAGE = _PROJECT.get("root_package", "lithos")
+ROOT_PACKAGE = _PROJECT["root_package"]
 _SRC_LAYOUT = _PROJECT.get("src_layout", "src")
 SRC_ROOT = (REPO_ROOT / _SRC_LAYOUT / ROOT_PACKAGE) if _SRC_LAYOUT else REPO_ROOT / ROOT_PACKAGE
 
@@ -89,5 +91,7 @@ def write(name: str, content: str) -> pathlib.Path:
     """Write a generated artifact under ``docs/generated/`` (subpaths allowed)."""
     out = GENERATED_DIR / name
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(content, encoding="utf-8")
+    # newline="\n" pins LF so regeneration is byte-identical on Windows too
+    # (the CI drift gate compares bytes).
+    out.write_text(content, encoding="utf-8", newline="\n")
     return out

--- a/tests/guardrail/_metrics_render.py
+++ b/tests/guardrail/_metrics_render.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from tests.guardrail._common import with_header
+from tests.guardrail._common import load_architecture, with_header
 from tests.guardrail._metrics_toolkit import COMPLEXITY_THRESHOLD, GOD_MODULE_LINES, budget_actual
 
 
@@ -115,15 +115,24 @@ def _complexity_section(metrics: dict[str, Any]) -> list[str]:
 
 def _summary_section(metrics: dict[str, Any]) -> list[str]:
     d, m, t = metrics["domain"], metrics["mcp"], metrics["tests"]
-    return [
-        "## Domain, tools & tests",
+    # The MCP tool surface is an optional adapter: only report it when this
+    # project declares one, so metrics.md doesn't advertise a surface with 0 tools.
+    has_tools = bool(load_architecture().get("tool_catalog", {}).get("include_modules"))
+    lines = [
+        "## Domain, tools & tests" if has_tools else "## Domain & tests",
         "",
         f"- Domain models: **{d['models']}** ({d['associations']} associations,"
         f" {d['models_without_docstrings']} without docstrings)",
-        f"- MCP tools: **{m['tools']}** ({m['tools_without_docstrings']} without docstrings)",
-        f"- Test-to-source line ratio: **{t['ratio']:.2f}**"
-        f" ({t['test_lines']} test lines / {t['src_lines']} source lines)",
     ]
+    if has_tools:
+        lines.append(
+            f"- MCP tools: **{m['tools']}** ({m['tools_without_docstrings']} without docstrings)"
+        )
+    lines.append(
+        f"- Test-to-source line ratio: **{t['ratio']:.2f}**"
+        f" ({t['test_lines']} test lines / {t['src_lines']} source lines)"
+    )
+    return lines
 
 
 def render_metrics_md(metrics: dict[str, Any], budgets: dict[str, int]) -> str:

--- a/tests/guardrail/test_architecture_diagram.py
+++ b/tests/guardrail/test_architecture_diagram.py
@@ -21,11 +21,9 @@ def test_generate_component_diagram() -> None:
 
 def test_every_internal_module_maps_to_a_component() -> None:
     """No lithos module should be missing from the component map (orphan check)."""
-    import grimp
-
     arch = dt.load_architecture()
     components = arch["components"]
-    graph = grimp.build_graph(dt.ROOT_PACKAGE)
+    graph = dt.build_import_graph()  # memoized in _common; don't rebuild
     orphans = sorted(
         m for m in graph.modules if m != dt.ROOT_PACKAGE and dt.component_of(m, components) is None
     )

--- a/tests/test_metrics_diff.py
+++ b/tests/test_metrics_diff.py
@@ -1,9 +1,17 @@
-"""Unit tests for the pure metrics-diff logic used by CI PR summaries."""
+"""Unit tests for the metrics-diff logic used by CI PR summaries.
+
+Covers the pure diff/render helpers and the ``main()`` CLI wrapper — including
+the empty-base branch that fires on a port's own first PR, before
+``metrics.json`` exists on the base branch.
+"""
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
@@ -55,3 +63,38 @@ def test_render_markdown_has_table_and_delta() -> None:
 
 def test_render_markdown_no_changes() -> None:
     assert "no changes" in metrics_diff.render([], markdown=True)
+
+
+def _write(path: Path, obj: object) -> Path:
+    path.write_text(json.dumps(obj), encoding="utf-8")
+    return path
+
+
+def test_main_empty_base_prints_first_snapshot(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    base = _write(tmp_path / "base.json", {})  # no base snapshot yet
+    head = _write(tmp_path / "head.json", {"size": {"total_sloc": 100}})
+
+    assert metrics_diff.main([str(base), str(head)]) == 0
+    out = capsys.readouterr().out
+    assert "no base to diff" in out.lower()
+    assert "total_sloc" not in out  # not the full "— -> value" table
+
+
+def test_main_empty_base_markdown(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    base = _write(tmp_path / "base.json", {})
+    head = _write(tmp_path / "head.json", {"size": {"total_sloc": 100}})
+
+    assert metrics_diff.main([str(base), str(head), "--markdown"]) == 0
+    assert capsys.readouterr().out.startswith("### Architecture metrics: first snapshot")
+
+
+def test_main_with_base_emits_diff(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    base = _write(tmp_path / "base.json", {"size": {"total_sloc": 100}})
+    head = _write(tmp_path / "head.json", {"size": {"total_sloc": 110}})
+
+    assert metrics_diff.main([str(base), str(head)]) == 0
+    out = capsys.readouterr().out
+    assert "size.total_sloc" in out
+    assert "no base to diff" not in out.lower()

--- a/tests/test_metrics_history.py
+++ b/tests/test_metrics_history.py
@@ -1,13 +1,20 @@
-"""Unit tests for scripts/metrics_history.py pure functions.
+"""Unit tests for scripts/metrics_history.py.
 
-``iter_snapshots`` is git-backed and covered by the make target; here we test the
-pure extraction/rendering over synthetic snapshots, including empty history.
+The pure extraction/rendering helpers are tested over synthetic snapshots. The
+git-backed ``iter_snapshots`` walker is tested with ``_git`` monkeypatched to
+exercise normal history, commits missing the snapshot, and malformed snapshots —
+so the walk's parse/skip logic is covered without a real repo.
 """
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
+from collections.abc import Callable, Mapping
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
@@ -58,3 +65,62 @@ def test_emit_mermaid_missing_value_is_zero() -> None:
 def test_emit_handles_empty_history() -> None:
     assert mh.emit_csv([], ["k"]) == "sha,date,k\n"
     assert mh.emit_mermaid([], ["k"]).startswith("## k")
+
+
+def _fake_git(log_out: str, shows: Mapping[str, object]) -> Callable[..., str]:
+    """Stand-in for ``_git``: ``log`` returns ``log_out``; ``show <sha>:PATH``
+    returns ``shows[sha]`` (a str), or raises it if it is an Exception."""
+
+    def fake(*args: str) -> str:
+        if args[0] == "log":
+            return log_out
+        if args[0] == "show":
+            sha = args[1].split(":", 1)[0]
+            result = shows[sha]
+            if isinstance(result, Exception):
+                raise result
+            assert isinstance(result, str)
+            return result
+        raise AssertionError(f"unexpected git args: {args}")
+
+    return fake
+
+
+def test_iter_snapshots_parses_first_parent_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_out = "aaaaaaa 2026-01-01\nbbbbbbb 2026-02-01\n"
+    shows = {
+        "aaaaaaa": json.dumps({"graph": {"cross_component_edges": 63}}),
+        "bbbbbbb": json.dumps({"graph": {"cross_component_edges": 60}}),
+    }
+    monkeypatch.setattr(mh, "_git", _fake_git(log_out, shows))
+    snaps = mh.iter_snapshots()
+    assert [(sha, date) for sha, date, _ in snaps] == [
+        ("aaaaaaa", "2026-01-01"),
+        ("bbbbbbb", "2026-02-01"),
+    ]
+    assert snaps[0][2]["graph"]["cross_component_edges"] == 63
+
+
+def test_iter_snapshots_skips_commit_missing_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_out = "aaaaaaa 2026-01-01\nbbbbbbb 2026-02-01\n"
+    shows = {
+        "aaaaaaa": subprocess.CalledProcessError(128, "git show"),
+        "bbbbbbb": json.dumps({"graph": {"cross_component_edges": 60}}),
+    }
+    monkeypatch.setattr(mh, "_git", _fake_git(log_out, shows))
+    assert [sha for sha, _, _ in mh.iter_snapshots()] == ["bbbbbbb"]
+
+
+def test_iter_snapshots_skips_malformed_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_out = "aaaaaaa 2026-01-01\nbbbbbbb 2026-02-01\n"
+    shows = {
+        "aaaaaaa": "{not valid json",
+        "bbbbbbb": json.dumps({"graph": {"cross_component_edges": 60}}),
+    }
+    monkeypatch.setattr(mh, "_git", _fake_git(log_out, shows))
+    assert [sha for sha, _, _ in mh.iter_snapshots()] == ["bbbbbbb"]
+
+
+def test_iter_snapshots_empty_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mh, "_git", _fake_git("", {}))
+    assert mh.iter_snapshots() == []


### PR DESCRIPTION
## What

The "diagrams as tests" architecture tooling (#379) was ported to the three sibling repos (lithos-lens, lithos-loom, influx). Two rounds of review on those ports surfaced small **kit-level** issues — one real bug, a few robustness/coverage gaps, and doc polish. The kit originated here and is meant to stay byte-identical across all four repos, so this PR brings the same fixes back to lithos.

No generated-docs behaviour changes: `metrics.md` is byte-identical apart from the self-referential `test_lines` count bumping for the new tests.

## Fixes

- **`Makefile` `metrics-diff` masked failures** *(bug)* — the recipe ended with `rm`, so `metrics_diff.py`'s exit status was swallowed. Now uses `set -e` + `trap 'rm -f …' EXIT` so it exits with the script's status.
- **`metrics_history.py` history walk** — skips a commit whose snapshot is malformed (not just missing), so one bad blob can't crash `make metrics-history`.
- **`metrics_diff.py` empty-base guard** — when the base snapshot is absent/empty (a fresh port's first PR, before `metrics.json` exists on base), prints "first snapshot (no base to diff)" instead of a full `— -> value` table for every metric.
- **`_common.py`** — `root_package` is now required (dropped the `"lithos"` fallback) so a missing/typo'd `[project]` fails loudly instead of silently scanning the wrong package; `write()` pins `newline="\n"` for byte-identical regeneration on Windows.
- **`test_architecture_diagram.py`** — the orphan check reuses the memoized `build_import_graph()` from `_common` instead of rebuilding grimp's graph.
- **`_metrics_render.py`** — the MCP-tools line is gated on a configured tool surface (`[tool_catalog].include_modules`). lithos has one, so its `metrics.md` is unchanged; the change lets the kit render cleanly on the client repos that omit the adapter (no more "MCP tools: 0").

## Tests

- **`metrics_diff.main()`** — new CLI-level tests for the empty-base branch (text + markdown) plus a populated-base case.
- **`iter_snapshots`** — new tests (monkeypatched `_git`) covering normal history, a commit missing the snapshot, a malformed snapshot, and empty history.

## Docs

- `docs/architecture.toml [budgets]` header now documents `max_module_lines` as a stop-loss ceiling (distinct from the value-pinned ratchets); `modules_over_800_lines` ratchets the *count* of oversized modules.
- `tests/guardrail/AGENTS.md` notes the fresh-port first-run test-ordering gotcha.

## Test plan

- [x] `make check` (lint + pyright + pytest) green.
- [x] `make diagrams` deterministic; `metrics.md` unchanged except the `test_lines` bump.

Companion PRs: agent-lore/lithos-lens#16, agent-lore/lithos-loom#228, agent-lore/influx#258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
