### PR TITLE
refactor: consolidate edge-write policy + non-spoofable enrich loop-break (PR1b, task 681ac952)

### DIFF
--- a/docs/generated/components/Events.md
+++ b/docs/generated/components/Events.md
@@ -11,12 +11,13 @@ Internal event bus decoupling producers from consumers.
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `lithos.events` | S | 2 | 0 |
+| `lithos.events` | M | 2 | 1 |
 
 ## Public API
 
 ### `lithos.events`
 - class `LithosEvent` — A typed event emitted by the Lithos event bus.
+- def `make_edge_upserted_event` — Build the canonical :data:`EDGE_UPSERTED` event.
 - class `EventBus` — In-memory event bus with filtered subscriptions and ring buffer history.
 
 ## Dependencies

--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -12,6 +12,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
 | `lithos.lcma` | XS | 0 | 0 |
+| `lithos.lcma.edge_reinforce` | XS | 0 | 1 |
 | `lithos.lcma.edges` | S | 0 | 0 |
 | `lithos.lcma.enrich` | L | 1 | 0 |
 | `lithos.lcma.entities` | M | 0 | 1 |
@@ -22,6 +23,9 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.utils` | S | 1 | 1 |
 
 ## Public API
+
+### `lithos.lcma.edge_reinforce`
+- def `reinforce_related_edge` — Strengthen an existing ``related_to`` edge or create one.
 
 ### `lithos.lcma.enrich`
 - class `EnrichWorker` — In-process background worker that consumes events and drains enrichment work.

--- a/docs/generated/domain_model.md
+++ b/docs/generated/domain_model.md
@@ -100,11 +100,11 @@ classDiagram
   class LithosEvent {
     +type str
     +agent str
-    +origin str
     +payload dict[str, str | int | float | bool | None]
     +tags list[str]
     +id str
     +timestamp datetime
+    +origin str
   }
 ```
 

--- a/docs/generated/domain_model.md
+++ b/docs/generated/domain_model.md
@@ -100,6 +100,7 @@ classDiagram
   class LithosEvent {
     +type str
     +agent str
+    +origin str
     +payload dict[str, str | int | float | bool | None]
     +tags list[str]
     +id str

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -367,11 +367,11 @@
         "classes": 3,
         "functions": 12,
         "largest_module": "lithos.events",
-        "largest_module_lines": 320,
-        "lines": 320,
+        "largest_module_lines": 323,
+        "lines": 323,
         "modules": 1,
         "public_symbols": 3,
-        "sloc": 256
+        "sloc": 259
       },
       "Graph": {
         "classes": 8,
@@ -469,13 +469,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23378,
+    "total_lines": 23381,
     "total_modules": 38,
-    "total_sloc": 18879
+    "total_sloc": 18882
   },
   "tests": {
     "ratio": 1.84,
-    "src_lines": 23378,
-    "test_lines": 42993
+    "src_lines": 23381,
+    "test_lines": 43010
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -115,7 +115,7 @@
         "qualname": "lithos.server.LithosServer._validate_task_feedback"
       }
     ],
-    "total_functions": 660
+    "total_functions": 663
   },
   "domain": {
     "associations": 26,
@@ -207,7 +207,7 @@
       }
     },
     "cross_component_edges": 64,
-    "cross_component_module_edges": 131,
+    "cross_component_module_edges": 133,
     "longest_component_chain": 5,
     "module_cycle_count": 2,
     "module_cycles": [
@@ -317,11 +317,11 @@
         "classes": 2,
         "functions": 27,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 1004,
-        "lines": 1004,
+        "largest_module_lines": 992,
+        "lines": 992,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 822
+        "sloc": 814
       },
       "Config": {
         "classes": 9,
@@ -365,13 +365,13 @@
       },
       "Events": {
         "classes": 3,
-        "functions": 11,
+        "functions": 12,
         "largest_module": "lithos.events",
-        "largest_module_lines": 270,
-        "lines": 270,
+        "largest_module_lines": 320,
+        "lines": 320,
         "modules": 1,
-        "public_symbols": 2,
-        "sloc": 219
+        "public_symbols": 3,
+        "sloc": 256
       },
       "Graph": {
         "classes": 8,
@@ -387,11 +387,11 @@
         "classes": 8,
         "functions": 6,
         "largest_module": "lithos.intake",
-        "largest_module_lines": 618,
-        "lines": 618,
+        "largest_module_lines": 624,
+        "lines": 624,
         "modules": 1,
         "public_symbols": 8,
-        "sloc": 524
+        "sloc": 529
       },
       "Knowledge": {
         "classes": 10,
@@ -405,13 +405,13 @@
       },
       "LCMA": {
         "classes": 5,
-        "functions": 129,
+        "functions": 130,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4642,
-        "modules": 9,
-        "public_symbols": 19,
-        "sloc": 3731
+        "lines": 4695,
+        "modules": 10,
+        "public_symbols": 20,
+        "sloc": 3778
       },
       "Logging": {
         "classes": 1,
@@ -425,13 +425,13 @@
       },
       "Provenance": {
         "classes": 5,
-        "functions": 11,
+        "functions": 12,
         "largest_module": "lithos.provenance",
-        "largest_module_lines": 402,
-        "lines": 402,
+        "largest_module_lines": 415,
+        "lines": 415,
         "modules": 1,
         "public_symbols": 5,
-        "sloc": 306
+        "sloc": 317
       },
       "Search": {
         "classes": 12,
@@ -469,13 +469,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23268,
-    "total_modules": 37,
-    "total_sloc": 18787
+    "total_lines": 23378,
+    "total_modules": 38,
+    "total_sloc": 18879
   },
   "tests": {
     "ratio": 1.84,
-    "src_lines": 23268,
-    "test_lines": 42888
+    "src_lines": 23378,
+    "test_lines": 42993
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -21,7 +21,7 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **64** (131 module-level)
+- Cross-component edges: **64** (133 module-level)
 - Component cycles: Coordination ↔ Graph ↔ Intake ↔ Knowledge ↔ LCMA ↔ Provenance ↔ Search
 - Module cycles: lithos.graph ↔ lithos.knowledge ↔ lithos.lcma.edges ↔ lithos.provenance ↔ lithos.search; lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
@@ -34,24 +34,24 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
-| CognitiveMemory | 1 | 1004 | 822 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 992 | 814 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 11 | 5203 | 4202 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
 | Errors | 2 | 182 | 129 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
-| Events | 1 | 270 | 219 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
+| Events | 1 | 320 | 256 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
-| Intake | 1 | 618 | 524 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
+| Intake | 1 | 624 | 529 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 3102 | 2505 | 7 | 6 | 0.46 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 11 |
-| LCMA | 9 | 4642 | 3731 | 2 | 10 | 0.83 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
+| LCMA | 10 | 4695 | 3778 | 2 | 10 | 0.83 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 23 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
-| Provenance | 1 | 402 | 306 | 4 | 4 | 0.50 | 13 (`lithos.provenance.ProvenanceProjection._plan_reconcile_to`) | 1 |
+| Provenance | 1 | 415 | 317 | 4 | 4 | 0.50 | 13 (`lithos.provenance.ProvenanceProjection._plan_reconcile_to`) | 1 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
 | Telemetry | 1 | 1183 | 909 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
 
 ## Size
 
-- Modules: **37**, lines: **23268**, SLOC: **18787**
+- Modules: **38**, lines: **23378**, SLOC: **18879**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -68,7 +68,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **660**, cyclomatic > 10: **67**
+- Functions: **663**, cyclomatic > 10: **67**
 
 Top 10 most complex functions:
 
@@ -159,4 +159,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.84** (42888 test lines / 23268 source lines)
+- Test-to-source line ratio: **1.84** (42993 test lines / 23378 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -39,7 +39,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 11 | 5203 | 4202 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
 | Errors | 2 | 182 | 129 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
-| Events | 1 | 320 | 256 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
+| Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 624 | 529 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 3102 | 2505 | 7 | 6 | 0.46 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 11 |
@@ -51,7 +51,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **38**, lines: **23378**, SLOC: **18879**
+- Modules: **38**, lines: **23381**, SLOC: **18882**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -159,4 +159,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.84** (42993 test lines / 23378 source lines)
+- Test-to-source line ratio: **1.84** (43010 test lines / 23381 source lines)

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -26,9 +26,10 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from lithos.errors import SearchBackendError
-from lithos.events import EDGE_UPSERTED, LithosEvent
+from lithos.events import EVENT_ORIGIN_ENRICH, LithosEvent, make_edge_upserted_event
 from lithos.intake import EdgeRequest, NoteUpdateRequest
 from lithos.knowledge import _normalize_datetime
+from lithos.lcma.edge_reinforce import RELATED_TO_STRENGTHEN_DELTA, reinforce_related_edge
 from lithos.lcma.enrich import ENRICH_AGENT, EnrichWorker
 
 # Re-exported for callers outside the lcma boundary (ADR-0005): the CLI
@@ -219,7 +220,7 @@ class CognitiveMemory:
                 config=self._config.lcma,
                 event_bus=self._event_bus,
                 stats_store=self._stats_store,
-                edge_store=self._projection._edge_store,
+                edge_store=self._projection.edge_store,
                 knowledge=self._knowledge,
                 coordination=self._coordination,
                 intake=self._intake,
@@ -354,7 +355,7 @@ class CognitiveMemory:
             knowledge=self._knowledge,
             graph=self._graph,
             coordination=self._coordination,
-            edge_store=self._projection._edge_store,
+            edge_store=self._projection.edge_store,
             projection=self._projection,
             stats_store=self._stats_store,
             lcma_config=self._config.lcma,
@@ -474,15 +475,11 @@ class CognitiveMemory:
 
         No MCP surface today — provided for the four-method shape ADR-0005
         describes and for future asserted-edge retraction work (e.g.
-        agent-driven contradictions). Mirrors the interim
-        ``self._projection._edge_store.delete_edges`` reach-through that
-        the enrich worker still uses; ADR-0005 / future #263 will route
-        this through a projection-owned write API once it exists.
+        agent-driven contradictions). Writes through the public
+        ``ProvenanceProjection.edge_store`` property; a projection-owned
+        write API may replace the direct ``delete_edges`` call later.
         """
-        # Interim: direct edge-store call mirrors today's use sites and
-        # collapses to a public projection write in ADR-0005's successor
-        # issue (#263).
-        return await self._projection._edge_store.delete_edges(edge_ids=edge_ids)
+        return await self._projection.edge_store.delete_edges(edge_ids=edge_ids)
 
     # ------------------------------------------------------------------
     # Reinforcement (issue #259, ADR-0005)
@@ -492,9 +489,9 @@ class CognitiveMemory:
     # passes *what it knows* (cited / ignored / misleading node ids) and
     # the Module applies the consequences against its owned StatsStore
     # and the projection's EdgeStore. Callers no longer thread stores by
-    # hand. ``self._projection._edge_store`` is a private-attribute read
-    # matching the precedent set in :meth:`start`; a follow-up issue will
-    # promote it to a public ``ProvenanceProjection.edge_store`` property.
+    # hand. Edge writes reach the store through the public
+    # ``ProvenanceProjection.edge_store`` property (these mutate rows the
+    # projection does not own — ``related_to`` reinforcement, edge weakening).
 
     async def reinforce_cited(self, cited_ids: list[str]) -> None:
         """Boost stats for every cited node.
@@ -571,7 +568,7 @@ class CognitiveMemory:
             "CognitiveMemory.reinforce_between: strengthening edges",
             extra={"cited_count": len(cited_ids)},
         )
-        edge_store = self._projection._edge_store
+        edge_store = self._projection.edge_store
 
         # Resolve namespace per node from the meta cache.
         ns_map: dict[str, str] = {}
@@ -603,41 +600,32 @@ class CognitiveMemory:
             from_id, to_id = (a, b) if a <= b else (b, a)
             namespace = ns_a
 
-            existing = await edge_store.list_edges(
-                from_id=from_id,
-                to_id=to_id,
-                edge_type="related_to",
-                namespace=namespace,
+            edge_id, created = await reinforce_related_edge(
+                edge_store,
+                from_id,
+                to_id,
+                namespace,
+                initial_weight=0.5,
+                provenance_type="reinforcement",
             )
-
-            if existing:
-                edge_id = str(existing[0]["edge_id"])
-                await edge_store.adjust_weight(edge_id, 0.03)
+            if created:
+                logger.debug(
+                    "CognitiveMemory.reinforce_between: created new related_to edge",
+                    extra={
+                        "edge_id": edge_id,
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "namespace": namespace,
+                    },
+                )
+            else:
                 logger.debug(
                     "CognitiveMemory.reinforce_between: strengthened existing edge",
                     extra={
                         "edge_id": edge_id,
                         "from_id": from_id,
                         "to_id": to_id,
-                        "weight_delta": 0.03,
-                    },
-                )
-            else:
-                eid = await edge_store.upsert(
-                    from_id=from_id,
-                    to_id=to_id,
-                    edge_type="related_to",
-                    weight=0.5,
-                    namespace=namespace,
-                    provenance_type="reinforcement",
-                )
-                logger.debug(
-                    "CognitiveMemory.reinforce_between: created new related_to edge",
-                    extra={
-                        "edge_id": eid,
-                        "from_id": from_id,
-                        "to_id": to_id,
-                        "namespace": namespace,
+                        "weight_delta": RELATED_TO_STRENGTHEN_DELTA,
                     },
                 )
 
@@ -680,6 +668,7 @@ class CognitiveMemory:
                     await self._intake.note_update(
                         ENRICH_AGENT,
                         NoteUpdateRequest(id=node_id, lcma_status="quarantined"),
+                        origin=EVENT_ORIGIN_ENRICH,
                     )
                     logger.info(
                         "CognitiveMemory.reinforce_misleading: node quarantined",
@@ -690,7 +679,7 @@ class CognitiveMemory:
                 extra={"node_id": node_id, "salience_delta": -0.05},
             )
 
-        edge_store = self._projection._edge_store
+        edge_store = self._projection.edge_store
         seen: set[str] = set()
         for node_id in misleading_ids:
             edges_from = await edge_store.list_edges(from_id=node_id)
@@ -960,7 +949,7 @@ class CognitiveMemory:
                     }
                 loser_id = to_id if winner_id == from_id else from_id
 
-            updated = await self._projection._edge_store.update_conflict_resolution(
+            updated = await self._projection.edge_store.update_conflict_resolution(
                 edge_id,
                 conflict_state=resolution,
                 provenance_actor=resolver,
@@ -985,15 +974,14 @@ class CognitiveMemory:
                 )
 
             await self._emit(
-                LithosEvent(
-                    type=EDGE_UPSERTED,
-                    payload={
-                        "edge_id": edge_id,
-                        "from_id": from_id,
-                        "to_id": to_id,
-                        "type": "contradicts",
-                        "conflict_state": resolution,
-                    },
+                make_edge_upserted_event(
+                    agent=resolver,
+                    edge_id=edge_id,
+                    from_id=from_id,
+                    to_id=to_id,
+                    edge_type="contradicts",
+                    namespace=str(edge["namespace"]),
+                    conflict_state=resolution,
                 )
             )
 

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -76,16 +76,19 @@ class LithosEvent:
     ``origin`` is an internal subsystem marker (see the "Event origin markers"
     section above) — set only by trusted in-process callers, never surfaced on
     the MCP schema or SSE wire. It exists so background workers can drop their
-    own events without keying on the spoofable ``agent`` field.
+    own events without keying on the spoofable ``agent`` field. It is appended
+    **last** so adding it did not shift any existing positional field
+    (``type``/``agent``/``payload``/``tags``/``id``/``timestamp``); all callers
+    set it by keyword.
     """
 
     type: str
     agent: str = ""
-    origin: str = ""
     payload: dict[str, str | int | float | bool | None] = field(default_factory=dict)
     tags: list[str] = field(default_factory=list)
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    origin: str = ""
 
 
 def make_edge_upserted_event(

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -46,6 +46,16 @@ EDGE_UPSERTED = "edge.upserted"
 
 AGENT_REGISTERED = "agent.registered"
 
+# --- Event origin markers ---
+#
+# An internal, non-caller-facing signal on ``LithosEvent.origin`` naming the
+# subsystem that produced a write. Background workers use it to skip their own
+# events (loop-break) WITHOUT overloading the caller-facing ``agent`` field.
+# It is set only by trusted in-process callers (e.g. the enrich worker via the
+# intake) and is never surfaced on the MCP tool schema or the SSE wire, so an
+# external caller cannot forge it. Default ``""`` = ordinary external write.
+EVENT_ORIGIN_ENRICH = "enrich"
+
 BATCH_QUEUED = "batch.queued"
 BATCH_APPLYING = "batch.applying"
 BATCH_PROJECTING = "batch.projecting"
@@ -61,14 +71,54 @@ ENRICH_SUBSCRIBER_QUEUE_SIZE = 10_000
 
 @dataclass
 class LithosEvent:
-    """A typed event emitted by the Lithos event bus."""
+    """A typed event emitted by the Lithos event bus.
+
+    ``origin`` is an internal subsystem marker (see the "Event origin markers"
+    section above) — set only by trusted in-process callers, never surfaced on
+    the MCP schema or SSE wire. It exists so background workers can drop their
+    own events without keying on the spoofable ``agent`` field.
+    """
 
     type: str
     agent: str = ""
+    origin: str = ""
     payload: dict[str, str | int | float | bool | None] = field(default_factory=dict)
     tags: list[str] = field(default_factory=list)
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+def make_edge_upserted_event(
+    *,
+    agent: str,
+    edge_id: str,
+    from_id: str,
+    to_id: str,
+    edge_type: str,
+    namespace: str,
+    conflict_state: str | None = None,
+    origin: str = "",
+) -> LithosEvent:
+    """Build the canonical :data:`EDGE_UPSERTED` event.
+
+    Single source of the payload shape so every emitter
+    (``CorpusIntake.assert_edge``, ``CognitiveMemory.conflict_resolve``) agrees
+    on the same keys — previously the two hand-rolled dicts diverged (one had
+    ``namespace``/``agent`` but no ``conflict_state``, the other the reverse).
+    """
+    return LithosEvent(
+        type=EDGE_UPSERTED,
+        agent=agent,
+        origin=origin,
+        payload={
+            "edge_id": edge_id,
+            "from_id": from_id,
+            "to_id": to_id,
+            "type": edge_type,
+            "namespace": namespace,
+            "conflict_state": conflict_state,
+        },
+    )
 
 
 @dataclass

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -32,12 +32,12 @@ from lithos.coordination import CoordinationService
 from lithos.edge_store import EdgeStore
 from lithos.errors import SlugCollisionError
 from lithos.events import (
-    EDGE_UPSERTED,
     NOTE_CREATED,
     NOTE_DELETED,
     NOTE_UPDATED,
     EventBus,
     LithosEvent,
+    make_edge_upserted_event,
 )
 from lithos.graph import KnowledgeGraph
 from lithos.knowledge import (
@@ -448,7 +448,9 @@ class CorpusIntake:
                 warnings=list(result.warnings),
             )
 
-    async def note_update(self, agent: str, request: NoteUpdateRequest) -> WriteOutcome:
+    async def note_update(
+        self, agent: str, request: NoteUpdateRequest, *, origin: str = ""
+    ) -> WriteOutcome:
         """Patch a note's metadata/tags/title/status without touching its body.
 
         The metadata-only counterpart to :meth:`write`. The body is preserved
@@ -465,6 +467,11 @@ class CorpusIntake:
         ``WriteOutcome(status="slug_collision")``; all other non-success
         ``WriteResult`` statuses are forwarded verbatim. ``ensure_agent_known``
         runs for every call.
+
+        ``origin`` stamps the emitted ``NOTE_UPDATED`` with an internal subsystem
+        marker (e.g. :data:`EVENT_ORIGIN_ENRICH`) so background workers can drop
+        their own writes without keying on the spoofable ``agent`` field. It is a
+        code-level seam parameter — external MCP writes never set it.
         """
         tracer = get_tracer()
         with tracer.start_as_current_span("lithos.intake.note_update") as span:
@@ -533,6 +540,7 @@ class CorpusIntake:
                 LithosEvent(
                     type=NOTE_UPDATED,
                     agent=agent,
+                    origin=origin,
                     payload={"id": doc.id, "title": doc.title, "path": str(doc.path)},
                     tags=list(doc.metadata.tags),
                 )
@@ -591,16 +599,14 @@ class CorpusIntake:
             span.set_attribute("lithos.edge.edge_id", edge_id)
 
             await self._emit(
-                LithosEvent(
-                    type=EDGE_UPSERTED,
+                make_edge_upserted_event(
                     agent=agent,
-                    payload={
-                        "edge_id": edge_id,
-                        "from_id": request.from_id,
-                        "to_id": request.to_id,
-                        "type": request.edge_type,
-                        "namespace": request.namespace,
-                    },
+                    edge_id=edge_id,
+                    from_id=request.from_id,
+                    to_id=request.to_id,
+                    edge_type=request.edge_type,
+                    namespace=request.namespace,
+                    conflict_state=request.conflict_state,
                 )
             )
 

--- a/src/lithos/lcma/edge_reinforce.py
+++ b/src/lithos/lcma/edge_reinforce.py
@@ -1,0 +1,63 @@
+"""Shared reinforcement policy for undirected ``related_to`` edges.
+
+Both the enrich worker's task consolidation (``EnrichWorker._consolidate_task``)
+and CognitiveMemory's citation reinforcement (``reinforce_between``) strengthen
+or create a canonical ``related_to`` edge between a pair of same-namespace nodes.
+The create-or-strengthen mechanics were duplicated; this module owns the single
+copy. Callers keep their own concerns — pair enumeration, canonical
+``from_id <= to_id`` ordering, same-namespace filtering, and any cross-store
+idempotency bookkeeping (they differ only in the initial weight and
+``provenance_type`` recorded for a brand-new edge).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lithos.edge_store import EdgeStore
+
+# Weight bump applied to an already-existing related_to edge when a pair is
+# reinforced again. Shared by both callers (was hard-coded to 0.03 in each).
+RELATED_TO_STRENGTHEN_DELTA = 0.03
+
+
+async def reinforce_related_edge(
+    edge_store: EdgeStore,
+    from_id: str,
+    to_id: str,
+    namespace: str,
+    *,
+    initial_weight: float,
+    provenance_type: str,
+    strengthen_delta: float = RELATED_TO_STRENGTHEN_DELTA,
+) -> tuple[str, bool]:
+    """Strengthen an existing ``related_to`` edge or create one.
+
+    If a ``related_to`` edge already exists for ``(from_id, to_id, namespace)``
+    its weight is bumped by ``strengthen_delta``; otherwise a new edge is created
+    at ``initial_weight`` with ``provenance_type``.
+
+    Returns ``(edge_id, created)`` — ``created`` is ``True`` when a new edge was
+    inserted, ``False`` when an existing edge was strengthened — so callers can
+    keep their own create-vs-strengthen logging.
+
+    The caller is responsible for canonicalising ``from_id <= to_id`` and for
+    same-namespace filtering; this helper neither reorders nor validates.
+    """
+    existing = await edge_store.list_edges(
+        from_id=from_id, to_id=to_id, edge_type="related_to", namespace=namespace
+    )
+    if existing:
+        edge_id = str(existing[0]["edge_id"])
+        await edge_store.adjust_weight(edge_id, strengthen_delta)
+        return edge_id, False
+    edge_id = await edge_store.upsert(
+        from_id=from_id,
+        to_id=to_id,
+        edge_type="related_to",
+        weight=initial_weight,
+        namespace=namespace,
+        provenance_type=provenance_type,
+    )
+    return edge_id, True

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from lithos.events import (
     EDGE_UPSERTED,
     ENRICH_SUBSCRIBER_QUEUE_SIZE,
+    EVENT_ORIGIN_ENRICH,
     FINDING_POSTED,
     NOTE_CREATED,
     NOTE_DELETED,
@@ -23,6 +24,7 @@ from lithos.events import (
     TASK_COMPLETED,
     LithosEvent,
 )
+from lithos.lcma.edge_reinforce import reinforce_related_edge
 from lithos.lcma.entities import ENTITY_EXTRACTOR_VERSION, extract_entities
 
 if TYPE_CHECKING:
@@ -45,22 +47,15 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 
-# System-reserved actor for enrichment-originated Corpus writes. Mirrors
-# ``WATCHER_AGENT`` (watch_intake.py): a synthetic agent id so writes made by
-# the enrich subsystem are attributable and — crucially — recognisable by this
-# worker's own event filter. Enrichment writes now flow through ``CorpusIntake``
-# (which re-indexes Search/graph, fixing Drift) and therefore emit
-# ``NOTE_UPDATED`` / ``EDGE_UPSERTED``; :meth:`EnrichWorker._handle_event` drops
-# events stamped with this actor so the worker never re-enqueues the very node
-# it just wrote (enrich→write→event→enrich).
+# Contributor attribution for enrichment-originated Corpus writes. Mirrors
+# ``WATCHER_AGENT`` (watch_intake.py): a synthetic agent id recorded as the
+# author of writes the enrich subsystem makes (entity extraction, quarantine).
 #
-# RESERVATION CAVEAT: the loop-break keys on the caller-facing ``agent`` string,
-# so an external write that passes agent="lithos-enrich" is also skipped (its
-# node is merely deferred to the periodic full_sweep, not dropped). This id is
-# treated as system-reserved, but that is convention, not enforcement. PR1b of
-# task 681ac952 replaces this with a non-spoofable event-origin marker set by
-# the intake (which callers cannot forge), folded into its EDGE_UPSERTED payload
-# rework.
+# The enrich→write→event→enrich loop-break is NOT keyed on this string — it uses
+# the non-spoofable ``LithosEvent.origin`` marker (:data:`EVENT_ORIGIN_ENRICH`)
+# that the intake stamps and :meth:`EnrichWorker._handle_event` filters on. That
+# marker is a code-level seam the MCP surface never exposes, so an external write
+# passing agent="lithos-enrich" is no longer mistaken for a self-event.
 ENRICH_AGENT = "lithos-enrich"
 
 _SUBSCRIBED_EVENT_TYPES = [
@@ -204,16 +199,16 @@ class EnrichWorker:
 
     async def _handle_event(self, event: LithosEvent) -> None:
         """Route a single event to enrich_queue."""
-        # Drop self-originated events. Enrichment writes now flow through
-        # CorpusIntake (fixing view Drift), which emits NOTE_UPDATED /
-        # EDGE_UPSERTED. Without this guard those events would re-enqueue the
-        # very node the worker just wrote — looping enrich→write→event→enrich.
-        # Filtering on the synthetic actor makes the loop-break explicit rather
-        # than relying on the entities-extractor marker's incidental idempotency.
-        if event.agent == ENRICH_AGENT:
+        # Drop self-originated events. Enrichment writes flow through CorpusIntake
+        # (fixing view Drift), which emits NOTE_UPDATED / EDGE_UPSERTED. Without
+        # this guard those events would re-enqueue the very node the worker just
+        # wrote — looping enrich→write→event→enrich. The origin marker is set by
+        # the intake and cannot be forged through the MCP surface (unlike the
+        # caller-facing ``agent`` field), so this is a non-spoofable loop-break.
+        if event.origin == EVENT_ORIGIN_ENRICH:
             logger.debug(
                 "EnrichWorker: skipping self-originated event",
-                extra={"event_type": event.type, "agent": event.agent},
+                extra={"event_type": event.type, "origin": event.origin},
             )
             return
         logger.debug(
@@ -539,7 +534,7 @@ class EnrichWorker:
         # Route through CorpusIntake so the entity write re-indexes Search/graph
         # and emits NOTE_UPDATED — calling KnowledgeManager.update directly here
         # skipped both, leaving the derived views stale until the next Reconcile
-        # (Drift, task 681ac952). ENRICH_AGENT stamps the emitted event so
+        # (Drift, task 681ac952). ``origin`` stamps the emitted event so
         # :meth:`_handle_event` drops it rather than re-enqueuing this node.
         from lithos.intake import NoteUpdateRequest
 
@@ -550,6 +545,7 @@ class EnrichWorker:
                 entities=extracted,
                 entities_extractor=ENTITY_EXTRACTOR_VERSION,
             ),
+            origin=EVENT_ORIGIN_ENRICH,
         )
         logger.debug(
             "EnrichWorker: entity extraction complete",
@@ -679,22 +675,16 @@ class EnrichWorker:
                     continue
                 await self._stats_store.record_consolidation_edge_op(task_id, from_id, to_id)
 
-                # Upsert or adjust edge
-                existing = await self._edge_store.list_edges(
-                    from_id=from_id, to_id=to_id, edge_type="related_to", namespace=ns
+                # Upsert or strengthen the consolidation edge (shared related_to
+                # policy; consolidation starts a fresh edge at weight 0.03).
+                await reinforce_related_edge(
+                    self._edge_store,
+                    from_id,
+                    to_id,
+                    ns,
+                    initial_weight=0.03,
+                    provenance_type="consolidation",
                 )
-                if existing:
-                    edge_id = str(existing[0]["edge_id"])
-                    await self._edge_store.adjust_weight(edge_id, 0.03)
-                else:
-                    await self._edge_store.upsert(
-                        from_id=from_id,
-                        to_id=to_id,
-                        edge_type="related_to",
-                        weight=0.03,
-                        namespace=ns,
-                        provenance_type="consolidation",
-                    )
 
         # --- Salience boost for each frequent node ---
         for entry in frequent:

--- a/src/lithos/provenance.py
+++ b/src/lithos/provenance.py
@@ -178,6 +178,19 @@ class ProvenanceProjection:
         """
         await self._edge_store.close()
 
+    @property
+    def edge_store(self) -> EdgeStore:
+        """The underlying edge store (public accessor promised to CognitiveMemory).
+
+        ADR-0005 anticipated this so reinforcement/consolidation paths stop
+        reaching through the private ``_edge_store`` attribute. Corpus-derived
+        writes still go through the plan/apply pair; asserted-edge writes through
+        ``CorpusIntake.assert_edge``. This handle serves the LCMA write paths that
+        mutate rows the projection does not own (``related_to`` reinforcement,
+        conflict-resolution updates, edge weakening).
+        """
+        return self._edge_store
+
     # ---- package-private plan/apply (ADR-0001 step 3 / ADR-0004) ----
 
     async def _plan_reconcile_to(self, docs: Iterable[KnowledgeDocument]) -> ProvenancePlan:

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -120,6 +120,14 @@ async def memory(
         await cm.stop()
 
 
+async def test_projection_edge_store_property_exposes_store(
+    projection: ProvenanceProjection,
+) -> None:
+    """The public ``edge_store`` property returns the underlying store (11c) —
+    callers no longer reach through the private ``_edge_store`` attribute."""
+    assert projection.edge_store is projection._edge_store
+
+
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------
@@ -1375,3 +1383,21 @@ class TestConflictResolve:
         assert doc.metadata.supersedes == loser
         # ... and the winner was re-indexed through the intake view-sync (the fix).
         assert mock_search.index.called, "supersede did not re-index Search"
+
+    async def test_emits_unified_edge_upserted_payload(self, memory: CognitiveMemory) -> None:
+        """conflict_resolve emits EDGE_UPSERTED with the canonical unified payload
+        (agent + namespace + conflict_state), matching CorpusIntake.assert_edge —
+        the two hand-rolled dicts used to diverge (11c, task 681ac952)."""
+        edge_id = await self._make_contradiction_edge(memory)
+        memory._event_bus = AsyncMock()  # type: ignore[assignment]
+
+        await memory.conflict_resolve(
+            edge_id=edge_id, resolution="accepted_dual", resolver="agent-x"
+        )
+
+        event = memory._event_bus.emit.await_args.args[0]
+        assert event.type == EDGE_UPSERTED
+        assert event.agent == "agent-x"
+        assert event.payload["type"] == "contradicts"
+        assert event.payload["namespace"] == "default"
+        assert event.payload["conflict_state"] == "accepted_dual"

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -12,6 +12,7 @@ import pytest_asyncio
 from lithos.config import LcmaConfig, LithosConfig
 from lithos.events import (
     EDGE_UPSERTED,
+    EVENT_ORIGIN_ENRICH,
     FINDING_POSTED,
     NOTE_CREATED,
     NOTE_DELETED,
@@ -114,6 +115,35 @@ async def worker(
         coordination=mock_coordination,
         intake=_make_intake(mock_knowledge, event_bus, edge_store, mock_coordination),
     )
+
+
+async def test_reinforce_related_edge_creates_then_strengthens(edge_store: EdgeStore) -> None:
+    """Shared related_to policy (task 681ac952 dedup): the first call creates an
+    edge at ``initial_weight``, the second strengthens that same edge by the
+    delta. Both EnrichWorker._consolidate_task and CognitiveMemory.reinforce_between
+    route through this helper (differing only in initial weight / provenance_type).
+    """
+    from lithos.lcma.edge_reinforce import RELATED_TO_STRENGTHEN_DELTA, reinforce_related_edge
+
+    eid, created = await reinforce_related_edge(
+        edge_store, "a", "b", "default", initial_weight=0.5, provenance_type="reinforcement"
+    )
+    assert created is True
+    edges = await edge_store.list_edges(
+        from_id="a", to_id="b", edge_type="related_to", namespace="default"
+    )
+    assert len(edges) == 1
+    assert edges[0]["weight"] == pytest.approx(0.5)
+
+    eid2, created2 = await reinforce_related_edge(
+        edge_store, "a", "b", "default", initial_weight=0.5, provenance_type="reinforcement"
+    )
+    assert created2 is False
+    assert eid2 == eid
+    edges2 = await edge_store.list_edges(
+        from_id="a", to_id="b", edge_type="related_to", namespace="default"
+    )
+    assert edges2[0]["weight"] == pytest.approx(0.5 + RELATED_TO_STRENGTHEN_DELTA)
 
 
 # ---------------------------------------------------------------------------
@@ -952,20 +982,35 @@ class TestSelfOriginatedEventFilter:
     """
 
     async def test_self_originated_event_is_dropped(self, worker: EnrichWorker) -> None:
+        """An event carrying the enrich origin marker is dropped (loop-break)."""
         worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
 
         await worker._handle_event(
-            LithosEvent(type=NOTE_UPDATED, agent=ENRICH_AGENT, payload={"id": "n1"})
+            LithosEvent(type=NOTE_UPDATED, origin=EVENT_ORIGIN_ENRICH, payload={"id": "n1"})
         )
 
         worker._stats_store.enqueue.assert_not_called()
 
-    async def test_other_agents_still_enqueue(self, worker: EnrichWorker) -> None:
-        """The filter is specific to ENRICH_AGENT — genuine agent writes still enqueue."""
+    async def test_other_events_still_enqueue(self, worker: EnrichWorker) -> None:
+        """The filter is specific to the origin marker — ordinary writes still enqueue."""
         worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
 
         await worker._handle_event(
             LithosEvent(type=NOTE_UPDATED, agent="real-agent", payload={"id": "n1"})
+        )
+
+        worker._stats_store.enqueue.assert_awaited_once()
+
+    async def test_agent_string_alone_does_not_suppress(self, worker: EnrichWorker) -> None:
+        """Finding-1 fix: a write with agent='lithos-enrich' but NO origin marker is
+        not treated as a self-event. The loop-break keys on the non-spoofable
+        ``origin`` set by the intake, not the caller-facing ``agent`` field, so an
+        external caller can no longer suppress its own enrichment by spoofing the id.
+        """
+        worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
+
+        await worker._handle_event(
+            LithosEvent(type=NOTE_UPDATED, agent=ENRICH_AGENT, payload={"id": "n1"})
         )
 
         worker._stats_store.enqueue.assert_awaited_once()
@@ -1012,12 +1057,15 @@ class TestSelfOriginatedEventFilter:
 
         await worker._extract_entities(doc_id)
 
-        # The entity write emitted a NOTE_UPDATED stamped with the sentinel actor ...
+        # The entity write emitted a NOTE_UPDATED carrying the enrich origin
+        # marker (and attributed to ENRICH_AGENT) ...
         emitted = captured_bus.emit.await_args.args[0]
         assert emitted.type == NOTE_UPDATED
         assert emitted.agent == ENRICH_AGENT
+        assert emitted.origin == EVENT_ORIGIN_ENRICH
         assert emitted.payload["id"] == doc_id
-        # ... and routing that same emitted event back through the worker drops it.
+        # ... and routing that same emitted event back through the worker drops it
+        # (on the origin marker, not the agent).
         worker._stats_store.enqueue = AsyncMock()  # type: ignore[method-assign]
         await worker._handle_event(emitted)
         worker._stats_store.enqueue.assert_not_called()

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -25,6 +25,7 @@ from starlette.responses import StreamingResponse
 
 from lithos.config import EventsConfig, LithosConfig, StorageConfig
 from lithos.events import (
+    EVENT_ORIGIN_ENRICH,
     NOTE_CREATED,
     NOTE_DELETED,
     NOTE_UPDATED,
@@ -143,6 +144,22 @@ class TestFormatSSE:
         assert data["task_id"] == "t1"
         assert data["title"] == "My Task"
         assert data["agent"] == "bot"
+
+    def test_origin_not_emitted_on_wire(self) -> None:
+        """The internal ``origin`` loop-break marker must never reach SSE clients
+        (task 681ac952): it is an in-process signal, not part of the event wire.
+        """
+        evt = LithosEvent(
+            type=NOTE_UPDATED,
+            agent="az",
+            origin=EVENT_ORIGIN_ENRICH,
+            payload={"id": "n1"},
+        )
+        result = _format_sse(evt)
+        assert "origin" not in result
+        assert EVENT_ORIGIN_ENRICH not in result
+        data = json.loads(result.split("data: ")[1].strip())
+        assert "origin" not in data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -21,6 +21,7 @@ from lithos.edge_store import EdgeStore
 from lithos.errors import SlugCollisionError
 from lithos.events import (
     EDGE_UPSERTED,
+    EVENT_ORIGIN_ENRICH,
     NOTE_CREATED,
     NOTE_DELETED,
     NOTE_UPDATED,
@@ -325,6 +326,33 @@ async def test_note_update_forwards_supersedes(
     assert outcome.status == "updated"
     doc, _ = await knowledge_manager.read(id=winner.document.id)
     assert doc.metadata.supersedes == loser.document.id
+
+
+@pytest.mark.asyncio
+async def test_note_update_stamps_internal_origin_on_event(
+    stub_intake: tuple[CorpusIntake, dict[str, Any]],
+    knowledge_manager: KnowledgeManager,
+) -> None:
+    """The ``origin`` seam stamps the emitted NOTE_UPDATED; default is unset.
+
+    This is the non-spoofable loop-break marker (task 681ac952): background
+    workers drop events carrying their own origin. It is a code-level parameter,
+    never exposed on the MCP tool surface, so external writes always emit "".
+    """
+    intake, mocks = stub_intake
+    created = await knowledge_manager.create(title="orig", content="b", agent="agent-1")
+    assert created.document is not None
+    doc_id = created.document.id
+
+    # Default: ordinary external write carries no origin.
+    await intake.note_update("agent-1", NoteUpdateRequest(id=doc_id, tags=["x"]))
+    assert mocks["event_bus"].emit.await_args.args[0].origin == ""
+
+    # Explicit internal origin is stamped onto the event.
+    await intake.note_update(
+        "agent-1", NoteUpdateRequest(id=doc_id, tags=["y"]), origin=EVENT_ORIGIN_ENRICH
+    )
+    assert mocks["event_bus"].emit.await_args.args[0].origin == EVENT_ORIGIN_ENRICH
 
 
 @pytest.mark.asyncio
@@ -838,6 +866,9 @@ async def test_assert_edge_emits_edge_upserted_after_upsert(
     assert emitted_event.payload["to_id"] == "b"
     assert emitted_event.payload["type"] == "related_to"
     assert emitted_event.payload["namespace"] == "default"
+    # Unified EDGE_UPSERTED shape carries conflict_state (None here); the
+    # conflict_resolve emitter produces the same keys (task 681ac952 / 11c).
+    assert emitted_event.payload["conflict_state"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**PR1b of task `681ac952`** — the clean, no-behaviour-change half of Task 2 (edge-policy consolidation). PR1a fixed the Drift bug + added the loop-break; this PR consolidates the edge-write surfaces. The behaviour-changing provenance-projection migration is deferred to **PR1c**.

Three consolidations, all low-risk:

### 1. Loop-break hardening (PR1a review Finding 1)

The `enrich→write→event→enrich` loop-break now keys on a new **non-spoofable `LithosEvent.origin` marker** set by the intake, not the caller-facing `agent` string. Previously an external write passing `agent="lithos-enrich"` would have been dropped as a self-event; now it isn't. `origin` is a code-level seam parameter on `CorpusIntake.note_update` — absent from the MCP tool schema **and** the SSE wire, so callers cannot forge it. `ENRICH_AGENT` remains as contributor attribution only.

### 2. `related_to` policy dedup

`EnrichWorker._consolidate_task` and `CognitiveMemory.reinforce_between` shared a create-or-strengthen skeleton (differing only in initial weight / `provenance_type`). Extracted to `lcma/edge_reinforce.reinforce_related_edge`, which returns `(edge_id, created)` so each caller keeps its own create-vs-strengthen logging.

### 3. 11c edge_store plumbing

- Added the public **`ProvenanceProjection.edge_store` property** (promised in ADR-0005) and retired the **6 `_projection._edge_store` reach-throughs** in `cognitive_memory.py`.
- Unified the two divergent `EDGE_UPSERTED` payloads behind **`events.make_edge_upserted_event`** — one shape (`edge_id`, `from_id`, `to_id`, `type`, `namespace`, `conflict_state`). Previously `assert_edge` had `namespace`/`agent` but no `conflict_state`, and `conflict_resolve` the reverse.

## Not in this PR

- **PR1c** (behaviour change): route enrich's `derived_from` writes through `ProvenanceProjection` plan/apply (needs a new per-node projection method + injecting the projection into `EnrichWorker` + the asserted-key/drift handling the simpler helper lacks).
- `cli.py` extract-entities still writes directly (crosses no lcma seam; folds into Task 6's CLI factory).

## Guardrails

No new cross-component edge — `CognitiveMemory→LCMA` already existed, so importing `lcma.edge_reinforce` adds none; the new module maps to the LCMA component by prefix. `cross_component_edges` stays 64. Regenerated `docs/generated/` committed.

## Test plan

- [x] `make check` — typecheck 0 errors, unit **1556 passed**, lint clean
- [x] `make test-integration` — **428 passed**
- [x] `make diagrams` — 48 guardrails pass; regenerated docs committed
- New/updated tests:
  - `test_enrich_worker.py`: loop-break now keyed on `origin`; **`test_agent_string_alone_does_not_suppress`** proves the Finding-1 fix (agent string no longer suppresses); connecting test asserts the emitted event carries `origin`; `test_reinforce_related_edge_creates_then_strengthens` covers the shared helper.
  - `test_intake.py`: `test_note_update_stamps_internal_origin_on_event` (origin passthrough + default `""`); assert_edge emit test now asserts the unified `conflict_state` key.
  - `test_cognitive_memory.py`: `test_emits_unified_edge_upserted_payload` (conflict_resolve now carries agent/namespace/conflict_state); `test_projection_edge_store_property_exposes_store`.
