### PR TITLE
refactor: one composition root for the component graph (PR2a, task ba8d7f25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,16 @@ Environment variables override `endpoint` per signal when needed:
 
 ### Local debugging without a collector
 
-Pass `--telemetry-console` to `lithos serve` to route metrics and spans to
-stdout via console exporters. This is equivalent to setting
-`telemetry.enabled=true` + `telemetry.console_fallback=true` in config, and is
-the shortest path to "is my instrumentation even firing?" when no collector is
-running.
+Pass `--telemetry-console` to `lithos` to route metrics and spans to stdout
+via console exporters. This is equivalent to setting `telemetry.enabled=true` +
+`telemetry.console_fallback=true` in config, and is the shortest path to "is my
+instrumentation even firing?" when no collector is running.
+
+It is a global option, so it works for any command — not just `serve`:
 
 ```bash
-lithos --data-dir ./data serve --telemetry-console
+lithos --data-dir ./data --telemetry-console serve
+lithos --data-dir ./data --telemetry-console reconcile
 ```
 
 ### Running the full observability stack locally

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1607,7 +1607,7 @@ lithos --data-dir ./data serve --transport http --host 0.0.0.0 --port 8765
 lithos --data-dir ./data serve --no-watch
 
 # Route OTEL metrics + spans to stdout (local debugging without a collector)
-lithos --data-dir ./data serve --telemetry-console
+lithos --data-dir ./data --telemetry-console serve
 
 # Rebuild indices (incremental by default)
 lithos --data-dir ./data reindex

--- a/docs/adr/0008-entity-extraction-ner-and-provenance.md
+++ b/docs/adr/0008-entity-extraction-ner-and-provenance.md
@@ -49,3 +49,18 @@ The v3 staging sweep surfaced two residual classes the gate still let through:
 - **Junk wiki-link targets** (`[[\phi]]`, `[[IntegerPropertyFilter(...)]]`) — wiki-link targets were kept verbatim as author intent, bypassing every other gate. v4 still keeps them lenient but drops a target carrying code punctuation (`()[]{}=<>`), a leading backslash (LaTeX), or a filename extension. Real links (`[[Knowledge Graph]]`, `[[target-doc|display]]`) are unaffected.
 
 `ENTITY_EXTRACTOR_VERSION` → 4; the `--force` re-sweep heals the corpus via the marker contract.
+
+## Amendment — `extract-entities` no longer needs a follow-up reconcile (task ba8d7f25)
+
+The Consequences above say operators run `lithos reconcile` after
+`lithos extract-entities --force` to refresh derived views. That is no longer
+true, and the requirement was never by design: the command wrote through
+`KnowledgeManager.update`, which bypassed the Search/graph re-index and emitted
+no event, so the reconcile existed to repair drift the command itself had
+manufactured (the same bypass task 681ac952 removed from the enrich worker).
+
+The command now routes through `CorpusIntake.note_update`, which re-indexes the
+derived views inline and emits `NOTE_UPDATED` — stamped `origin=enrich` so a
+running worker drops the event rather than re-enqueueing the node. Extraction is
+still a corpus mutation and therefore still not a Reconcile (see CONTEXT.md);
+what changed is that it no longer leaves drift behind for one.

--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -35,7 +35,7 @@ src_layout   = "src"
 # (docs/generated/components/<Component>.md). test_component_pages requires one
 # for every component in [components].
 [component_docs]
-Entrypoints     = "CLI, MCP server, tool handlers, and filesystem watcher — the outward-facing surfaces."
+Entrypoints     = "CLI, MCP server, tool handlers, filesystem watcher — the outward-facing surfaces — plus the composition root that wires the graph for a process."
 Knowledge       = "The corpus owner: Markdown note CRUD with frontmatter, plus reconcile of derived views."
 Search          = "Full-text (Tantivy) and semantic (ChromaDB) search behind one engine that hides its backends."
 Graph           = "The wiki-link knowledge graph and the authoritative edges.db store."
@@ -51,7 +51,12 @@ Errors          = "Standard error types and canonical MCP error envelopes."
 Logging         = "Structured JSON logging setup."
 
 [components]
-Entrypoints     = ["lithos.cli", "lithos.server", "lithos.tools", "lithos.watch_intake", "lithos.__main__"]
+# lithos.pipeline is the composition root: it imports across Core to assemble the
+# graph, and only Entrypoints (server, cli) import it. It belongs at the outermost
+# layer for the same reason a DI container does — Core must stay unaware of who
+# wires it. Placing it in Core instead would add a Core module depending on nine
+# other Core components, which is the cycle-prone shape this model exists to catch.
+Entrypoints     = ["lithos.cli", "lithos.server", "lithos.tools", "lithos.watch_intake", "lithos.__main__", "lithos.pipeline"]
 Knowledge       = ["lithos.knowledge", "lithos.reconcile", "lithos._merge"]
 Search          = ["lithos.search"]
 Graph           = ["lithos.graph", "lithos.edge_store"]
@@ -135,9 +140,10 @@ include_modules = [
     "lithos.intake",
     "lithos.search",
 ]
-# Not domain entities: config/settings, error types, and LCMA-internal pipeline
-# working types (e.g. lcma.utils.Candidate).
-exclude_modules = ["lithos.config", "lithos.errors", "lithos.lcma"]
+# Not domain entities: config/settings, error types, LCMA-internal pipeline
+# working types (e.g. lcma.utils.Candidate), and the composition root's Pipeline
+# — a wiring container holding the built components, not a thing the domain has.
+exclude_modules = ["lithos.config", "lithos.errors", "lithos.lcma", "lithos.pipeline"]
 
 # Container / data-store view (docs/generated/containers.md). Store topology is
 # deployment knowledge, not derivable from imports — declared here, but every

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,9 +34,19 @@ These options apply to all commands:
 lithos [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  -c, --config PATH    Path to config file (YAML)
-  -d, --data-dir PATH  Data directory path
-  --help               Show this message and exit.
+  -c, --config PATH     Path to config file (YAML)
+  -d, --data-dir PATH   Data directory path
+  --telemetry-console   Route OTEL metrics + spans to stdout (local debugging
+                        without a collector)
+  --help                Show this message and exit.
+```
+
+Logging and telemetry are set up once here, at the group entrypoint, so **every**
+command exports spans and metrics — not just `serve`. `--telemetry-console` is
+therefore global too, and works for any command:
+
+```bash
+lithos --telemetry-console reconcile
 ```
 
 ## Commands
@@ -61,9 +71,8 @@ lithos serve --no-watch
 | `--host` | `127.0.0.1` | Host for the HTTP transport |
 | `-p, --port` | `8765` | Port for the HTTP transport |
 | `--watch / --no-watch` | watch enabled | Watch for file changes |
-| `--telemetry-console` | off | Route OTEL metrics + spans to stdout (for local debugging without a collector) |
 
-> **Metrics:** Lithos exports metrics via OTLP push to a configured OTEL collector — there is no `/metrics` scrape endpoint on the process itself. See the "Telemetry & Observability" section in the main README for the full push→collector→Prometheus data flow, or use `--telemetry-console` above when no collector is available.
+> **Metrics:** Lithos exports metrics via OTLP push to a configured OTEL collector — there is no `/metrics` scrape endpoint on the process itself. See the "Telemetry & Observability" section in the main README for the full push→collector→Prometheus data flow, or use the global `--telemetry-console` option when no collector is available.
 
 ### `search` — Search the knowledge base
 

--- a/docs/generated/components/Entrypoints.md
+++ b/docs/generated/components/Entrypoints.md
@@ -3,7 +3,7 @@
 
 # Entrypoints
 
-CLI, MCP server, tool handlers, and filesystem watcher — the outward-facing surfaces.
+CLI, MCP server, tool handlers, filesystem watcher — the outward-facing surfaces — plus the composition root that wires the graph for a process.
 
 **Tier:** Entrypoints
 
@@ -12,6 +12,7 @@ CLI, MCP server, tool handlers, and filesystem watcher — the outward-facing su
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
 | `lithos.cli` | L | 0 | 15 |
+| `lithos.pipeline` | S | 1 | 1 |
 | `lithos.server` | L | 1 | 2 |
 | `lithos.tools` | XS | 0 | 1 |
 | `lithos.tools._seam` | XS | 0 | 1 |
@@ -41,6 +42,10 @@ CLI, MCP server, tool handlers, and filesystem watcher — the outward-facing su
 - def `inspect_doc` — Inspect a knowledge document by ID or path.
 - def `audit` — Show the read-access audit log.
 - def `main` — Main entry point.
+
+### `lithos.pipeline`
+- class `Pipeline` — A fully-wired, not-yet-running Lithos component graph.
+- def `build_pipeline` — Build the component graph for *config*, in dependency order.
 
 ### `lithos.server`
 - class `LithosServer` — Lithos MCP Server.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -17,7 +17,7 @@
         "max_function": "lithos.coordination.CoordinationService.create_task"
       },
       "Entrypoints": {
-        "functions_over_10": 13,
+        "functions_over_10": 14,
         "max_complexity": 65,
         "max_function": "lithos.tools.notes.register.lithos_write"
       },
@@ -72,7 +72,7 @@
         "max_function": "lithos.telemetry.setup_telemetry"
       }
     },
-    "functions_over_10": 63,
+    "functions_over_10": 64,
     "top_functions": [
       {
         "complexity": 71,
@@ -115,7 +115,7 @@
         "qualname": "lithos.server.LithosServer._validate_task_feedback"
       }
     ],
-    "total_functions": 669
+    "total_functions": 670
   },
   "domain": {
     "associations": 26,
@@ -343,10 +343,10 @@
         "functions": 125,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5373,
+        "lines": 5404,
         "modules": 12,
         "public_symbols": 29,
-        "sloc": 4336
+        "sloc": 4356
       },
       "Errors": {
         "classes": 9,
@@ -380,13 +380,13 @@
       },
       "Intake": {
         "classes": 8,
-        "functions": 6,
+        "functions": 7,
         "largest_module": "lithos.intake",
-        "largest_module_lines": 624,
-        "lines": 624,
+        "largest_module_lines": 635,
+        "lines": 635,
         "modules": 1,
         "public_symbols": 8,
-        "sloc": 529
+        "sloc": 538
       },
       "Knowledge": {
         "classes": 10,
@@ -464,13 +464,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23501,
+    "total_lines": 23543,
     "total_modules": 38,
-    "total_sloc": 18987
+    "total_sloc": 19016
   },
   "tests": {
     "ratio": 1.85,
-    "src_lines": 23501,
-    "test_lines": 43526
+    "src_lines": 23543,
+    "test_lines": 43586
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -17,7 +17,7 @@
         "max_function": "lithos.coordination.CoordinationService.create_task"
       },
       "Entrypoints": {
-        "functions_over_10": 14,
+        "functions_over_10": 13,
         "max_complexity": 65,
         "max_function": "lithos.tools.notes.register.lithos_write"
       },
@@ -72,7 +72,7 @@
         "max_function": "lithos.telemetry.setup_telemetry"
       }
     },
-    "functions_over_10": 64,
+    "functions_over_10": 63,
     "top_functions": [
       {
         "complexity": 71,
@@ -115,7 +115,7 @@
         "qualname": "lithos.server.LithosServer._validate_task_feedback"
       }
     ],
-    "total_functions": 666
+    "total_functions": 669
   },
   "domain": {
     "associations": 26,
@@ -204,7 +204,7 @@
       }
     },
     "cross_component_edges": 63,
-    "cross_component_module_edges": 131,
+    "cross_component_module_edges": 142,
     "longest_component_chain": 7,
     "module_cycle_count": 2,
     "module_cycles": [
@@ -312,11 +312,11 @@
         "classes": 2,
         "functions": 27,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 992,
-        "lines": 992,
+        "largest_module_lines": 998,
+        "lines": 998,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 814
+        "sloc": 820
       },
       "Config": {
         "classes": 9,
@@ -339,14 +339,14 @@
         "sloc": 2256
       },
       "Entrypoints": {
-        "classes": 3,
-        "functions": 122,
-        "largest_module": "lithos.server",
-        "largest_module_lines": 1004,
-        "lines": 5203,
-        "modules": 11,
-        "public_symbols": 27,
-        "sloc": 4202
+        "classes": 4,
+        "functions": 125,
+        "largest_module": "lithos.tools.tasks",
+        "largest_module_lines": 985,
+        "lines": 5373,
+        "modules": 12,
+        "public_symbols": 29,
+        "sloc": 4336
       },
       "Errors": {
         "classes": 9,
@@ -464,13 +464,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23325,
-    "total_modules": 37,
-    "total_sloc": 18847
+    "total_lines": 23501,
+    "total_modules": 38,
+    "total_sloc": 18987
   },
   "tests": {
     "ratio": 1.85,
-    "src_lines": 23325,
-    "test_lines": 43266
+    "src_lines": 23501,
+    "test_lines": 43526
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -21,7 +21,7 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **63** (131 module-level)
+- Cross-component edges: **63** (142 module-level)
 - Component cycles: Graph ↔ Knowledge ↔ Provenance ↔ Search
 - Module cycles: lithos.graph ↔ lithos.knowledge ↔ lithos.provenance ↔ lithos.search; lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
@@ -34,10 +34,10 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
-| CognitiveMemory | 1 | 992 | 814 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 998 | 820 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 11 | 5203 | 4202 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
+| Entrypoints | 12 | 5373 | 4336 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 13 |
 | Errors | 2 | 210 | 151 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
@@ -51,7 +51,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **37**, lines: **23325**, SLOC: **18847**
+- Modules: **38**, lines: **23501**, SLOC: **18987**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -68,7 +68,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **666**, cyclomatic > 10: **64**
+- Functions: **669**, cyclomatic > 10: **63**
 
 Top 10 most complex functions:
 
@@ -157,4 +157,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.85** (43266 test lines / 23325 source lines)
+- Test-to-source line ratio: **1.85** (43526 test lines / 23501 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -37,11 +37,11 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | CognitiveMemory | 1 | 998 | 820 | 1 | 11 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 12 | 5373 | 4336 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 13 |
+| Entrypoints | 12 | 5404 | 4356 | 0 | 12 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 14 |
 | Errors | 2 | 210 | 151 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
-| Intake | 1 | 624 | 529 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
+| Intake | 1 | 635 | 538 | 3 | 7 | 0.70 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 3127 | 2524 | 7 | 6 | 0.46 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 11 |
 | LCMA | 9 | 4534 | 3657 | 1 | 10 | 0.91 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
@@ -51,7 +51,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **38**, lines: **23501**, SLOC: **18987**
+- Modules: **38**, lines: **23543**, SLOC: **19016**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -68,7 +68,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **669**, cyclomatic > 10: **63**
+- Functions: **670**, cyclomatic > 10: **64**
 
 Top 10 most complex functions:
 
@@ -157,4 +157,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **42** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.85** (43526 test lines / 23501 source lines)
+- Test-to-source line ratio: **1.85** (43586 test lines / 23543 source lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ forbidden_modules = [
     "lithos.watch_intake",
     "lithos.__main__",
     "lithos.tools",
+    "lithos.pipeline",
 ]
 
 [[tool.importlinter.contracts]]
@@ -187,6 +188,7 @@ forbidden_modules = [
     "lithos.watch_intake",
     "lithos.__main__",
     "lithos.tools",
+    "lithos.pipeline",
 ]
 
 [tool.pytest.ini_options]

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -10,6 +10,7 @@ import click
 
 from lithos.config import LithosConfig, load_config, set_config
 from lithos.logging_config import setup_logging
+from lithos.telemetry import setup_telemetry, shutdown_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +28,19 @@ logger = logging.getLogger(__name__)
     type=click.Path(path_type=Path),
     help="Data directory path",
 )
+@click.option(
+    "--telemetry-console",
+    is_flag=True,
+    default=False,
+    help="Route OTEL metrics + spans to stdout (local debugging without a collector)",
+)
 @click.pass_context
-def cli(ctx: click.Context, config: Path | None, data_dir: Path | None) -> None:
+def cli(
+    ctx: click.Context,
+    config: Path | None,
+    data_dir: Path | None,
+    telemetry_console: bool,
+) -> None:
     """Lithos - Local shared knowledge base for AI agents."""
     ctx.ensure_object(dict)
 
@@ -39,8 +51,27 @@ def cli(ctx: click.Context, config: Path | None, data_dir: Path | None) -> None:
     if data_dir:
         cfg.storage.data_dir = data_dir
 
+    # --telemetry-console: ensure telemetry runs in console-fallback mode so
+    # metrics/spans land on stdout even when no OTLP collector is configured.
+    # This is a DX shortcut for local debugging — see also #164. Must be applied
+    # before setup_telemetry() reads the config below.
+    if telemetry_console:
+        cfg.telemetry.enabled = True
+        cfg.telemetry.console_fallback = True
+        click.echo("Telemetry console-fallback enabled (metrics + spans will print to stdout).")
+
     set_config(cfg)
     ctx.obj["config"] = cfg
+
+    # Observability belongs to the whole CLI, not just ``serve``. Both calls
+    # used to live in the serve command body, so every other command ran with
+    # no-op providers: `lithos reconcile` — the operator's repair tool — emitted
+    # none of the spans and metrics its code path raises. Setting up here also
+    # means construction-time log records land in a configured root logger
+    # rather than being dropped.
+    setup_logging()
+    setup_telemetry(cfg)
+    ctx.call_on_close(shutdown_telemetry)
 
 
 @cli.command()
@@ -68,16 +99,6 @@ def cli(ctx: click.Context, config: Path | None, data_dir: Path | None) -> None:
     default=True,
     help="Watch for file changes (default: enabled)",
 )
-@click.option(
-    "--telemetry-console",
-    is_flag=True,
-    default=False,
-    help=(
-        "Route OTEL metrics and spans to stdout via console exporters. "
-        "Useful for local debugging when no OTEL collector is running. "
-        "Equivalent to setting telemetry.enabled=true + telemetry.console_fallback=true."
-    ),
-)
 @click.pass_context
 def serve(
     ctx: click.Context,
@@ -85,21 +106,11 @@ def serve(
     host: str,
     port: int,
     watch: bool,
-    telemetry_console: bool,
 ) -> None:
     """Start the Lithos MCP server."""
     from lithos.server import create_server
-    from lithos.telemetry import setup_telemetry, shutdown_telemetry
 
     config: LithosConfig = ctx.obj["config"]
-
-    # --telemetry-console: ensure telemetry runs in console-fallback mode so
-    # metrics/spans land on stdout even when no OTLP collector is configured.
-    # This is a DX shortcut for local debugging — see also #164.
-    if telemetry_console:
-        config.telemetry.enabled = True
-        config.telemetry.console_fallback = True
-        click.echo("Telemetry console-fallback enabled (metrics + spans will print to stdout).")
 
     server = create_server(config)
 
@@ -158,8 +169,6 @@ def serve(
             )
 
     try:
-        setup_logging()
-        setup_telemetry(config)
         asyncio.run(run_server())
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
@@ -169,8 +178,6 @@ def serve(
         # (ADR-0007) — one call, no risk of forgetting a subsystem.
         asyncio.run(server.shutdown())
         logger.info("lithos server stopped")
-    finally:
-        shutdown_telemetry()
 
 
 @cli.command()
@@ -182,20 +189,18 @@ def serve(
 @click.pass_context
 def reindex(ctx: click.Context, clear: bool) -> None:
     """Rebuild search indices from knowledge files."""
-    from lithos.graph import KnowledgeGraph
-    from lithos.knowledge import KnowledgeManager
-    from lithos.provenance import ProvenanceProjection
-    from lithos.search import SearchEngine
+    from lithos.pipeline import build_pipeline
 
     config: LithosConfig = ctx.obj["config"]
-    config.ensure_directories()
-
-    knowledge = KnowledgeManager(config)
-    graph = KnowledgeGraph(config)
 
     async def do_reindex() -> None:
-        search = await SearchEngine.create(config)
-        projection = await ProvenanceProjection.create(config)
+        # One EdgeStore writer, shared by the projection and the intake
+        # (ADR-0006 Slice 1, #263). This command used to call
+        # ProvenanceProjection.create(config) with no injected store, which took
+        # the self-create branch and opened a second writer against edges.db.
+        pipeline = await build_pipeline(config)
+        knowledge, search, graph = pipeline.knowledge, pipeline.search, pipeline.graph
+        projection = pipeline.projection
         try:
             if clear:
                 click.echo("Clearing existing indices...")
@@ -240,7 +245,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
             click.echo(f"Graph nodes: {graph.node_count()}")
             click.echo(f"Graph edges: {graph.edge_count()}")
         finally:
-            await projection.close()
+            await pipeline.aclose()
 
     asyncio.run(do_reindex())
 
@@ -544,14 +549,31 @@ def extract_entities_cmd(ctx: click.Context, dry_run: bool, force: bool) -> None
     (no marker) are preserved. Use --force once to bootstrap a corpus written
     before extractor provenance existed.
     """
-    from lithos.cognitive_memory import ENTITY_EXTRACTOR_VERSION, extract_entities
+    from lithos.cognitive_memory import ENRICH_AGENT, ENTITY_EXTRACTOR_VERSION, extract_entities
+    from lithos.events import EVENT_ORIGIN_ENRICH
+    from lithos.intake import NoteUpdateRequest
     from lithos.knowledge import KnowledgeManager
+    from lithos.pipeline import Pipeline, build_pipeline
 
     config: LithosConfig = ctx.obj["config"]
     config.ensure_directories()
-    knowledge = KnowledgeManager(config)
 
     async def run() -> None:
+        # A dry run only reads, so it stays cheap: no pipeline, hence no
+        # embedding-model load and no edges.db created as a side effect of
+        # asking a read-only question.
+        pipeline = None if dry_run else await build_pipeline(config)
+        try:
+            await _extract(pipeline)
+        finally:
+            if pipeline is not None:
+                # Release the aiosqlite handle even if extraction raised —
+                # a leaked worker thread is the #172 "event loop is closed" hang.
+                await pipeline.aclose()
+
+    async def _extract(pipeline: "Pipeline | None") -> None:
+        knowledge = pipeline.knowledge if pipeline else KnowledgeManager(config)
+
         _, total = await knowledge.list_all(limit=0)
         docs, _ = (await knowledge.list_all(limit=total)) if total else ([], 0)
         click.echo(f"Scanning {len(docs)} documents (force={force}, dry_run={dry_run})")
@@ -585,12 +607,21 @@ def extract_entities_cmd(ctx: click.Context, dry_run: bool, force: bool) -> None
             before_count += len(doc.metadata.entities)
             after_count += len(extracted)
             updated += 1
-            if not dry_run:
-                result = await knowledge.update(
-                    id=doc.id,
-                    agent="lithos-enrich",
-                    entities=extracted,
-                    entities_extractor=ENTITY_EXTRACTOR_VERSION,
+            if pipeline is not None:
+                # Route through CorpusIntake, not KnowledgeManager.update: the
+                # direct call skipped the Search/graph re-index and emitted no
+                # event, manufacturing Drift (task 681ac952). PR1a fixed this on
+                # the enrich worker's path; this CLI copy was the other half.
+                # origin marks the write as enrich-originated so a running
+                # worker drops the event instead of re-enqueueing the node.
+                result = await pipeline.intake.note_update(
+                    ENRICH_AGENT,
+                    NoteUpdateRequest(
+                        id=doc.id,
+                        entities=extracted,
+                        entities_extractor=ENTITY_EXTRACTOR_VERSION,
+                    ),
+                    origin=EVENT_ORIGIN_ENRICH,
                 )
                 if result.status != "updated":
                     click.echo(f"  failed to update {doc.id}: {result.message}", err=True)
@@ -605,8 +636,9 @@ def extract_entities_cmd(ctx: click.Context, dry_run: bool, force: bool) -> None
                 f"entities on touched docs: {before_count} -> {after_count}"
                 f" (mean {before_count / updated:.1f} -> {after_count / updated:.1f} per doc)"
             )
-        if not dry_run and updated:
-            click.echo("\nNote: run `lithos reconcile` to refresh derived views.")
+        # The "now run `lithos reconcile`" advice that used to print here is
+        # gone: routing through the intake re-indexes the derived views inline,
+        # so there is no drift left to repair.
 
     asyncio.run(run())
 

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -50,7 +50,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ENTITY_EXTRACTOR_VERSION", "CognitiveMemory", "NodeStats", "extract_entities"]
+__all__ = [
+    "ENRICH_AGENT",
+    "ENTITY_EXTRACTOR_VERSION",
+    "CognitiveMemory",
+    "NodeStats",
+    "extract_entities",
+]
 
 
 # Default values for ``node_stats`` columns. Used both when a node is

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -224,6 +224,17 @@ class CorpusIntake:
         self._event_bus = event_bus
         self._edge_store = edge_store
 
+    @property
+    def edge_store(self) -> EdgeStore:
+        """The underlying edge store backing ``assert_edge``.
+
+        Public so the composition root can verify the ADR-0006 Slice 1 (#263)
+        one-writer invariant — that this store is the same handle the
+        ``ProvenanceProjection`` holds — without reaching through a private
+        attribute. Mirrors :attr:`ProvenanceProjection.edge_store`.
+        """
+        return self._edge_store
+
     async def delete(self, agent: str, request: DeleteRequest) -> DeleteOutcome:
         """Delete a note from the Corpus and synchronise derived views.
 

--- a/src/lithos/pipeline.py
+++ b/src/lithos/pipeline.py
@@ -1,0 +1,170 @@
+"""The one place the Lithos component graph is wired together.
+
+Before this module, three paths built the same graph by hand — ``LithosServer``
+(``server.py``), the ``reconcile`` per-scope functions, and half a dozen ``cli``
+commands — and they had drifted. The cost was not just duplication: the
+"exactly one ``EdgeStore`` writer" rule of ADR-0006 Slice 1 (issue #263) was
+unexpressible at any interface, so the CLI and reconcile paths quietly opened a
+*second* writer against ``edges.db`` by letting
+:meth:`ProvenanceProjection.create` self-create its store.
+
+:func:`build_pipeline` is that missing interface. Construction order and the
+one-writer rule live here once, and a constructor signature change stops being a
+three-file audit.
+
+Scope: construction, plus the opens construction implies (the embedding model,
+the SQLite handles). It deliberately stops short of *lifecycle* — no
+``memory.start()``, no schema migrations, no background workers, no OTEL gauge
+registration. Those stay with the server, which owns process lifetime. A CLI
+command gets the same object graph simply by never starting the workers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lithos.cognitive_memory import CognitiveMemory
+from lithos.coordination import CoordinationService
+from lithos.edge_store import EdgeStore
+from lithos.events import EventBus
+from lithos.graph import KnowledgeGraph
+from lithos.intake import CorpusIntake
+from lithos.knowledge import KnowledgeManager
+from lithos.provenance import ProvenanceProjection
+from lithos.search import SearchEngine
+
+if TYPE_CHECKING:
+    from lithos.config import LithosConfig
+
+__all__ = ["Pipeline", "build_pipeline"]
+
+
+@dataclass(frozen=True)
+class Pipeline:
+    """A fully-wired, not-yet-running Lithos component graph.
+
+    Frozen because the wiring is an invariant, not state: once built, no caller
+    should swap a component out from under the others that captured it.
+    """
+
+    config: LithosConfig
+    knowledge: KnowledgeManager
+    search: SearchEngine
+    graph: KnowledgeGraph
+    coordination: CoordinationService
+    event_bus: EventBus
+    edge_store: EdgeStore
+    projection: ProvenanceProjection
+    intake: CorpusIntake
+    memory: CognitiveMemory
+
+    async def aclose(self) -> None:
+        """Release the pipeline's own resources. Idempotent.
+
+        Only ``edge_store`` holds a handle this module opened —
+        :class:`SearchEngine` and :class:`CoordinationService` expose no close.
+        Closing matters most to short-lived CLI runs: leaving the aiosqlite
+        worker thread alive is what produced the "Event loop is closed"
+        warnings and CI hangs of issue #172.
+
+        Does *not* stop workers — a caller that ran ``memory.start()`` owns the
+        matching ``stop()``.
+        """
+        await self.edge_store.close()
+
+
+async def build_pipeline(
+    config: LithosConfig,
+    *,
+    knowledge: KnowledgeManager | None = None,
+    search: SearchEngine | None = None,
+    graph: KnowledgeGraph | None = None,
+    coordination: CoordinationService | None = None,
+    event_bus: EventBus | None = None,
+    edge_store: EdgeStore | None = None,
+    projection: ProvenanceProjection | None = None,
+    intake: CorpusIntake | None = None,
+    memory: CognitiveMemory | None = None,
+) -> Pipeline:
+    """Build the component graph for *config*, in dependency order.
+
+    Every component may be supplied pre-built, in which case it is adopted
+    as-is and its collaborators are wired to it. That is what keeps the server's
+    test-injection seam working (tests pre-inject a mock ``search`` to skip the
+    real embedding backend) and it is the only reason these keyword arguments
+    exist — production callers pass ``config`` alone.
+
+    The order below is load-bearing:
+
+    1. ``ensure_directories`` — the SQLite opens below create files under them.
+    2. ``SearchEngine.create`` — async so the embedding model is loaded before
+       any caller can observe an unloaded engine; captured by value by the
+       intake and by CognitiveMemory, so it must exist first.
+    3. **One** ``EdgeStore``, opened here and injected into both the projection
+       and the intake. This is the ADR-0006 invariant: the projection owns
+       projection-class rows, ``CorpusIntake.assert_edge`` owns asserted-class
+       rows, and they share a single SQLite handle so there is exactly one
+       writer. Passing ``edge_store=`` to ``ProvenanceProjection.create`` also
+       suppresses its self-create-and-open branch.
+    4. ``CorpusIntake`` before ``CognitiveMemory`` — the latter declares intake
+       as a constructor dependency so ``edge_upsert`` routes through
+       ``intake.assert_edge``.
+    5. ``attach_coordination`` — a transitional setter (ADR-0005) that
+       ``memory.start()`` requires; done here so no caller can forget it.
+
+    Returns a :class:`Pipeline` that is wired but idle. Start workers via
+    ``pipeline.memory.start()``; release handles via ``pipeline.aclose()``.
+    """
+    config.ensure_directories()
+
+    knowledge = knowledge or KnowledgeManager(config)
+    graph = graph or KnowledgeGraph(config)
+    coordination = coordination or CoordinationService(config)
+    event_bus = event_bus or EventBus(config.events)
+
+    if search is None:
+        search = await SearchEngine.create(config)
+
+    if edge_store is None:
+        edge_store = EdgeStore(config)
+        await edge_store.open()
+    if projection is None:
+        projection = await ProvenanceProjection.create(config, edge_store=edge_store)
+
+    if intake is None:
+        intake = CorpusIntake(
+            knowledge=knowledge,
+            search=search,
+            graph=graph,
+            coordination=coordination,
+            event_bus=event_bus,
+            edge_store=edge_store,
+        )
+
+    if memory is None:
+        memory = await CognitiveMemory.create(
+            config=config,
+            knowledge=knowledge,
+            search=search,
+            graph=graph,
+            projection=projection,
+            event_bus=event_bus,
+            intake=intake,
+        )
+        memory.attach_coordination(coordination)
+
+    await coordination.initialize()
+
+    return Pipeline(
+        config=config,
+        knowledge=knowledge,
+        search=search,
+        graph=graph,
+        coordination=coordination,
+        event_bus=event_bus,
+        edge_store=edge_store,
+        projection=projection,
+        intake=intake,
+        memory=memory,
+    )

--- a/src/lithos/pipeline.py
+++ b/src/lithos/pipeline.py
@@ -68,6 +68,13 @@ class Pipeline:
         worker thread alive is what produced the "Event loop is closed"
         warnings and CI hangs of issue #172.
 
+        Closes the store regardless of who built it. A caller that *injected* an
+        ``edge_store`` (or a projection holding one) owns that store's lifecycle
+        and should close it itself rather than calling this — mirroring
+        :meth:`ProvenanceProjection.close`. In practice ownership is
+        unambiguous: production callers pass ``config`` alone, and injection is
+        a test affordance.
+
         Does *not* stop workers — a caller that ran ``memory.start()`` owns the
         matching ``stop()``.
         """
@@ -126,9 +133,18 @@ async def build_pipeline(
     if search is None:
         search = await SearchEngine.create(config)
 
+    # An injected projection or intake already holds a store; adopt it rather
+    # than opening a second one behind its back. Without this, injecting either
+    # one *without* an edge_store would leave the two holders on different
+    # handles — the exact defect this factory exists to prevent.
     if edge_store is None:
-        edge_store = EdgeStore(config)
-        await edge_store.open()
+        if projection is not None:
+            edge_store = projection.edge_store
+        elif intake is not None:
+            edge_store = intake.edge_store
+        else:
+            edge_store = EdgeStore(config)
+            await edge_store.open()
     if projection is None:
         projection = await ProvenanceProjection.create(config, edge_store=edge_store)
 
@@ -153,6 +169,21 @@ async def build_pipeline(
             intake=intake,
         )
         memory.attach_coordination(coordination)
+
+    # Enforce the one-writer rule rather than merely intending it. Deriving the
+    # store above fixes the cases that *can* be fixed; contradictory injection
+    # (a projection and an intake built against different stores) cannot be, and
+    # must not be papered over — a Pipeline that looks valid while holding two
+    # writers is worse than no Pipeline.
+    if projection.edge_store is not edge_store or intake.edge_store is not edge_store:
+        raise ValueError(
+            "build_pipeline: projection and intake must share one EdgeStore "
+            "(ADR-0006 Slice 1, #263) — got "
+            f"projection={id(projection.edge_store):#x}, "
+            f"intake={id(intake.edge_store):#x}, "
+            f"pipeline={id(edge_store):#x}. Pass the same edge_store to each, "
+            "or let the factory build it."
+        )
 
     await coordination.initialize()
 

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -29,6 +29,7 @@ from lithos.intake import CorpusIntake
 from lithos.knowledge import (
     KnowledgeManager,
 )
+from lithos.pipeline import build_pipeline
 from lithos.provenance import ProvenanceProjection
 from lithos.search import Healthy, SearchEngine
 from lithos.telemetry import (
@@ -611,50 +612,36 @@ class LithosServer:
             span.set_attribute("lithos.server.port", self._config.server.port)
 
             try:
-                # Ensure directories exist
-                self.config.ensure_directories()
-
-                # Build the search engine eagerly so the embedding model is
-                # loaded before any request arrives. Tests may pre-inject a
-                # ``search`` instance (e.g. a MagicMock) to avoid the real
-                # backend cost.
-                if self.search is None:
-                    self.search = await SearchEngine.create(self._config)
-
-                # Construct the EdgeStore directly and inject the same
-                # instance into the projection and the intake (ADR-0006
-                # Slice 1, issue #263). The projection owns
-                # projection-class rows; ``CorpusIntake.assert_edge`` owns
-                # asserted-class rows. They share the SQLite handle so
-                # there is exactly one writer per server. Tests may
-                # pre-inject either ``self.edge_store`` or
-                # ``self.projection`` to skip real SQLite.
-                if self.edge_store is None:
-                    self.edge_store = EdgeStore(self._config)
-                    await self.edge_store.open()
-                if self.projection is None:
-                    self.projection = await ProvenanceProjection.create(
-                        self._config, edge_store=self.edge_store
-                    )
-
-                # Build the Corpus intake before the CognitiveMemory Module.
-                # ADR-0006 Slice 1 (#263) makes ``CognitiveMemory`` declare
-                # ``CorpusIntake`` as a constructor dependency so that
-                # ``edge_upsert`` routes through ``intake.assert_edge``.
-                # Tests that pre-inject ``self.intake`` keep that injection.
-                if self.intake is None:
-                    self.intake = CorpusIntake(
-                        knowledge=self.knowledge,
-                        search=self.search,
-                        graph=self.graph,
-                        coordination=self.coordination,
-                        event_bus=self.event_bus,
-                        edge_store=self.edge_store,
-                    )
+                # Build the component graph through the shared factory so the
+                # server and the CLI wire it identically — including the
+                # one-EdgeStore-writer invariant of ADR-0006 Slice 1 (#263).
+                # Passing the current attributes through preserves the
+                # test-injection seam: anything a test pre-injected (e.g. a
+                # MagicMock ``search``, to skip the real embedding backend) is
+                # adopted as-is rather than rebuilt.
+                pipeline = await build_pipeline(
+                    self._config,
+                    knowledge=self.knowledge,
+                    search=self.search,
+                    graph=self.graph,
+                    coordination=self.coordination,
+                    event_bus=self.event_bus,
+                    edge_store=self.edge_store,
+                    projection=self.projection,
+                    intake=self.intake,
+                    memory=self.memory,
+                )
+                self.search = pipeline.search
+                self.edge_store = pipeline.edge_store
+                self.projection = pipeline.projection
+                self.intake = pipeline.intake
+                self.memory = pipeline.memory
 
                 # Build the watcher intake — peer of CorpusIntake (ADR-0007).
-                # Same late-binding idiom: tests that pre-inject
-                # ``self.watch_intake`` keep their injection.
+                # Server-only: nothing outside a long-running process watches
+                # the filesystem, so it stays out of the shared factory. Same
+                # late-binding idiom — tests that pre-inject keep their
+                # injection.
                 if self.watch_intake is None:
                     self.watch_intake = WatchIntake(
                         knowledge=self.knowledge,
@@ -664,29 +651,10 @@ class LithosServer:
                         watch_path=self.config.storage.knowledge_path,
                     )
 
-                # Build the CognitiveMemory Module eagerly (ADR-0005, issue
-                # #255). The transitional ``attach_coordination`` setter
-                # supplies the CoordinationService that ``EnrichWorker``
-                # requires until coordination consolidates into the Module
-                # per ADR-0005's "Anticipated evolution" section.
-                if self.memory is None:
-                    self.memory = await CognitiveMemory.create(
-                        config=self._config,
-                        knowledge=self.knowledge,
-                        search=self.search,
-                        graph=self.graph,
-                        projection=self.projection,
-                        event_bus=self.event_bus,
-                        intake=self.intake,
-                    )
-                    self.memory.attach_coordination(self.coordination)
-
                 # Run LCMA schema migrations through the Module so the lcma
-                # boundary stays locked (issue #262).
+                # boundary stays locked (issue #262). Lifecycle, not
+                # construction — hence here rather than in the factory.
                 await self.memory.run_schema_migrations()
-
-                # Initialize coordination database
-                await self.coordination.initialize()
 
                 # Prime the coordination stats cache BEFORE registering OTEL
                 # gauges — otherwise the first scrape would read the initial

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -346,10 +346,17 @@ class TestCLIContracts:
         assert calls["watch_started"] == 1
         assert calls["watch_stopped"] == 0
 
-    def test_serve_telemetry_console_flag_sets_config_fields(self, temp_dir, monkeypatch):
+    def test_telemetry_console_flag_sets_config_fields(self, temp_dir, monkeypatch):
         """`--telemetry-console` must flip telemetry.enabled + console_fallback
         on the live config before ``setup_telemetry`` reads them, so metrics and
-        spans actually land on stdout without requiring an OTLP endpoint."""
+        spans actually land on stdout without requiring an OTLP endpoint.
+
+        The flag is on the ``cli`` group, not ``serve`` (task ba8d7f25 PR2a):
+        telemetry setup moved to the group entrypoint so every command exports,
+        and a serve-only flag could no longer be applied before setup ran.
+        Console-fallback now works for any command — `lithos --telemetry-console
+        reconcile` is the case that motivated it.
+        """
         config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
         config.ensure_directories()
         set_config(config)
@@ -384,13 +391,15 @@ class TestCLIContracts:
             # Snapshot the config at the moment setup_telemetry() would read it.
             captured["config"] = cfg
 
-        monkeypatch.setattr("lithos.telemetry.setup_telemetry", _capture_setup)
-        monkeypatch.setattr("lithos.telemetry.shutdown_telemetry", lambda: None)
+        # cli.py imports these at module scope, so patch the names it bound —
+        # patching lithos.telemetry.* would not affect the already-bound refs.
+        monkeypatch.setattr("lithos.cli.setup_telemetry", _capture_setup)
+        monkeypatch.setattr("lithos.cli.shutdown_telemetry", lambda: None)
 
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["--data-dir", str(temp_dir), "serve", "--no-watch", "--telemetry-console"],
+            ["--data-dir", str(temp_dir), "--telemetry-console", "serve", "--no-watch"],
         )
         assert result.exit_code == 0, result.output
         assert "Telemetry console-fallback enabled" in result.output
@@ -458,3 +467,104 @@ class TestCLIContracts:
         assert result.exit_code == 0, result.output
         assert "Shutting down..." in result.output
         assert calls["stop"] == 1
+
+
+class TestExtractEntitiesRoutesThroughIntake:
+    """`lithos extract-entities` must not manufacture Drift (task ba8d7f25 PR2a).
+
+    It used to call KnowledgeManager.update directly, which skipped the
+    Search/graph re-index and emitted no event — so the entities it wrote were
+    invisible to search until someone ran `lithos reconcile`. The command even
+    printed a note telling you to do exactly that. PR1a (task 681ac952) fixed
+    the identical bypass on the enrich worker's path; this was the other half.
+    """
+
+    # A token that appears in no document's content, so it can only ever reach
+    # the search index via the `entities` field. Extracted entities always
+    # appear in content (they are extracted *from* it), so proving a re-index
+    # means watching a stale entity disappear, not a fresh one appear.
+    STALE_ENTITY = "Zzyzxtown"
+
+    def _seed(self, temp_dir):
+        config = LithosConfig(storage=StorageConfig(data_dir=temp_dir))
+        config.ensure_directories()
+        # set_config() needed for CLI commands invoked via Click's test runner
+        # (see test_reindex_and_search_output_shape for the full explanation).
+        set_config(config)
+        knowledge = KnowledgeManager(config)
+
+        async def _create() -> str:
+            result = await knowledge.create(
+                title="Entity Drift Seed",
+                content="Ada Lovelace worked with Charles Babbage in London.",
+                agent="cli-test",
+            )
+            assert result.document is not None
+            # Plant a stale entity that no extractor would ever produce.
+            await knowledge.update(
+                id=result.document.id,
+                agent="cli-test",
+                entities=[self.STALE_ENTITY],
+            )
+            return result.document.id
+
+        return config, asyncio.run(_create())
+
+    def test_stale_entity_leaves_the_index_without_a_reconcile(self, temp_dir):
+        """The re-index happens inline, so the superseded entity stops matching.
+
+        Pre-fix, the markdown was rewritten but the index was not, leaving
+        `Zzyzxtown` searchable against a document that no longer claims it.
+        """
+        self._seed(temp_dir)
+        runner = CliRunner()
+
+        assert runner.invoke(cli, ["--data-dir", str(temp_dir), "reindex"]).exit_code == 0
+
+        # Baseline: the stale entity is genuinely in the index to begin with,
+        # so the post-condition below is a real change and not a vacuous pass.
+        before = runner.invoke(
+            cli,
+            ["--data-dir", str(temp_dir), "search", self.STALE_ENTITY, "--fulltext"],
+        )
+        assert "Entity Drift Seed" in before.output, before.output
+
+        extract = runner.invoke(cli, ["--data-dir", str(temp_dir), "extract-entities", "--force"])
+        assert extract.exit_code == 0, extract.output
+        assert "updated: 1" in extract.output
+
+        after = runner.invoke(
+            cli,
+            ["--data-dir", str(temp_dir), "search", self.STALE_ENTITY, "--fulltext"],
+        )
+        assert after.exit_code == 0, after.output
+        assert "Entity Drift Seed" not in after.output, (
+            "stale entity still indexed — the write bypassed the Search re-index"
+        )
+
+    def test_no_longer_tells_the_operator_to_reconcile(self, temp_dir):
+        """The advice was the bug admitting itself; routing through intake
+        leaves no drift to repair."""
+        self._seed(temp_dir)
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["--data-dir", str(temp_dir), "extract-entities", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert "run `lithos reconcile`" not in result.output
+
+    def test_dry_run_writes_nothing_and_builds_no_pipeline(self, temp_dir):
+        """A read-only question must not have side effects — notably it must not
+        create edges.db just to report what it *would* do."""
+        config, _doc_id = self._seed(temp_dir)
+        edges_db = config.storage.edges_db_path
+        assert not edges_db.exists()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--data-dir", str(temp_dir), "extract-entities", "--force", "--dry-run"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "would update: 1" in result.output
+        assert not edges_db.exists(), "dry run created edges.db as a side effect"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,7 +51,7 @@ class TestBuildPipelineWiring:
         pipeline = await build_pipeline(test_config)
         try:
             assert pipeline.projection.edge_store is pipeline.edge_store
-            assert pipeline.intake._edge_store is pipeline.edge_store
+            assert pipeline.intake.edge_store is pipeline.edge_store
         finally:
             await pipeline.aclose()
 
@@ -114,9 +114,69 @@ class TestBuildPipelineInjection:
             pipeline = await build_pipeline(test_config, edge_store=store)
             assert pipeline.edge_store is store
             assert pipeline.projection.edge_store is store
-            assert pipeline.intake._edge_store is store
+            assert pipeline.intake.edge_store is store
         finally:
             await store.close()
+
+    async def test_injected_projection_supplies_the_edge_store(
+        self, test_config: LithosConfig
+    ) -> None:
+        """A projection injected *without* an edge_store must not be left on a
+        different handle from the intake.
+
+        The factory used to open a fresh store here and wire the intake to it
+        while the injected projection kept its own — two writers against
+        edges.db, from the very function introduced to prevent that.
+        """
+        from lithos.provenance import ProvenanceProjection
+
+        projection = await ProvenanceProjection.create(test_config)
+        try:
+            pipeline = await build_pipeline(test_config, projection=projection)
+            assert pipeline.edge_store is projection.edge_store
+            assert pipeline.intake.edge_store is projection.edge_store
+        finally:
+            await projection.close()
+
+    async def test_injected_intake_supplies_the_edge_store(self, test_config: LithosConfig) -> None:
+        """The same defect from the other side: an injected intake already holds
+        a store, so the projection must be built against that one."""
+        from lithos.edge_store import EdgeStore
+        from lithos.intake import CorpusIntake
+        from lithos.search import SearchEngine
+
+        store = EdgeStore(test_config)
+        await store.open()
+        try:
+            intake = CorpusIntake(
+                knowledge=MagicMock(),
+                search=MagicMock(spec=SearchEngine),
+                graph=MagicMock(),
+                coordination=MagicMock(),
+                event_bus=MagicMock(),
+                edge_store=store,
+            )
+            pipeline = await build_pipeline(test_config, intake=intake)
+            assert pipeline.edge_store is store
+            assert pipeline.projection.edge_store is store
+        finally:
+            await store.close()
+
+    async def test_contradictory_injection_is_rejected(self, test_config: LithosConfig) -> None:
+        """Two holders on two stores cannot be reconciled — fail loudly rather
+        than return a valid-looking Pipeline backed by two writers."""
+        from lithos.edge_store import EdgeStore
+        from lithos.provenance import ProvenanceProjection
+
+        other = EdgeStore(test_config)
+        await other.open()
+        projection = await ProvenanceProjection.create(test_config)
+        try:
+            with pytest.raises(ValueError, match="must share one EdgeStore"):
+                await build_pipeline(test_config, projection=projection, edge_store=other)
+        finally:
+            await other.close()
+            await projection.close()
 
 
 class TestPipelineLifecycle:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,150 @@
+"""Tests for the build_pipeline composition root (task ba8d7f25).
+
+The factory exists to make two things checkable that were previously only
+conventions spread across server.py, cli.py and reconcile.py: the wiring itself,
+and the ADR-0006 Slice 1 (#263) rule that exactly one EdgeStore writer backs
+edges.db.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lithos.config import LithosConfig
+from lithos.pipeline import Pipeline, build_pipeline
+
+
+class TestBuildPipelineWiring:
+    """The graph is wired, and wired to the *same* instances."""
+
+    async def test_returns_every_component_built(self, test_config: LithosConfig) -> None:
+        pipeline = await build_pipeline(test_config)
+        try:
+            assert pipeline.config is test_config
+            for name in (
+                "knowledge",
+                "search",
+                "graph",
+                "coordination",
+                "event_bus",
+                "edge_store",
+                "projection",
+                "intake",
+                "memory",
+            ):
+                assert getattr(pipeline, name) is not None, f"{name} not built"
+        finally:
+            await pipeline.aclose()
+
+    async def test_one_edge_store_backs_projection_and_intake(
+        self, test_config: LithosConfig
+    ) -> None:
+        """The ADR-0006 invariant, as an assertion rather than a comment.
+
+        The projection owns projection-class rows and CorpusIntake.assert_edge
+        owns asserted-class rows; they must share one SQLite handle so there is
+        exactly one writer. cli.reindex used to break this by calling
+        ProvenanceProjection.create(config) with no injected store.
+        """
+        pipeline = await build_pipeline(test_config)
+        try:
+            assert pipeline.projection.edge_store is pipeline.edge_store
+            assert pipeline.intake._edge_store is pipeline.edge_store
+        finally:
+            await pipeline.aclose()
+
+    async def test_collaborators_share_one_instance_each(self, test_config: LithosConfig) -> None:
+        """No component gets a private second copy of a collaborator."""
+        pipeline = await build_pipeline(test_config)
+        try:
+            assert pipeline.intake._knowledge is pipeline.knowledge
+            assert pipeline.intake._search is pipeline.search
+            assert pipeline.intake._graph is pipeline.graph
+            assert pipeline.intake._event_bus is pipeline.event_bus
+        finally:
+            await pipeline.aclose()
+
+    async def test_memory_has_coordination_attached(self, test_config: LithosConfig) -> None:
+        """attach_coordination is a transitional setter that memory.start()
+        requires; the factory does it so no caller can forget."""
+        pipeline = await build_pipeline(test_config)
+        try:
+            assert pipeline.memory._coordination is pipeline.coordination
+        finally:
+            await pipeline.aclose()
+
+    async def test_pipeline_is_frozen(self, test_config: LithosConfig) -> None:
+        """The wiring is an invariant, not state — no swapping components out
+        from under the collaborators that already captured them."""
+        pipeline = await build_pipeline(test_config)
+        try:
+            with pytest.raises(AttributeError):
+                pipeline.search = MagicMock()  # type: ignore[misc]
+        finally:
+            await pipeline.aclose()
+
+
+class TestBuildPipelineInjection:
+    """Pre-built components are adopted, not rebuilt.
+
+    This is what keeps the server's test-injection seam working: server tests
+    pre-inject a MagicMock search to skip the real embedding backend.
+    """
+
+    async def test_injected_component_is_adopted(self, test_config: LithosConfig) -> None:
+        sentinel = MagicMock()
+        pipeline = await build_pipeline(test_config, search=sentinel)
+        try:
+            assert pipeline.search is sentinel
+            # ...and the adopted instance is what collaborators are wired to.
+            assert pipeline.intake._search is sentinel
+        finally:
+            await pipeline.aclose()
+
+    async def test_injected_edge_store_is_not_replaced(self, test_config: LithosConfig) -> None:
+        """An injected store must reach both holders — otherwise the one-writer
+        invariant silently depends on who built the store."""
+        from lithos.edge_store import EdgeStore
+
+        store = EdgeStore(test_config)
+        await store.open()
+        try:
+            pipeline = await build_pipeline(test_config, edge_store=store)
+            assert pipeline.edge_store is store
+            assert pipeline.projection.edge_store is store
+            assert pipeline.intake._edge_store is store
+        finally:
+            await store.close()
+
+
+class TestPipelineLifecycle:
+    async def test_aclose_closes_the_edge_store(self, test_config: LithosConfig) -> None:
+        """Short-lived CLI runs must release the aiosqlite handle; a leaked
+        worker thread is the #172 'event loop is closed' hang."""
+        pipeline = await build_pipeline(test_config)
+        await pipeline.aclose()
+        assert pipeline.edge_store._db is None
+
+    async def test_aclose_is_idempotent(self, test_config: LithosConfig) -> None:
+        pipeline = await build_pipeline(test_config)
+        await pipeline.aclose()
+        await pipeline.aclose()
+
+    async def test_build_does_not_start_workers(self, test_config: LithosConfig) -> None:
+        """The factory builds; it does not run. A CLI command gets the same
+        object graph simply by never calling memory.start()."""
+        pipeline = await build_pipeline(test_config)
+        try:
+            assert pipeline.memory._started is False
+            assert pipeline.memory._enrich_worker is None
+        finally:
+            await pipeline.aclose()
+
+
+class TestPipelineType:
+    def test_pipeline_is_not_constructible_without_full_wiring(self) -> None:
+        """Every field is required — a Pipeline cannot exist half-built."""
+        with pytest.raises(TypeError):
+            Pipeline()  # type: ignore[call-arg]


### PR DESCRIPTION
First of two PRs for task `ba8d7f25`. This one consolidates construction; **PR2b** takes `reconcile.py`'s disposition and the rebuild unification.

## Why

Three paths built the same component graph by hand — `LithosServer.initialize`, the `reconcile.py` per-scope functions, and half a dozen `cli` commands — and they had drifted. The cost wasn't just duplication: ADR-0006 Slice 1's **"exactly one `EdgeStore` writer"** rule was unexpressible at any interface, so `cli reindex` quietly opened a *second* writer against `edges.db` by calling `ProvenanceProjection.create(config)` with no injected store, taking its self-create branch.

## What

`lithos/pipeline.py` — `build_pipeline(config) -> Pipeline`, a frozen dataclass of the wired graph plus `aclose()`. Construction order and the one-writer rule now live once, at a named seam, **asserted by tests instead of described in comments**.

Scope is construction plus the opens it implies. Lifecycle — worker start, schema migrations, OTEL gauge registration — stays with the server, which owns process lifetime. A CLI command gets the same object graph by simply never starting the workers.

**Why Entrypoints?** It's the composition root: only `server` and `cli` import it, and Core must stay unaware of who wires it — the same reason a DI container sits at the outermost layer. Putting it in Core would mean a Core module depending on nine other Core components, which is the cycle-prone shape this model exists to catch. That placement is also edge-neutral: **`cross_component_edges` holds at 63** (module edges 131→142 collapse into `Entrypoints → Core` edges that already existed).

Adopted by `server.initialize` (**net −32 lines**; optional kwargs preserve the `if X is None` test-injection seam, so tests pre-injecting a MagicMock `search` still skip the real embedding backend) and by `cli reindex`, closing the second-writer defect.

## Also here, because it's the same surface

**Telemetry was dead on the whole CLI.** `setup_logging`/`setup_telemetry` lived in the `serve` body, so every other command ran with no-op providers — `lithos reconcile`, the operator's repair tool, emitted none of the spans and metrics its code path raises. Both now run in the `cli` group.

⚠️ **CLI surface break:** `--telemetry-console` moves from `serve` to the group. Setup now runs before any command body, so a serve-only flag couldn't be applied in time. This completes the fix — console fallback now works for `lithos --telemetry-console reconcile`, the case that motivated it.

```
lithos --data-dir ./data serve --telemetry-console   # before
lithos --data-dir ./data --telemetry-console serve   # after
```
README, `docs/cli.md`, `docs/SPECIFICATION.md` and the contract test updated.

**`extract-entities` Drift bug closed.** It called `KnowledgeManager.update` directly — skipping the Search/graph re-index, emitting no event. This is the same bug PR1a fixed on the enrich worker's path; the CLI was the other half. It now routes through `CorpusIntake.note_update(..., origin=EVENT_ORIGIN_ENRICH)`. The command used to print *"run `lithos reconcile` to refresh derived views"* — the bug admitting itself. That line is gone because there's no drift left to repair. `--dry-run` builds no pipeline, so it stays read-only and no longer risks creating `edges.db` to answer a read-only question. `ENRICH_AGENT` is re-exported via the `cognitive_memory` facade since the CLI can't cross the lcma seam.

## Test plan

- [x] `make check` — unit **1576**, typecheck 0, lint clean
- [x] `make test-integration` — **431**
- [x] `make diagrams` — guardrails **48**; `cross_component_edges` unchanged at 63
- [x] Drift regression **verified to fail against the pre-fix command**. It plants a stale entity appearing in no document's content, so the only way it leaves the index is a genuine re-index — a naive "search for the new entity" test passes either way, since entities are extracted *from* content.
- [x] New `tests/test_pipeline.py` (11): one-writer invariant, collaborator identity, injection adoption, frozen-ness, `aclose` releases the aiosqlite handle (#172), build-does-not-start-workers.

## Reviewer notes

- The `--telemetry-console` move is the one deliberate user-facing break; called out for a decision rather than buried.
- `reconcile.py` still self-creates its second `EdgeStore` (`:363`) — that's PR2b's, since it dies there anyway.
- The task described `reconcile.py` as "a shallow legacy-dict adapter". It isn't — it holds ~13 pieces of real behaviour (notably the `edges.db` short-circuit at `:351-360` that guards `ProvenanceProjection.create`'s eager file creation). That premise correction is why this is split, and why PR2b relocates rather than inlines.
