### PR TITLE
fix: route enrich/quarantine/supersede note writes through Corpus intake (PR1a, task 681ac952)

### DIFF
--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -85,8 +85,8 @@ Foundation  = ["Events", "Config", "Telemetry", "Errors", "Logging"]
 # is deliberately NOT pinned to the exact current high-water mark. Ratchet the
 # *count* of oversized modules down via modules_over_800_lines instead.
 [budgets]
-cross_component_edges  = 63    # measured 2026-07; direction: down
-component_cycles       = 1    # one 6-component SCC in Core (Coordination/Graph/Knowledge/LCMA/Provenance/Search); goal: shrink it
+cross_component_edges  = 64    # measured 2026-07; +1 (LCMA→Intake, task 681ac952: enrich/cognitive-memory note writes now route through CorpusIntake to fix Drift); direction: down
+component_cycles       = 1    # one 7-component SCC in Core (Coordination/Graph/Intake/Knowledge/LCMA/Provenance/Search); Intake joined via LCMA→Intake (681ac952); goal: shrink it
 module_cycles          = 2    # knowledge<->graph<->search<->provenance<->lcma.edges, server<->tools; goal: 0
 modules_over_800_lines = 11   # incl. tools.tasks (985) split from server in #374; direction: down
 max_module_lines       = 2800 # stop-loss; largest today is coordination.py at 2675

--- a/docs/generated/architecture.md
+++ b/docs/generated/architecture.md
@@ -89,6 +89,7 @@ graph TD
   LCMA --> Errors
   LCMA --> Events
   LCMA --> Graph
+  LCMA --> Intake
   LCMA --> Knowledge
   LCMA --> Provenance
   LCMA --> Search
@@ -127,10 +128,10 @@ graph TD
   linkStyle 45 stroke:#bbb
   linkStyle 47 stroke:#bbb
   linkStyle 48 stroke:#bbb
-  linkStyle 53 stroke:#bbb
   linkStyle 54 stroke:#bbb
-  linkStyle 58 stroke:#bbb
+  linkStyle 55 stroke:#bbb
   linkStyle 59 stroke:#bbb
-  linkStyle 61 stroke:#bbb
+  linkStyle 60 stroke:#bbb
   linkStyle 62 stroke:#bbb
+  linkStyle 63 stroke:#bbb
 ```

--- a/docs/generated/components/Intake.md
+++ b/docs/generated/components/Intake.md
@@ -28,7 +28,7 @@ The controlled mutation entry point: validates and applies writes to the corpus.
 ## Dependencies
 
 - Depends on: [Coordination](Coordination.md), [Errors](Errors.md), [Events](Events.md), [Graph](Graph.md), [Knowledge](Knowledge.md), [Search](Search.md), [Telemetry](Telemetry.md)
-- Used by: [CognitiveMemory](CognitiveMemory.md), [Entrypoints](Entrypoints.md)
+- Used by: [CognitiveMemory](CognitiveMemory.md), [Entrypoints](Entrypoints.md), [LCMA](LCMA.md)
 
 ## ADRs
 

--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -13,7 +13,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 |---|---|---:|---:|
 | `lithos.lcma` | XS | 0 | 0 |
 | `lithos.lcma.edges` | S | 0 | 0 |
-| `lithos.lcma.enrich` | M | 1 | 0 |
+| `lithos.lcma.enrich` | L | 1 | 0 |
 | `lithos.lcma.entities` | M | 0 | 1 |
 | `lithos.lcma.migrations` | S | 1 | 1 |
 | `lithos.lcma.retrieve` | L | 0 | 1 |
@@ -58,7 +58,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 
 ## Dependencies
 
-- Depends on: [Config](Config.md), [Coordination](Coordination.md), [Errors](Errors.md), [Events](Events.md), [Graph](Graph.md), [Knowledge](Knowledge.md), [Provenance](Provenance.md), [Search](Search.md), [Telemetry](Telemetry.md)
+- Depends on: [Config](Config.md), [Coordination](Coordination.md), [Errors](Errors.md), [Events](Events.md), [Graph](Graph.md), [Intake](Intake.md), [Knowledge](Knowledge.md), [Provenance](Provenance.md), [Search](Search.md), [Telemetry](Telemetry.md)
 - Used by: [CognitiveMemory](CognitiveMemory.md), [Provenance](Provenance.md)
 
 ## ADRs

--- a/docs/generated/domain_model.md
+++ b/docs/generated/domain_model.md
@@ -177,6 +177,9 @@ classDiagram
     +title str | None
     +tags list[str] | _UnsetType
     +lcma_status str | None | _UnsetType
+    +supersedes str | None | _UnsetType
+    +entities list[str] | None | _UnsetType
+    +entities_extractor int | None | _UnsetType
     +metadata dict | _UnsetType
     +expected_version int | None
   }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -317,11 +317,11 @@
         "classes": 2,
         "functions": 27,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 1003,
-        "lines": 1003,
+        "largest_module_lines": 1004,
+        "lines": 1004,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 821
+        "sloc": 822
       },
       "Config": {
         "classes": 9,
@@ -408,7 +408,7 @@
         "functions": 129,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4634,
+        "lines": 4642,
         "modules": 9,
         "public_symbols": 19,
         "sloc": 3731
@@ -469,13 +469,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23259,
+    "total_lines": 23268,
     "total_modules": 37,
-    "total_sloc": 18786
+    "total_sloc": 18787
   },
   "tests": {
     "ratio": 1.84,
-    "src_lines": 23259,
-    "test_lines": 42830
+    "src_lines": 23268,
+    "test_lines": 42888
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -127,6 +127,7 @@
       [
         "Coordination",
         "Graph",
+        "Intake",
         "Knowledge",
         "LCMA",
         "Provenance",
@@ -170,9 +171,9 @@
         "instability": 0.3
       },
       "Intake": {
-        "fan_in": 2,
+        "fan_in": 3,
         "fan_out": 7,
-        "instability": 0.78
+        "instability": 0.7
       },
       "Knowledge": {
         "fan_in": 7,
@@ -181,8 +182,8 @@
       },
       "LCMA": {
         "fan_in": 2,
-        "fan_out": 9,
-        "instability": 0.82
+        "fan_out": 10,
+        "instability": 0.83
       },
       "Logging": {
         "fan_in": 1,
@@ -205,9 +206,9 @@
         "instability": 0.1
       }
     },
-    "cross_component_edges": 63,
-    "cross_component_module_edges": 130,
-    "longest_component_chain": 6,
+    "cross_component_edges": 64,
+    "cross_component_module_edges": 131,
+    "longest_component_chain": 5,
     "module_cycle_count": 2,
     "module_cycles": [
       [
@@ -316,11 +317,11 @@
         "classes": 2,
         "functions": 27,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 994,
-        "lines": 994,
+        "largest_module_lines": 1003,
+        "lines": 1003,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 822
+        "sloc": 821
       },
       "Config": {
         "classes": 9,
@@ -386,11 +387,11 @@
         "classes": 8,
         "functions": 6,
         "largest_module": "lithos.intake",
-        "largest_module_lines": 605,
-        "lines": 605,
+        "largest_module_lines": 618,
+        "lines": 618,
         "modules": 1,
         "public_symbols": 8,
-        "sloc": 512
+        "sloc": 524
       },
       "Knowledge": {
         "classes": 10,
@@ -407,10 +408,10 @@
         "functions": 129,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4600,
+        "lines": 4634,
         "modules": 9,
         "public_symbols": 19,
-        "sloc": 3718
+        "sloc": 3731
       },
       "Logging": {
         "classes": 1,
@@ -468,13 +469,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23203,
+    "total_lines": 23259,
     "total_modules": 37,
-    "total_sloc": 18762
+    "total_sloc": 18786
   },
   "tests": {
     "ratio": 1.84,
-    "src_lines": 23203,
-    "test_lines": 42600
+    "src_lines": 23259,
+    "test_lines": 42830
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -12,7 +12,7 @@ lower a budget after improving the code to lock in the gain.
 | Metric | Actual | Budget | Headroom |
 |---|---:|---:|---:|
 | `component_cycles` | 1 | 1 | 0 |
-| `cross_component_edges` | 63 | 63 | 0 |
+| `cross_component_edges` | 64 | 64 | 0 |
 | `cross_module_private_refs` | 42 | 42 | 0 |
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 2 | 2 | 0 |
@@ -21,11 +21,11 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **63** (130 module-level)
-- Component cycles: Coordination ↔ Graph ↔ Knowledge ↔ LCMA ↔ Provenance ↔ Search
+- Cross-component edges: **64** (131 module-level)
+- Component cycles: Coordination ↔ Graph ↔ Intake ↔ Knowledge ↔ LCMA ↔ Provenance ↔ Search
 - Module cycles: lithos.graph ↔ lithos.knowledge ↔ lithos.lcma.edges ↔ lithos.provenance ↔ lithos.search; lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
-- Longest component dependency chain: 6
+- Longest component dependency chain: 5
 
 ## Components
 
@@ -34,16 +34,16 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
-| CognitiveMemory | 1 | 994 | 822 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 1003 | 821 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 11 | 5203 | 4202 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
 | Errors | 2 | 182 | 129 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 270 | 219 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
-| Intake | 1 | 605 | 512 | 2 | 7 | 0.78 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
+| Intake | 1 | 618 | 524 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 3102 | 2505 | 7 | 6 | 0.46 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 11 |
-| LCMA | 9 | 4600 | 3718 | 2 | 9 | 0.82 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
+| LCMA | 9 | 4634 | 3731 | 2 | 10 | 0.83 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 402 | 306 | 4 | 4 | 0.50 | 13 (`lithos.provenance.ProvenanceProjection._plan_reconcile_to`) | 1 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -51,7 +51,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **37**, lines: **23203**, SLOC: **18762**
+- Modules: **37**, lines: **23259**, SLOC: **18786**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -159,4 +159,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.84** (42600 test lines / 23203 source lines)
+- Test-to-source line ratio: **1.84** (42830 test lines / 23259 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -34,7 +34,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
-| CognitiveMemory | 1 | 1003 | 821 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 1004 | 822 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 11 | 5203 | 4202 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
@@ -43,7 +43,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 618 | 524 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 3102 | 2505 | 7 | 6 | 0.46 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 11 |
-| LCMA | 9 | 4634 | 3731 | 2 | 10 | 0.83 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
+| LCMA | 9 | 4642 | 3731 | 2 | 10 | 0.83 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 402 | 306 | 4 | 4 | 0.50 | 13 (`lithos.provenance.ProvenanceProjection._plan_reconcile_to`) | 1 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -51,7 +51,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **37**, lines: **23259**, SLOC: **18786**
+- Modules: **37**, lines: **23268**, SLOC: **18787**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -159,4 +159,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.84** (42830 test lines / 23259 source lines)
+- Test-to-source line ratio: **1.84** (42888 test lines / 23268 source lines)

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -653,7 +653,8 @@ class CognitiveMemory:
         - ``misleading_count += 1``
         - ``salience -= 0.05``
         - If ``misleading_count >= 3``, set ``status = 'quarantined'``
-          via :meth:`KnowledgeManager.update`.
+          via :meth:`CorpusIntake.note_update` (so the status flip re-indexes
+          Search/graph and emits ``NOTE_UPDATED``; task 681ac952).
 
         After per-node penalties, every edge incident to *any* of the
         misleading nodes is weakened by ``-0.05`` exactly once (a shared

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -27,9 +27,9 @@ from typing import TYPE_CHECKING, Any
 
 from lithos.errors import SearchBackendError
 from lithos.events import EDGE_UPSERTED, LithosEvent
-from lithos.intake import EdgeRequest
+from lithos.intake import EdgeRequest, NoteUpdateRequest
 from lithos.knowledge import _normalize_datetime
-from lithos.lcma.enrich import EnrichWorker
+from lithos.lcma.enrich import ENRICH_AGENT, EnrichWorker
 
 # Re-exported for callers outside the lcma boundary (ADR-0005): the CLI
 # extract-entities command shares the enrichment worker's extractor (#313).
@@ -222,6 +222,7 @@ class CognitiveMemory:
                 edge_store=self._projection._edge_store,
                 knowledge=self._knowledge,
                 coordination=self._coordination,
+                intake=self._intake,
             )
             await self._enrich_worker.start()
         self._started = True
@@ -670,10 +671,14 @@ class CognitiveMemory:
                 misleading = stats["misleading_count"]
                 assert isinstance(misleading, int)
                 if misleading >= 3:
-                    await self._knowledge.update(
-                        id=node_id,
-                        lcma_status="quarantined",
-                        agent="lithos-enrich",
+                    # Route through intake so the status flip re-indexes
+                    # Search/graph and emits NOTE_UPDATED; the direct
+                    # KnowledgeManager.update did neither (Drift, task 681ac952).
+                    # ENRICH_AGENT stamps the event so the enrich worker drops
+                    # it instead of re-enqueuing the quarantined node.
+                    await self._intake.note_update(
+                        ENRICH_AGENT,
+                        NoteUpdateRequest(id=node_id, lcma_status="quarantined"),
                     )
                     logger.info(
                         "CognitiveMemory.reinforce_misleading: node quarantined",
@@ -968,10 +973,14 @@ class CognitiveMemory:
                 }
 
             if resolution == "superseded" and winner_id is not None:
-                await self._knowledge.update(
-                    id=winner_id,
-                    agent=resolver,
-                    supersedes=loser_id,
+                # Route through intake so recording the supersedes link
+                # re-indexes Search/graph and emits NOTE_UPDATED, instead of
+                # the bypassing KnowledgeManager.update (Drift, task 681ac952).
+                # Attributed to the real resolver — a genuine agent write, so
+                # re-enrichment of the winner is legitimate, not a self-loop.
+                await self._intake.note_update(
+                    resolver,
+                    NoteUpdateRequest(id=winner_id, supersedes=loser_id),
                 )
 
             await self._emit(

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -117,12 +117,22 @@ class NoteUpdateRequest:
     there is no wholesale-clear affordance — ``metadata={}`` carries no change,
     matching ``lithos_task_update`` (the boundary rejects it when no other
     field is set rather than writing a no-op revision).
+
+    ``supersedes`` / ``entities`` / ``entities_extractor`` are LCMA-internal
+    frontmatter fields carried so the enrich worker and CognitiveMemory can
+    route their metadata patches (entity extraction, quarantine, supersede)
+    through this seam instead of calling ``KnowledgeManager.update`` directly
+    — the direct call skipped Search/graph re-index and emitted no event,
+    manufacturing Drift (task 681ac952).
     """
 
     id: str
     title: str | None = None
     tags: list[str] | _UnsetType = _UNSET
     lcma_status: str | None | _UnsetType = _UNSET
+    supersedes: str | None | _UnsetType = _UNSET
+    entities: list[str] | None | _UnsetType = _UNSET
+    entities_extractor: int | None | _UnsetType = _UNSET
     metadata: dict | _UnsetType = _UNSET
     expected_version: int | None = None
 
@@ -472,6 +482,9 @@ class CorpusIntake:
                     title=request.title,
                     tags=request.tags,
                     lcma_status=request.lcma_status,
+                    supersedes=request.supersedes,
+                    entities=request.entities,
+                    entities_extractor=request.entities_extractor,
                     expected_version=request.expected_version,
                     extra=request.metadata,
                 )

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from lithos.config import LcmaConfig
     from lithos.coordination import CoordinationService
     from lithos.events import EventBus
+    from lithos.intake import CorpusIntake
     from lithos.knowledge import KnowledgeDocument, KnowledgeManager
     from lithos.lcma.stats import StatsStore
     from lithos.provenance import EdgeStore
@@ -43,6 +44,16 @@ except Exception:
     _HAS_TELEMETRY = False
 
 logger = logging.getLogger(__name__)
+
+# System-reserved actor for enrichment-originated Corpus writes. Mirrors
+# ``WATCHER_AGENT`` (watch_intake.py): a synthetic agent id so writes made by
+# the enrich subsystem are attributable and — crucially — recognisable by this
+# worker's own event filter. Enrichment writes now flow through ``CorpusIntake``
+# (which re-indexes Search/graph, fixing Drift) and therefore emit
+# ``NOTE_UPDATED`` / ``EDGE_UPSERTED``; :meth:`EnrichWorker._handle_event` drops
+# events stamped with this actor so the worker never re-enqueues the very node
+# it just wrote (enrich→write→event→enrich).
+ENRICH_AGENT = "lithos-enrich"
 
 _SUBSCRIBED_EVENT_TYPES = [
     NOTE_CREATED,
@@ -118,6 +129,7 @@ class EnrichWorker:
         edge_store: EdgeStore,
         knowledge: KnowledgeManager,
         coordination: CoordinationService,
+        intake: CorpusIntake,
     ) -> None:
         self._config = config
         self._event_bus = event_bus
@@ -125,6 +137,7 @@ class EnrichWorker:
         self._edge_store = edge_store
         self._knowledge = knowledge
         self._coordination = coordination
+        self._intake = intake
 
         self._queue: asyncio.Queue[LithosEvent] | None = None
         self._consumer_task: asyncio.Task[None] | None = None
@@ -183,6 +196,18 @@ class EnrichWorker:
 
     async def _handle_event(self, event: LithosEvent) -> None:
         """Route a single event to enrich_queue."""
+        # Drop self-originated events. Enrichment writes now flow through
+        # CorpusIntake (fixing view Drift), which emits NOTE_UPDATED /
+        # EDGE_UPSERTED. Without this guard those events would re-enqueue the
+        # very node the worker just wrote — looping enrich→write→event→enrich.
+        # Filtering on the synthetic actor makes the loop-break explicit rather
+        # than relying on the entities-extractor marker's incidental idempotency.
+        if event.agent == ENRICH_AGENT:
+            logger.debug(
+                "EnrichWorker: skipping self-originated event",
+                extra={"event_type": event.type, "agent": event.agent},
+            )
+            return
         logger.debug(
             "EnrichWorker: received event",
             extra={"event_type": event.type, "event_id": event.id},
@@ -503,11 +528,20 @@ class EnrichWorker:
         if not extracted and not doc.metadata.entities:
             return
 
-        await self._knowledge.update(
-            id=node_id,
-            agent="lithos-enrich",
-            entities=extracted,
-            entities_extractor=ENTITY_EXTRACTOR_VERSION,
+        # Route through CorpusIntake so the entity write re-indexes Search/graph
+        # and emits NOTE_UPDATED — calling KnowledgeManager.update directly here
+        # skipped both, leaving the derived views stale until the next Reconcile
+        # (Drift, task 681ac952). ENRICH_AGENT stamps the emitted event so
+        # :meth:`_handle_event` drops it rather than re-enqueuing this node.
+        from lithos.intake import NoteUpdateRequest
+
+        await self._intake.note_update(
+            ENRICH_AGENT,
+            NoteUpdateRequest(
+                id=node_id,
+                entities=extracted,
+                entities_extractor=ENTITY_EXTRACTOR_VERSION,
+            ),
         )
         logger.debug(
             "EnrichWorker: entity extraction complete",

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -53,6 +53,14 @@ logger = logging.getLogger(__name__)
 # ``NOTE_UPDATED`` / ``EDGE_UPSERTED``; :meth:`EnrichWorker._handle_event` drops
 # events stamped with this actor so the worker never re-enqueues the very node
 # it just wrote (enrich→write→event→enrich).
+#
+# RESERVATION CAVEAT: the loop-break keys on the caller-facing ``agent`` string,
+# so an external write that passes agent="lithos-enrich" is also skipped (its
+# node is merely deferred to the periodic full_sweep, not dropped). This id is
+# treated as system-reserved, but that is convention, not enforcement. PR1b of
+# task 681ac952 replaces this with a non-spoofable event-origin marker set by
+# the intake (which callers cannot forge), folded into its EDGE_UPSERTED payload
+# rework.
 ENRICH_AGENT = "lithos-enrich"
 
 _SUBSCRIBED_EVENT_TYPES = [

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -1034,6 +1034,25 @@ class TestReinforceMisleading:
         assert cached is not None
         assert cached.status == "quarantined"
 
+    async def test_quarantine_reindexes_search_via_intake(
+        self,
+        memory_with_knowledge: CognitiveMemory,
+        knowledge_manager: KnowledgeManager,
+        mock_search: MagicMock,
+    ) -> None:
+        """Drift regression (task 681ac952): the quarantine status flip routes
+        through CorpusIntake, so Search is re-indexed. The old direct
+        KnowledgeManager.update left the index stale until the next Reconcile.
+        """
+        nid = await _create_note(knowledge_manager, "Note Mis-Reindex")
+        mock_search.index.reset_mock()
+
+        for _ in range(3):
+            await memory_with_knowledge.reinforce_misleading([nid])
+
+        assert knowledge_manager.get_cached_meta(nid).status == "quarantined"  # type: ignore[union-attr]
+        assert mock_search.index.called, "quarantine did not re-index Search"
+
     async def test_weakens_adjacent_edges_by_0_05(
         self,
         memory_with_knowledge: CognitiveMemory,
@@ -1318,3 +1337,41 @@ class TestConflictResolve:
         )
         assert result["status"] == "error"
         assert result["code"] == "invalid_input"
+
+    async def test_superseded_records_link_and_reindexes_via_intake(
+        self,
+        memory_with_knowledge: CognitiveMemory,
+        knowledge_manager: KnowledgeManager,
+        mock_search: MagicMock,
+    ) -> None:
+        """A successful supersede records the link on the winner AND re-indexes
+        Search through CorpusIntake (Drift regression, task 681ac952).
+
+        The existing superseded tests only cover the validation error paths; this
+        is the first to exercise the write, using a real KnowledgeManager so the
+        frontmatter and the view-sync are both observable.
+        """
+        winner = await _create_note(knowledge_manager, "Winner Note")
+        loser = await _create_note(knowledge_manager, "Loser Note")
+        edge_id = await memory_with_knowledge._projection._edge_store.upsert(
+            from_id=winner,
+            to_id=loser,
+            edge_type="contradicts",
+            weight=1.0,
+            namespace="default",
+        )
+        mock_search.index.reset_mock()
+
+        result = await memory_with_knowledge.conflict_resolve(
+            edge_id=edge_id,
+            resolution="superseded",
+            resolver="agent-x",
+            winner_id=winner,
+        )
+        assert result["status"] == "ok"
+
+        # supersedes link persisted on the winner ...
+        doc, _ = await knowledge_manager.read(id=winner)
+        assert doc.metadata.supersedes == loser
+        # ... and the winner was re-indexed through the intake view-sync (the fix).
+        assert mock_search.index.called, "supersede did not re-index Search"

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -20,11 +20,36 @@ from lithos.events import (
     EventBus,
     LithosEvent,
 )
+from lithos.intake import CorpusIntake
 from lithos.knowledge import KnowledgeManager
-from lithos.lcma.enrich import EnrichWorker, _resolve_node_id
+from lithos.lcma.enrich import ENRICH_AGENT, EnrichWorker, _resolve_node_id
 from lithos.lcma.entities import ENTITY_EXTRACTOR_VERSION
 from lithos.lcma.stats import StatsStore
 from lithos.provenance import EdgeStore, _project_node_provenance
+
+
+def _make_intake(
+    knowledge: object,
+    event_bus: EventBus,
+    edge_store: EdgeStore,
+    coordination: object,
+) -> CorpusIntake:
+    """A CorpusIntake wrapping ``knowledge`` with mocked Search/graph.
+
+    Enrichment writes route through ``intake.note_update`` now (task 681ac952),
+    so EnrichWorker requires a CorpusIntake. The entity-extraction tests need a
+    functional intake over their real KnowledgeManager for the frontmatter write
+    to land; Search/graph are mocked because the assertions check frontmatter and
+    stats, not the derived views.
+    """
+    return CorpusIntake(
+        knowledge=knowledge,  # type: ignore[arg-type]
+        search=MagicMock(),
+        graph=MagicMock(),
+        coordination=coordination,  # type: ignore[arg-type]
+        event_bus=event_bus,
+        edge_store=edge_store,
+    )
 
 
 @pytest_asyncio.fixture
@@ -87,6 +112,7 @@ async def worker(
         edge_store=edge_store,
         knowledge=mock_knowledge,
         coordination=mock_coordination,
+        intake=_make_intake(mock_knowledge, event_bus, edge_store, mock_coordination),
     )
 
 
@@ -913,6 +939,39 @@ class TestConsolidateTask:
 
 
 # ---------------------------------------------------------------------------
+# Self-originated event filter (loop-break)
+# ---------------------------------------------------------------------------
+
+
+class TestSelfOriginatedEventFilter:
+    """The worker drops events it caused itself (task 681ac952).
+
+    Enrichment writes now flow through CorpusIntake, which emits NOTE_UPDATED /
+    EDGE_UPSERTED stamped with ENRICH_AGENT. Re-enqueuing on those would loop
+    enrich→write→event→enrich; the actor filter breaks it explicitly.
+    """
+
+    async def test_self_originated_event_is_dropped(self, worker: EnrichWorker) -> None:
+        worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
+
+        await worker._handle_event(
+            LithosEvent(type=NOTE_UPDATED, agent=ENRICH_AGENT, payload={"id": "n1"})
+        )
+
+        worker._stats_store.enqueue.assert_not_called()
+
+    async def test_other_agents_still_enqueue(self, worker: EnrichWorker) -> None:
+        """The filter is specific to ENRICH_AGENT — genuine agent writes still enqueue."""
+        worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
+
+        await worker._handle_event(
+            LithosEvent(type=NOTE_UPDATED, agent="real-agent", payload={"id": "n1"})
+        )
+
+        worker._stats_store.enqueue.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # Entity extraction tests
 # ---------------------------------------------------------------------------
 
@@ -948,6 +1007,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=mock_coordination,
+            intake=_make_intake(km, event_bus, edge_store, mock_coordination),
         )
 
         await worker._extract_entities(doc_id)
@@ -958,6 +1018,59 @@ class TestExtractEntities:
         assert "NetworkX" in doc.metadata.entities
         assert "ChromaDB" in doc.metadata.entities
         assert doc.metadata.entities_extractor == ENTITY_EXTRACTOR_VERSION
+
+    async def test_extract_entities_reindexes_search_via_intake(
+        self,
+        test_config: LithosConfig,
+        lcma_config: LcmaConfig,
+        event_bus: EventBus,
+        stats_store: StatsStore,
+        edge_store: EdgeStore,
+        mock_coordination: AsyncMock,
+    ) -> None:
+        """Drift regression (task 681ac952): the entity write flows through
+        CorpusIntake, so Search is re-indexed. Calling KnowledgeManager.update
+        directly (the old path) persisted the frontmatter but left the Search
+        index and link graph stale until the next Reconcile.
+        """
+        km = KnowledgeManager(test_config)
+        result = await km.create(
+            title="Reindex Note",
+            content="Lithos uses [[NetworkX]] and `ChromaDB`.",
+            agent="test-agent",
+        )
+        assert result.document is not None
+        doc_id = result.document.id
+
+        mock_search = MagicMock()
+        mock_graph = MagicMock()
+        intake = CorpusIntake(
+            knowledge=km,
+            search=mock_search,
+            graph=mock_graph,
+            coordination=mock_coordination,
+            event_bus=event_bus,
+            edge_store=edge_store,
+        )
+        worker = EnrichWorker(
+            config=lcma_config,
+            event_bus=event_bus,
+            stats_store=stats_store,
+            edge_store=edge_store,
+            knowledge=km,
+            coordination=mock_coordination,
+            intake=intake,
+        )
+
+        await worker._extract_entities(doc_id)
+
+        # Frontmatter still persisted (behaviour preserved) ...
+        doc, _ = await km.read(id=doc_id)
+        assert "NetworkX" in doc.metadata.entities
+        assert doc.metadata.entities_extractor == ENTITY_EXTRACTOR_VERSION
+        # ... and the derived views were synced through the intake (the fix).
+        assert mock_search.index.called, "entity write did not re-index Search"
+        assert mock_graph.add_document.called, "entity write did not sync the graph"
 
     def _make_worker(
         self,
@@ -975,6 +1088,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=mock_coordination,
+            intake=_make_intake(km, event_bus, edge_store, mock_coordination),
         )
 
     async def test_stale_marker_entities_reextracted(
@@ -1116,6 +1230,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=coord,
+            intake=_make_intake(km, event_bus, edge_store, coord),
         )
         await worker.full_sweep()
 
@@ -1156,6 +1271,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=mock_coordination,
+            intake=_make_intake(km, event_bus, edge_store, mock_coordination),
         )
 
         await worker._extract_entities(doc_id)
@@ -1191,6 +1307,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=mock_coordination,
+            intake=_make_intake(km, event_bus, edge_store, mock_coordination),
         )
 
         # Call with edge.upserted trigger — should NOT extract entities
@@ -1239,6 +1356,7 @@ class TestExtractEntities:
             edge_store=edge_store,
             knowledge=km,
             coordination=mock_coordination,
+            intake=_make_intake(km, event_bus, edge_store, mock_coordination),
         )
 
         await worker._extract_entities(doc_id)
@@ -1279,6 +1397,7 @@ class TestFullSweep:
             edge_store=edge_store,
             knowledge=km,
             coordination=coord,
+            intake=_make_intake(km, event_bus, edge_store, coord),
         )
 
         # Create node_stats with last_used_at 14 days ago (will decay)
@@ -1339,6 +1458,7 @@ class TestFullSweep:
             edge_store=edge_store,
             knowledge=km,
             coordination=coord,
+            intake=_make_intake(km, event_bus, edge_store, coord),
         )
 
         # Create two notes: source-note and derived-note

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -970,6 +970,58 @@ class TestSelfOriginatedEventFilter:
 
         worker._stats_store.enqueue.assert_awaited_once()
 
+    async def test_extract_entities_emits_self_event_that_worker_drops(
+        self,
+        test_config: LithosConfig,
+        lcma_config: LcmaConfig,
+        stats_store: StatsStore,
+        edge_store: EdgeStore,
+        mock_coordination: AsyncMock,
+    ) -> None:
+        """End-to-end loop-break: the entity write emits a NOTE_UPDATED stamped
+        ENRICH_AGENT, and feeding that very emitted event back through
+        _handle_event is dropped. Connects the two halves the other tests prove
+        independently — the write really produces a self-event, and the worker
+        really drops that self-event — closing enrich→write→event→enrich.
+        """
+        km = KnowledgeManager(test_config)
+        result = await km.create(
+            title="Loop Note", content="Lithos uses [[NetworkX]].", agent="test-agent"
+        )
+        assert result.document is not None
+        doc_id = result.document.id
+
+        captured_bus = AsyncMock()
+        intake = CorpusIntake(
+            knowledge=km,
+            search=MagicMock(),
+            graph=MagicMock(),
+            coordination=mock_coordination,
+            event_bus=captured_bus,
+            edge_store=edge_store,
+        )
+        worker = EnrichWorker(
+            config=lcma_config,
+            event_bus=captured_bus,
+            stats_store=stats_store,
+            edge_store=edge_store,
+            knowledge=km,
+            coordination=mock_coordination,
+            intake=intake,
+        )
+
+        await worker._extract_entities(doc_id)
+
+        # The entity write emitted a NOTE_UPDATED stamped with the sentinel actor ...
+        emitted = captured_bus.emit.await_args.args[0]
+        assert emitted.type == NOTE_UPDATED
+        assert emitted.agent == ENRICH_AGENT
+        assert emitted.payload["id"] == doc_id
+        # ... and routing that same emitted event back through the worker drops it.
+        worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
+        await worker._handle_event(emitted)
+        worker._stats_store.enqueue.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Entity extraction tests

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -283,6 +283,8 @@ async def test_note_update_forwards_lcma_fields_and_reindexes(
     assert created.document is not None
     doc_id = created.document.id
     before, _ = await knowledge_manager.read(id=doc_id)
+    # Replace the real graph with a stub so the graph view-sync is observable.
+    intake._graph = MagicMock()  # type: ignore[assignment]
 
     outcome = await intake.note_update(
         "lithos-enrich",
@@ -294,8 +296,12 @@ async def test_note_update_forwards_lcma_fields_and_reindexes(
     assert after.content == before.content  # body untouched — frontmatter-only patch
     assert after.metadata.entities == ["NetworkX", "ChromaDB"]
     assert after.metadata.entities_extractor == 7
+    # Both derived views synced, and the event carries the caller's agent.
     mocks["search"].index.assert_called_once()
-    assert mocks["event_bus"].emit.await_args.args[0].type == NOTE_UPDATED
+    intake._graph.add_document.assert_called_once()
+    emitted = mocks["event_bus"].emit.await_args.args[0]
+    assert emitted.type == NOTE_UPDATED
+    assert emitted.agent == "lithos-enrich"
 
 
 @pytest.mark.asyncio

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -34,6 +34,7 @@ from lithos.intake import (
     DeleteRequest,
     EdgeOutcome,
     EdgeRequest,
+    NoteUpdateRequest,
     WriteOutcome,
     WriteRequest,
 )
@@ -266,6 +267,58 @@ async def test_write_update_returns_updated_outcome(
     emitted_event = mocks["event_bus"].emit.await_args.args[0]
     assert emitted_event.type == NOTE_UPDATED
     assert emitted_event.payload["id"] == doc_id
+
+
+@pytest.mark.asyncio
+async def test_note_update_forwards_lcma_fields_and_reindexes(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """note_update carries the LCMA-internal frontmatter fields
+    (entities / entities_extractor) through to KnowledgeManager, leaves the body
+    untouched, and re-indexes Search + emits NOTE_UPDATED. This is the seam the
+    enrich worker now uses instead of bypassing intake (task 681ac952)."""
+    intake, mocks = stub_intake
+    created = await knowledge_manager.create(title="orig", content="body-text", agent="agent-1")
+    assert created.document is not None
+    doc_id = created.document.id
+    before, _ = await knowledge_manager.read(id=doc_id)
+
+    outcome = await intake.note_update(
+        "lithos-enrich",
+        NoteUpdateRequest(id=doc_id, entities=["NetworkX", "ChromaDB"], entities_extractor=7),
+    )
+
+    assert outcome.status == "updated"
+    after, _ = await knowledge_manager.read(id=doc_id)
+    assert after.content == before.content  # body untouched — frontmatter-only patch
+    assert after.metadata.entities == ["NetworkX", "ChromaDB"]
+    assert after.metadata.entities_extractor == 7
+    mocks["search"].index.assert_called_once()
+    assert mocks["event_bus"].emit.await_args.args[0].type == NOTE_UPDATED
+
+
+@pytest.mark.asyncio
+async def test_note_update_forwards_supersedes(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """note_update forwards ``supersedes`` — the field conflict_resolve now
+    writes through intake instead of a bypassing KnowledgeManager.update."""
+    intake, _ = stub_intake
+    winner = await knowledge_manager.create(title="winner", content="w", agent="agent-1")
+    loser = await knowledge_manager.create(title="loser", content="l", agent="agent-1")
+    assert winner.document is not None
+    assert loser.document is not None
+
+    outcome = await intake.note_update(
+        "agent-1",
+        NoteUpdateRequest(id=winner.document.id, supersedes=loser.document.id),
+    )
+
+    assert outcome.status == "updated"
+    doc, _ = await knowledge_manager.read(id=winner.document.id)
+    assert doc.metadata.supersedes == loser.document.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**PR1a of task `681ac952`** (architecture-review epic `f80b6eb4`). Fixes a real
Drift bug: three note writes bypassed `CorpusIntake` and mutated the Corpus via
`KnowledgeManager.update` directly, so the Search index and link graph were never
re-synced and no `NOTE_UPDATED` event fired — the derived views stayed stale until
the next Reconcile.

The three bypassing writes, now routed through `CorpusIntake.note_update`:

| Site | Write |
|------|-------|
| `lcma/enrich.py` `_extract_entities` | entities / entities_extractor |
| `cognitive_memory.py` `reinforce_misleading` | `lcma_status="quarantined"` |
| `cognitive_memory.py` `conflict_resolve` | `supersedes` (on the winner) |

## What changed

- **`NoteUpdateRequest`** gains `supersedes` / `entities` / `entities_extractor`
  (all `_UNSET`-defaulted) so the frontmatter-only patch seam can carry the
  LCMA-internal fields; `note_update` forwards them to `KnowledgeManager.update`.
- **`EnrichWorker`** takes a `CorpusIntake` dependency (wired in
  `CognitiveMemory.start`) and routes its entity write through it.
- **Loop-break.** Those writes now emit events that `EnrichWorker` subscribes to,
  which would re-enqueue the just-written node (enrich→write→event→enrich). New
  `ENRICH_AGENT = "lithos-enrich"` sentinel stamps enrichment-originated writes,
  and `_handle_event` drops any event carrying that actor. This makes the
  loop-break **explicit**, replacing the incidental protection that previously
  relied only on the entities-extractor marker's idempotency.

## Architecture budget

Routing enrich through intake introduces the **LCMA → Intake** edge, so
`cross_component_edges` goes 63 → 64 and Intake joins the Core SCC. This is
intrinsic to the fix; the budget is raised in `docs/architecture.toml` with a
rationale and the generated diagrams regenerated (guardrails green).

## Scope & follow-ups

- **Deferred to PR1b** (same task, after this merges): route provenance edges
  through `ProvenanceProjection` plan/apply, dedupe the two `related_to` policies,
  and the edge_store plumbing cleanup (public `edge_store` property, retire
  reach-throughs, unify the two `EDGE_UPSERTED` payloads).
- **Out of scope:** `cli.py` `extract-entities` still writes directly — the CLI
  can't cross the lcma import seam and needs its own intake; it folds into Task 6's
  CLI pipeline factory.

## Test plan

- [x] `make check` — typecheck (0 errors), unit tests (1550 passed), lint (clean)
- [x] `make test-integration` — 428 passed
- [x] `make diagrams` — 48 guardrail tests pass; regenerated docs committed
- New regression tests:
  - `test_enrich_worker.py::TestExtractEntities::test_extract_entities_reindexes_search_via_intake` — entity write now re-indexes Search + syncs graph (Drift closed) while still persisting frontmatter.
  - `test_enrich_worker.py::TestSelfOriginatedEventFilter` — `ENRICH_AGENT` events are dropped; genuine agent writes still enqueue.
  - `test_cognitive_memory.py::...::test_quarantine_reindexes_search_via_intake` — quarantine re-indexes Search.
  - `test_cognitive_memory.py::...::test_superseded_records_link_and_reindexes_via_intake` — first positive superseded test: records the link on the winner **and** re-indexes.
  - `test_intake.py::test_note_update_forwards_lcma_fields_and_reindexes` / `test_note_update_forwards_supersedes` — new fields round-trip, body untouched.
