### PR TITLE
refactor: extract the derived corpus index out of KnowledgeManager (PR4a, task ebaf33bc)

### DIFF
--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -73,7 +73,7 @@ Logging         = "Structured JSON logging setup."
 # after the extraction actually broke it. It is pure and dependency-free, so it is held
 # to Foundation discipline by import-linter (as lithos._merge and lithos.edge_store are).
 Entrypoints     = ["lithos.cli", "lithos.server", "lithos.tools", "lithos.watch_intake", "lithos.__main__", "lithos.pipeline", "lithos.cli_reconcile"]
-Knowledge       = ["lithos.knowledge", "lithos._merge"]
+Knowledge       = ["lithos.knowledge", "lithos._merge", "lithos.corpus_index"]
 Codec           = ["lithos.frontmatter_codec"]
 Search          = ["lithos.search"]
 Graph           = ["lithos.graph", "lithos.edge_store"]
@@ -153,6 +153,7 @@ include_modules = [
     "lithos.events",
     "lithos.knowledge",
     "lithos.frontmatter_codec",
+    "lithos.corpus_index",
     "lithos.provenance",
     "lithos.cognitive_memory",
     "lithos.intake",

--- a/docs/generated/components/Knowledge.md
+++ b/docs/generated/components/Knowledge.md
@@ -12,12 +12,18 @@ The corpus owner: Markdown note CRUD with frontmatter, plus reconcile of derived
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
 | `lithos._merge` | XS | 0 | 1 |
-| `lithos.knowledge` | XL | 5 | 0 |
+| `lithos.corpus_index` | L | 3 | 0 |
+| `lithos.knowledge` | L | 5 | 0 |
 
 ## Public API
 
 ### `lithos._merge`
 - def `merge_metadata` — Apply an additive per-key patch to a metadata dict.
+
+### `lithos.corpus_index`
+- class `CachedMeta` — Lightweight metadata cache for filtering without disk I/O.
+- class `ScannedNote` — One note as seen by a startup scan — the input row to :meth:`CorpusIndex.rebuild`.
+- class `CorpusIndex` — The derived, in-memory view of the Corpus that KnowledgeManager queries.
 
 ### `lithos.knowledge`
 - class `DuplicateInfo` — Information about a duplicate document.

--- a/docs/generated/domain_model.md
+++ b/docs/generated/domain_model.md
@@ -268,6 +268,23 @@ classDiagram
 
 ```mermaid
 classDiagram
+  class CachedMeta {
+    +title str
+    +author str
+    +tags list[str]
+    +updated_at datetime
+    +path Path
+    +namespace str
+    +expires_at datetime | None
+    +access_scope str | None
+    +source str | None
+    +note_type str | None
+    +status str | None
+    +source_url str | None
+    +entities list[str]
+    +extra dict
+    +seq int
+  }
   class DuplicateInfo {
     +id str
     +title str
@@ -275,6 +292,12 @@ classDiagram
   }
   class ReconcilePlan
   class ReconcileResult
+  class ScannedNote {
+    +doc_id str
+    +title str
+    +frontmatter dict
+    +rel_path Path
+  }
   class WriteResult {
     +status Literal['created', 'updated', 'duplicate', 'error', 'invalid_input', 'version_conflict', 'content_too_large', 'path_collision']
     +warnings list[str]

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -393,11 +393,11 @@
         "classes": 9,
         "functions": 85,
         "largest_module": "lithos.knowledge",
-        "largest_module_lines": 1264,
-        "lines": 2004,
+        "largest_module_lines": 1267,
+        "lines": 2007,
         "modules": 3,
         "public_symbols": 9,
-        "sloc": 1600
+        "sloc": 1602
       },
       "LCMA": {
         "classes": 5,
@@ -465,13 +465,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23770,
+    "total_lines": 23773,
     "total_modules": 40,
-    "total_sloc": 19122
+    "total_sloc": 19124
   },
   "tests": {
     "ratio": 1.85,
-    "src_lines": 23770,
+    "src_lines": 23773,
     "test_lines": 44047
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -47,8 +47,8 @@
         "max_function": "lithos.intake.CorpusIntake.write"
       },
       "Knowledge": {
-        "functions_over_10": 7,
-        "max_complexity": 71,
+        "functions_over_10": 6,
+        "max_complexity": 62,
         "max_function": "lithos.knowledge.KnowledgeManager.update"
       },
       "LCMA": {
@@ -77,31 +77,19 @@
         "max_function": "lithos.telemetry.setup_telemetry"
       }
     },
-    "functions_over_10": 66,
+    "functions_over_10": 65,
     "top_functions": [
-      {
-        "complexity": 71,
-        "qualname": "lithos.knowledge.KnowledgeManager.update"
-      },
       {
         "complexity": 65,
         "qualname": "lithos.tools.notes.register.lithos_write"
       },
       {
+        "complexity": 62,
+        "qualname": "lithos.knowledge.KnowledgeManager.update"
+      },
+      {
         "complexity": 51,
         "qualname": "lithos.lcma.retrieve._run_retrieve_impl"
-      },
-      {
-        "complexity": 40,
-        "qualname": "lithos.knowledge.KnowledgeManager._scan_existing"
-      },
-      {
-        "complexity": 36,
-        "qualname": "lithos.knowledge.KnowledgeManager._sync_from_disk_unlocked"
-      },
-      {
-        "complexity": 34,
-        "qualname": "lithos.knowledge.KnowledgeManager.create"
       },
       {
         "complexity": 33,
@@ -117,14 +105,26 @@
       },
       {
         "complexity": 26,
+        "qualname": "lithos.knowledge.KnowledgeManager.create"
+      },
+      {
+        "complexity": 26,
         "qualname": "lithos.server.LithosServer._validate_task_feedback"
+      },
+      {
+        "complexity": 25,
+        "qualname": "lithos.cognitive_memory.CognitiveMemory.cache_lookup"
+      },
+      {
+        "complexity": 25,
+        "qualname": "lithos.tools.notes.register.lithos_note_update"
       }
     ],
-    "total_functions": 675
+    "total_functions": 719
   },
   "domain": {
     "associations": 26,
-    "models": 42,
+    "models": 44,
     "models_without_docstrings": 0
   },
   "graph": {
@@ -207,7 +207,7 @@
       }
     },
     "cross_component_edges": 68,
-    "cross_component_module_edges": 149,
+    "cross_component_module_edges": 150,
     "longest_component_chain": 9,
     "module_cycle_count": 1,
     "module_cycles": [
@@ -252,8 +252,6 @@
       "lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id",
       "lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics",
       "lithos.lcma.scouts -> lithos.graph.KnowledgeGraph._resolve_link",
-      "lithos.lcma.scouts -> lithos.knowledge.KnowledgeManager._id_to_path",
-      "lithos.lcma.scouts -> lithos.knowledge.KnowledgeManager._source_url_to_id",
       "lithos.lcma.stats -> lithos.telemetry._LithosMetrics",
       "lithos.tools.agents -> lithos.server.LithosServer._emit",
       "lithos.tools.findings_stats -> lithos.server.LithosServer._cached_active_claims",
@@ -264,7 +262,7 @@
       "lithos.tools.tasks -> lithos.server.LithosServer._apply_task_feedback",
       "lithos.tools.tasks -> lithos.server.LithosServer._validate_task_feedback"
     ],
-    "cross_module_private_refs": 34,
+    "cross_module_private_refs": 32,
     "tests_private_detail": [
       "tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)",
       "tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)",
@@ -392,14 +390,14 @@
         "sloc": 533
       },
       "Knowledge": {
-        "classes": 7,
-        "functions": 41,
+        "classes": 9,
+        "functions": 85,
         "largest_module": "lithos.knowledge",
-        "largest_module_lines": 1773,
-        "lines": 1803,
-        "modules": 2,
-        "public_symbols": 6,
-        "sloc": 1450
+        "largest_module_lines": 1264,
+        "lines": 2004,
+        "modules": 3,
+        "public_symbols": 9,
+        "sloc": 1600
       },
       "LCMA": {
         "classes": 5,
@@ -467,13 +465,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23569,
-    "total_modules": 39,
-    "total_sloc": 18972
+    "total_lines": 23770,
+    "total_modules": 40,
+    "total_sloc": 19122
   },
   "tests": {
-    "ratio": 1.87,
-    "src_lines": 23569,
-    "test_lines": 44043
+    "ratio": 1.85,
+    "src_lines": 23770,
+    "test_lines": 44047
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -43,7 +43,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
-| Knowledge | 3 | 2004 | 1600 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 6 |
+| Knowledge | 3 | 2007 | 1602 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 6 |
 | LCMA | 9 | 4535 | 3658 | 1 | 11 | 0.92 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **40**, lines: **23770**, SLOC: **19122**
+- Modules: **40**, lines: **23773**, SLOC: **19124**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -152,4 +152,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.85** (44047 test lines / 23770 source lines)
+- Test-to-source line ratio: **1.85** (44047 test lines / 23773 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -13,7 +13,7 @@ lower a budget after improving the code to lock in the gain.
 |---|---:|---:|---:|
 | `component_cycles` | 0 | 0 | 0 |
 | `cross_component_edges` | 68 | 68 | 0 |
-| `cross_module_private_refs` | 34 | 42 | 8 |
+| `cross_module_private_refs` | 32 | 42 | 10 |
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
@@ -21,7 +21,7 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **68** (149 module-level)
+- Cross-component edges: **68** (150 module-level)
 - Component cycles: none
 - Module cycles: lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
@@ -43,7 +43,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
-| Knowledge | 2 | 1803 | 1450 | 5 | 7 | 0.58 | 71 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
+| Knowledge | 3 | 2004 | 1600 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 6 |
 | LCMA | 9 | 4535 | 3658 | 1 | 11 | 0.92 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **39**, lines: **23569**, SLOC: **18972**
+- Modules: **40**, lines: **23770**, SLOC: **19122**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -69,29 +69,29 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **675**, cyclomatic > 10: **66**
+- Functions: **719**, cyclomatic > 10: **65**
 
 Top 10 most complex functions:
 
 | Complexity | Function |
 |---:|---|
-| 71 | `lithos.knowledge.KnowledgeManager.update` |
 | 65 | `lithos.tools.notes.register.lithos_write` |
+| 62 | `lithos.knowledge.KnowledgeManager.update` |
 | 51 | `lithos.lcma.retrieve._run_retrieve_impl` |
-| 40 | `lithos.knowledge.KnowledgeManager._scan_existing` |
-| 36 | `lithos.knowledge.KnowledgeManager._sync_from_disk_unlocked` |
-| 34 | `lithos.knowledge.KnowledgeManager.create` |
 | 33 | `lithos.search.SearchEngine.graph_search` |
 | 30 | `lithos.tools.read_search.register.lithos_list` |
 | 27 | `lithos.lcma.scouts.scout_graph` |
+| 26 | `lithos.knowledge.KnowledgeManager.create` |
 | 26 | `lithos.server.LithosServer._validate_task_feedback` |
+| 25 | `lithos.cognitive_memory.CognitiveMemory.cache_lookup` |
+| 25 | `lithos.tools.notes.register.lithos_note_update` |
 
 ## Seams
 
 Private-name reaches across module seams. Both counts can be pinned as
 `[budgets]` ratchets (`cross_module_private_refs`, `tests_private_imports`).
 
-- Cross-module private refs (src): **34**
+- Cross-module private refs (src): **32**
   - `lithos.tools.tasks -> lithos.server.LithosServer._emit (x8)`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._config (x2)`
   - `lithos.tools.read_search -> lithos.server.LithosServer._config (x2)`
@@ -106,8 +106,6 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id`
   - `lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics`
   - `lithos.lcma.scouts -> lithos.graph.KnowledgeGraph._resolve_link`
-  - `lithos.lcma.scouts -> lithos.knowledge.KnowledgeManager._id_to_path`
-  - `lithos.lcma.scouts -> lithos.knowledge.KnowledgeManager._source_url_to_id`
   - `lithos.lcma.stats -> lithos.telemetry._LithosMetrics`
   - `lithos.tools.agents -> lithos.server.LithosServer._emit`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._cached_active_claims`
@@ -152,6 +150,6 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 ## Domain, tools & tests
 
-- Domain models: **42** (26 associations, 0 without docstrings)
+- Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.87** (44043 test lines / 23569 source lines)
+- Test-to-source line ratio: **1.85** (44047 test lines / 23770 source lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ source_modules = [
 ]
 forbidden_modules = [
     "lithos.knowledge",
+    "lithos.corpus_index",
     "lithos.search",
     "lithos.graph",
     "lithos.coordination",
@@ -175,6 +176,7 @@ name = "Core must not import Entrypoints"
 type = "forbidden"
 source_modules = [
     "lithos.knowledge",
+    "lithos.corpus_index",
     "lithos.search",
     "lithos.graph",
     "lithos.coordination",

--- a/src/lithos/corpus_index.py
+++ b/src/lithos/corpus_index.py
@@ -1,0 +1,710 @@
+"""The in-memory projection over the Corpus: KnowledgeManager's query accelerator.
+
+The Corpus is the source of truth; this is the derived view that makes it
+queryable without a disk read. It owns the per-document metadata cache, the five
+inverted indexes that turn equality filters into set intersections (#306/#316),
+the path/slug/source-url maps, and the in-memory provenance graph
+(``derived_from`` forward + reverse). All of it is rebuilt from the Corpus on
+construction and maintained incrementally on every write.
+
+It lives apart from :mod:`lithos.knowledge` because it is a *view*, not the
+store. :class:`KnowledgeManager` owns files, slug allocation, dedup policy and
+validation; it holds one :class:`CorpusIndex` and routes the derived-state
+mutations through it. Naming the projection keeps query-acceleration bugs in one
+module and lets :class:`CachedMeta` cross the seam as a real value type (as
+:class:`~lithos.search.IndexableDocument` does for Search) instead of being
+re-projected by every consumer.
+
+Unlike Tantivy, the link graph, and ``edges.db``, this view never persists: it is
+rebuilt from :meth:`KnowledgeManager.scan_corpus` every process start, so it
+cannot drift across processes and needs no reconcile — it is always consistent
+with the Corpus its manager last scanned. Pure in-memory, no disk access: the
+manager reads files and hands over frontmatter.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lithos.frontmatter_codec import (
+    KnowledgeMetadata,
+    canonical_metadata_value,
+    derive_namespace,
+    extract_extra,
+    normalize_datetime,
+    normalize_derived_from_ids_lenient,
+    normalize_url,
+    slugify,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedMeta:
+    """Lightweight metadata cache for filtering without disk I/O.
+
+    ``namespace`` is the resolved LCMA namespace — either an explicit value
+    from frontmatter or the path-derived default. Callers MUST read this
+    field rather than re-deriving from ``path`` so explicit overrides are
+    honored consistently across the retrieval pipeline.
+    """
+
+    title: str
+    author: str
+    tags: list[str]
+    updated_at: datetime
+    path: Path
+    namespace: str
+    expires_at: datetime | None = None
+    access_scope: str | None = None
+    source: str | None = None
+    note_type: str | None = None
+    status: str | None = None
+    source_url: str | None = None
+    # Extracted/curated entity names (#316) — kept here so the entities
+    # inverted index can be maintained without a disk read.
+    entities: list[str] = field(default_factory=list)
+    # Free-form key/value metadata (#305) — kept here so equality filtering and
+    # the inverted index (#306) work without a disk read.
+    extra: dict = field(default_factory=dict)
+    # Insertion ordinal — reproduces _meta_cache ordering in the index path so
+    # list pagination stays stable (#306).
+    seq: int = 0
+
+    @classmethod
+    def from_metadata(cls, metadata: KnowledgeMetadata, path: Path, *, seq: int) -> CachedMeta:
+        """Build a cache entry from a document's typed metadata.
+
+        The namespace is the explicit frontmatter value when set, otherwise the
+        path-derived default — matching ``apply_lcma_defaults`` at read time.
+        Shared by create/update/sync so the field mapping lives in one place.
+        """
+        return cls(
+            title=metadata.title,
+            author=metadata.author,
+            tags=list(metadata.tags),
+            updated_at=metadata.updated_at,
+            path=path,
+            namespace=metadata.namespace or derive_namespace(path),
+            expires_at=metadata.expires_at,
+            access_scope=metadata.access_scope,
+            source=metadata.source,
+            note_type=metadata.note_type,
+            status=metadata.status,
+            source_url=metadata.source_url,
+            entities=list(metadata.entities),
+            extra=dict(metadata.extra),
+            seq=seq,
+        )
+
+    @classmethod
+    def from_frontmatter(cls, meta: dict, rel_path: Path, *, seq: int) -> CachedMeta:
+        """Build a cache entry from raw frontmatter during a startup scan.
+
+        Defensive by construction: frontmatter is hand-editable, so every field
+        is type-guarded and falls back to a safe default rather than trusting
+        the on-disk value. This is the cheap path — no full document decode.
+        """
+        raw_updated = meta.get("updated_at")
+        if isinstance(raw_updated, str):
+            updated_at = datetime.fromisoformat(raw_updated)
+        elif isinstance(raw_updated, datetime):
+            updated_at = raw_updated
+        else:
+            updated_at = datetime.now(UTC)
+
+        raw_expires = meta.get("expires_at")
+        if isinstance(raw_expires, str):
+            try:
+                cached_expires: datetime | None = datetime.fromisoformat(raw_expires)
+            except ValueError:
+                cached_expires = None
+        elif isinstance(raw_expires, datetime):
+            cached_expires = raw_expires
+        else:
+            cached_expires = None
+
+        raw_namespace = meta.get("namespace")
+        namespace = (
+            raw_namespace
+            if isinstance(raw_namespace, str) and raw_namespace
+            else derive_namespace(rel_path)
+        )
+        raw_tags = meta.get("tags", [])
+        raw_author = meta.get("author", "")
+        raw_access_scope = meta.get("access_scope")
+        raw_source = meta.get("source")
+        raw_note_type = meta.get("note_type")
+        raw_status = meta.get("status")
+        raw_source_url = meta.get("source_url")
+        raw_entities = meta.get("entities", [])
+        return cls(
+            title=meta.get("title", "") if isinstance(meta.get("title"), str) else "",
+            author=raw_author if isinstance(raw_author, str) else "",
+            tags=raw_tags if isinstance(raw_tags, list) else [],
+            updated_at=updated_at,
+            path=rel_path,
+            namespace=namespace,
+            expires_at=cached_expires,
+            access_scope=raw_access_scope if isinstance(raw_access_scope, str) else None,
+            source=raw_source if isinstance(raw_source, str) else None,
+            note_type=raw_note_type if isinstance(raw_note_type, str) else None,
+            status=raw_status if isinstance(raw_status, str) else None,
+            source_url=raw_source_url if isinstance(raw_source_url, str) else None,
+            entities=raw_entities if isinstance(raw_entities, list) else [],
+            extra=extract_extra(meta),
+            seq=seq,
+        )
+
+
+@dataclass(frozen=True)
+class ScannedNote:
+    """One note as seen by a startup scan — the input row to :meth:`CorpusIndex.rebuild`.
+
+    Carries the frontmatter the manager already read plus the resolved id/title,
+    so the index does the projection while the manager keeps the file I/O.
+    """
+
+    doc_id: str
+    title: str
+    frontmatter: dict
+    rel_path: Path
+
+
+class CorpusIndex:
+    """The derived, in-memory view of the Corpus that KnowledgeManager queries.
+
+    Holds all derived state privately and exposes an explicit read + mutation
+    surface. The manager never touches the maps directly; it calls the methods
+    here, which keeps every query-acceleration invariant in one place.
+    """
+
+    def __init__(self) -> None:
+        self._id_to_path: dict[str, Path] = {}
+        self._path_to_id: dict[Path, str] = {}
+        self._slug_to_id: dict[str, str] = {}
+        self._source_url_to_id: dict[str, str] = {}
+        # Provenance indexes
+        self._doc_to_sources: dict[str, list[str]] = {}
+        self._source_to_derived: dict[str, set[str]] = {}
+        self._unresolved_provenance: dict[str, set[str]] = {}
+        self._id_to_title: dict[str, str] = {}
+        self._meta_cache: dict[str, CachedMeta] = {}
+        # Inverted indexes for sub-linear equality filtering (#306). All map a
+        # value to the set of doc ids carrying it; maintained beside _meta_cache.
+        self._author_index: dict[str, set[str]] = {}
+        self._status_index: dict[str, set[str]] = {}
+        self._tag_index: dict[str, set[str]] = {}
+        self._entities_index: dict[str, set[str]] = {}
+        self._metadata_index: dict[str, dict[str, set[str]]] = {}
+        self._meta_seq: int = 0
+        self.duplicate_url_count: int = 0
+
+    def next_seq(self) -> int:
+        """Return a monotonically increasing insertion ordinal for CachedMeta.seq."""
+        self._meta_seq += 1
+        return self._meta_seq
+
+    # ==================== Inverted-index maintenance ====================
+
+    def index_doc(self, doc_id: str, cached: CachedMeta) -> None:
+        """Add a doc's equality-filter contributions to the inverted indexes."""
+        if cached.author:
+            self._author_index.setdefault(cached.author, set()).add(doc_id)
+        if cached.status:
+            self._status_index.setdefault(cached.status, set()).add(doc_id)
+        for tag in cached.tags:
+            self._tag_index.setdefault(tag, set()).add(doc_id)
+        for entity in cached.entities:
+            self._entities_index.setdefault(entity, set()).add(doc_id)
+        for key, value in cached.extra.items():
+            buckets = self._metadata_index.setdefault(key, {})
+            # A list value is matched element-wise (contains); a scalar by value.
+            elements = value if isinstance(value, list) else [value]
+            for element in elements:
+                buckets.setdefault(canonical_metadata_value(element), set()).add(doc_id)
+
+    def deindex_doc(self, doc_id: str, cached: CachedMeta) -> None:
+        """Remove a doc's contributions (using its *previous* cached meta)."""
+
+        def _discard(index: dict[str, set[str]], value: str | None) -> None:
+            if value is None:
+                return
+            bucket = index.get(value)
+            if bucket is not None:
+                bucket.discard(doc_id)
+                if not bucket:
+                    del index[value]
+
+        _discard(self._author_index, cached.author or None)
+        _discard(self._status_index, cached.status or None)
+        for tag in cached.tags:
+            _discard(self._tag_index, tag)
+        for entity in cached.entities:
+            _discard(self._entities_index, entity)
+        for key, value in cached.extra.items():
+            buckets = self._metadata_index.get(key)
+            if buckets is None:
+                continue
+            elements = value if isinstance(value, list) else [value]
+            for element in elements:
+                _discard(buckets, canonical_metadata_value(element))
+            if not buckets:
+                del self._metadata_index[key]
+
+    def candidate_ids(
+        self,
+        *,
+        tags: list[str] | None,
+        author: str | None,
+        metadata_match: dict | None,
+        exclude_status: list[str] | None,
+        entities: list[str] | None = None,
+    ) -> set[str] | None:
+        """Resolve equality filters to a candidate id set via the inverted index.
+
+        Returns ``None`` when no equality/AND filter is supplied, signalling the
+        caller to use the existing full-scan path (correct for unfiltered /
+        prefix-only / since-only / exclude-only queries). Otherwise returns the
+        (possibly empty) intersected candidate set — never iterating all docs.
+        """
+        seed_sets: list[set[str]] = []
+        if author:
+            seed_sets.append(self._author_index.get(author, set()))
+        if tags:
+            for tag in tags:
+                seed_sets.append(self._tag_index.get(tag, set()))
+        if entities:
+            for entity in entities:
+                seed_sets.append(self._entities_index.get(entity, set()))
+        if metadata_match:
+            for key, value in metadata_match.items():
+                bucket = self._metadata_index.get(key, {})
+                seed_sets.append(bucket.get(canonical_metadata_value(value), set()))
+
+        if not seed_sets:
+            return None
+
+        # Intersect smallest-first; any empty seed short-circuits to empty.
+        seed_sets.sort(key=len)
+        candidates = set(seed_sets[0])
+        for s in seed_sets[1:]:
+            candidates &= s
+            if not candidates:
+                break
+
+        if candidates and exclude_status:
+            for status in exclude_status:
+                candidates -= self._status_index.get(status, set())
+
+        return candidates
+
+    def metadata_candidate_ids(self, metadata_match: dict | None) -> set[str] | None:
+        """Candidate ids for a ``metadata_match`` filter, or ``None`` if empty (#306)."""
+        if not metadata_match:
+            return None
+        return self.candidate_ids(
+            tags=None, author=None, metadata_match=metadata_match, exclude_status=None
+        )
+
+    def entities_candidate_ids(self, entities: list[str] | None) -> set[str] | None:
+        """Candidate ids carrying every named entity, or ``None`` if empty (#316)."""
+        if not entities:
+            return None
+        return self.candidate_ids(
+            tags=None, author=None, metadata_match=None, exclude_status=None, entities=entities
+        )
+
+    # ==================== Provenance maintenance ====================
+
+    def _classify_provenance(self, doc_id: str, sources: list[str]) -> list[str]:
+        """Record ``doc_id``'s sources and file each into resolved/unresolved.
+
+        Sets the forward map and, per source, adds ``doc_id`` to
+        ``_source_to_derived`` when the source exists or ``_unresolved_provenance``
+        when it does not. Returns a warning per missing source. Shared core of
+        create/update/sync/scan — the callers own removal, auto-resolve, and
+        whether to surface the warnings.
+        """
+        self._doc_to_sources[doc_id] = list(sources)
+        warnings: list[str] = []
+        for source_id in sources:
+            if source_id in self._id_to_path:
+                self._source_to_derived.setdefault(source_id, set()).add(doc_id)
+            else:
+                self._unresolved_provenance.setdefault(source_id, set()).add(doc_id)
+                warnings.append(f"derived_from_ids contains missing document: {source_id}")
+        return warnings
+
+    def _classify_and_log(self, doc_id: str, sources: list[str]) -> list[str]:
+        """Classify provenance and log each unresolved source. Returns warnings.
+
+        The write paths (create/update) surface warnings to the caller and log
+        the dangling reference; the silent paths (sync/scan) call
+        :meth:`_classify_provenance` directly.
+        """
+        warnings = self._classify_provenance(doc_id, sources)
+        for source_id in sources:
+            if source_id not in self._id_to_path:
+                logger.warning(
+                    "Provenance resolution failed: source_id=%s dependent_doc_id=%s",
+                    source_id,
+                    doc_id,
+                )
+        return warnings
+
+    def _auto_resolve(self, doc_id: str) -> None:
+        """Promote docs that referenced ``doc_id`` before it existed to resolved."""
+        if doc_id in self._unresolved_provenance:
+            resolved_docs = self._unresolved_provenance.pop(doc_id)
+            self._source_to_derived.setdefault(doc_id, set()).update(resolved_docs)
+
+    def remove_provenance(self, doc_id: str) -> None:
+        """Remove a document's forward references from the reverse indexes.
+
+        Cleans ``_source_to_derived`` and ``_unresolved_provenance`` for the
+        given doc_id based on its current ``_doc_to_sources`` entries. Leaves
+        the forward ``_doc_to_sources`` entry untouched (callers overwrite it).
+        """
+        old_sources = self._doc_to_sources.get(doc_id, [])
+        for source_id in old_sources:
+            if source_id in self._source_to_derived:
+                self._source_to_derived[source_id].discard(doc_id)
+                if not self._source_to_derived[source_id]:
+                    del self._source_to_derived[source_id]
+            if source_id in self._unresolved_provenance:
+                self._unresolved_provenance[source_id].discard(doc_id)
+                if not self._unresolved_provenance[source_id]:
+                    del self._unresolved_provenance[source_id]
+
+    def replace_provenance(self, doc_id: str, sources: list[str]) -> list[str]:
+        """Replace a document's provenance: drop old reverse entries, classify new.
+
+        The update path's semantics — logs and returns a warning per missing
+        source, but does not auto-resolve (a re-pointed note is not a new node).
+        """
+        self.remove_provenance(doc_id)
+        return self._classify_and_log(doc_id, sources)
+
+    def sync_provenance(self, doc_id: str, sources: list[str], *, is_new: bool) -> None:
+        """Diff-and-apply provenance during a file-watcher sync.
+
+        A modified note only re-files when its sources changed; a new note
+        classifies and then auto-resolves anything that referenced it.
+        """
+        if not is_new:
+            if self._doc_to_sources.get(doc_id, []) != sources:
+                self.remove_provenance(doc_id)
+                self._classify_provenance(doc_id, sources)
+        else:
+            self._classify_provenance(doc_id, sources)
+            self._auto_resolve(doc_id)
+
+    # ==================== Document mutation ====================
+
+    def add_document(
+        self,
+        doc_id: str,
+        cached: CachedMeta,
+        *,
+        title: str,
+        norm_url: str | None,
+        sources: list[str],
+    ) -> list[str]:
+        """Register a freshly-created document across every index. Returns warnings.
+
+        Warnings name any source in ``sources`` that does not yet exist (the
+        note still records the dangling reference). Also auto-resolves docs that
+        referenced ``doc_id`` before it existed.
+        """
+        self._id_to_path[doc_id] = cached.path
+        self._path_to_id[cached.path] = doc_id
+        self._slug_to_id[slugify(title)] = doc_id
+        if norm_url is not None:
+            self._source_url_to_id[norm_url] = doc_id
+        self._id_to_title[doc_id] = title
+
+        warnings = self._classify_and_log(doc_id, sources)
+        self._auto_resolve(doc_id)
+
+        self._meta_cache[doc_id] = cached
+        self.index_doc(doc_id, cached)
+        return warnings
+
+    def reindex_document(self, doc_id: str, cached: CachedMeta) -> None:
+        """Replace a document's cache entry and inverted-index contributions.
+
+        Deindexes the prior entry first (if any); the caller preserves ``seq``
+        on ``cached`` so list ordering/pagination is unchanged by an update.
+        """
+        old_cached = self._meta_cache.get(doc_id)
+        if old_cached is not None:
+            self.deindex_doc(doc_id, old_cached)
+        self._meta_cache[doc_id] = cached
+        self.index_doc(doc_id, cached)
+
+    def remove_document(self, doc_id: str) -> None:
+        """Remove a document from every index (id/path/slug/title/provenance/cache)."""
+        old_path = self._id_to_path.pop(doc_id, None)
+        if old_path is not None:
+            self._path_to_id.pop(old_path, None)
+        self._slug_to_id = {k: v for k, v in self._slug_to_id.items() if v != doc_id}
+
+        # 1. Remove this doc as a "derived" doc from reverse indexes
+        self.remove_provenance(doc_id)
+        # 2. Remove forward index entry
+        self._doc_to_sources.pop(doc_id, None)
+        # 3. If this doc was a source for others, move those to unresolved
+        derived_docs = self._source_to_derived.pop(doc_id, set())
+        if derived_docs:
+            self._unresolved_provenance[doc_id] = derived_docs
+        # 4. Remove from title and metadata caches + inverted index
+        self._id_to_title.pop(doc_id, None)
+        removed = self._meta_cache.pop(doc_id, None)
+        if removed is not None:
+            self.deindex_doc(doc_id, removed)
+
+    def set_title(self, doc_id: str, title: str) -> None:
+        """Record a document's title for id→title lookups."""
+        self._id_to_title[doc_id] = title
+
+    def set_path(self, doc_id: str, rel_path: Path) -> None:
+        """Point ``doc_id`` at ``rel_path``, dropping any prior path mapping.
+
+        Handles a file-watcher rename where a known doc moves to a new path.
+        """
+        old_path = self._id_to_path.get(doc_id)
+        if old_path is not None:
+            self._path_to_id.pop(old_path, None)
+        self._id_to_path[doc_id] = rel_path
+        self._path_to_id[rel_path] = doc_id
+
+    def reroute_slug_for(self, doc_id: str, new_slug: str) -> None:
+        """Move ``doc_id`` to ``new_slug``, finding its current slug by scan.
+
+        The sync path does not carry the old slug (the on-disk title may have
+        changed under it), so the previous entry is located by value.
+        """
+        old_slug = next((s for s, sid in self._slug_to_id.items() if sid == doc_id), None)
+        if old_slug and old_slug != new_slug and self._slug_to_id.get(old_slug) == doc_id:
+            del self._slug_to_id[old_slug]
+        self._slug_to_id[new_slug] = doc_id
+
+    def reroute_slug(self, old_slug: str, new_slug: str, doc_id: str) -> None:
+        """Move ``doc_id``'s slug entry from ``old_slug`` to ``new_slug``."""
+        if old_slug != new_slug:
+            if self._slug_to_id.get(old_slug) == doc_id:
+                del self._slug_to_id[old_slug]
+            self._slug_to_id[new_slug] = doc_id
+
+    def set_source_url(self, norm_url: str, doc_id: str) -> None:
+        """Point a normalized source URL at ``doc_id``."""
+        self._source_url_to_id[norm_url] = doc_id
+
+    def remove_source_url(self, norm_url: str, doc_id: str) -> None:
+        """Drop a normalized source URL mapping if ``doc_id`` currently owns it."""
+        if self._source_url_to_id.get(norm_url) == doc_id:
+            del self._source_url_to_id[norm_url]
+
+    def clear_source_urls_for(self, doc_id: str) -> None:
+        """Drop every source-URL mapping currently pointing at ``doc_id``."""
+        for k in [k for k, v in self._source_url_to_id.items() if v == doc_id]:
+            del self._source_url_to_id[k]
+
+    def source_url_owner(self, norm_url: str) -> str | None:
+        """Return the doc id currently owning ``norm_url``, or ``None``."""
+        return self._source_url_to_id.get(norm_url)
+
+    def rebuild(self, scanned: Iterable[ScannedNote]) -> None:
+        """Rebuild every index from a startup scan of the Corpus.
+
+        Two passes over the (already file-read) notes: pass 1 builds the core
+        maps, the metadata cache, and the source-url map (tracking duplicates);
+        pass 2 classifies each note's provenance now that every id is known.
+        Clears all prior state first, so a rescan can never accumulate staleness.
+        """
+        self._id_to_path.clear()
+        self._path_to_id.clear()
+        self._slug_to_id.clear()
+        self._source_url_to_id.clear()
+        self._doc_to_sources.clear()
+        self._source_to_derived.clear()
+        self._unresolved_provenance.clear()
+        self._id_to_title.clear()
+        self._meta_cache.clear()
+        self._author_index.clear()
+        self._status_index.clear()
+        self._tag_index.clear()
+        self._entities_index.clear()
+        self._metadata_index.clear()
+        self._meta_seq = 0
+        self.duplicate_url_count = 0
+
+        collisions: list[tuple[str, str, str]] = []  # (norm_url, first_id, dup_id)
+        deferred_provenance: list[tuple[str, list[str]]] = []
+
+        # Pass 1: populate core indexes, collect provenance.
+        for note in scanned:
+            doc_id = note.doc_id
+            self._id_to_path[doc_id] = note.rel_path
+            self._path_to_id[note.rel_path] = doc_id
+            if note.title:
+                slug = slugify(note.title)
+                existing_slug_id = self._slug_to_id.get(slug)
+                if existing_slug_id is not None and existing_slug_id != doc_id:
+                    logger.warning(
+                        "Slug collision detected: slug=%r already used by %r, also claimed by %r",
+                        slug,
+                        existing_slug_id,
+                        doc_id,
+                    )
+                else:
+                    self._slug_to_id[slug] = doc_id
+                    self._id_to_title[doc_id] = note.title
+
+            cached = CachedMeta.from_frontmatter(
+                note.frontmatter, note.rel_path, seq=self.next_seq()
+            )
+            self._meta_cache[doc_id] = cached
+            self.index_doc(doc_id, cached)
+
+            raw_url = note.frontmatter.get("source_url")
+            if isinstance(raw_url, str) and raw_url:
+                try:
+                    norm = normalize_url(raw_url)
+                    if norm not in self._source_url_to_id:
+                        self._source_url_to_id[norm] = doc_id
+                    else:
+                        collisions.append((norm, self._source_url_to_id[norm], doc_id))
+                except ValueError:
+                    pass  # Skip invalid URLs on load
+
+            derived_from = note.frontmatter.get("derived_from_ids", [])
+            deferred_provenance.append(
+                (doc_id, derived_from if isinstance(derived_from, list) else [])
+            )
+
+        # Pass 2: normalize and classify provenance now that all ids are known.
+        for doc_id, source_ids in deferred_provenance:
+            normalized_ids = normalize_derived_from_ids_lenient(source_ids, self_id=doc_id)
+            self._classify_provenance(doc_id, normalized_ids)
+
+        resolved_count = sum(len(v) for v in self._source_to_derived.values())
+        unresolved_count = sum(len(v) for v in self._unresolved_provenance.values())
+        if resolved_count or unresolved_count:
+            logger.info(
+                "Provenance scan: %d resolved references, %d unresolved references",
+                resolved_count,
+                unresolved_count,
+            )
+
+        # Report collisions deterministically (sorted by normalized URL).
+        if collisions:
+            collisions.sort(key=lambda t: t[0])
+            self.duplicate_url_count = len(collisions)
+            for norm_url, first_id, dup_id in collisions:
+                logger.warning(
+                    "Duplicate source_url at startup: %s owned by %s, duplicate in %s (skipped)",
+                    norm_url,
+                    first_id,
+                    dup_id,
+                )
+
+    # ==================== Read accessors ====================
+
+    def get_cached_meta(self, node_id: str) -> CachedMeta | None:
+        """Return cached metadata for a node, or ``None`` if unknown."""
+        return self._meta_cache.get(node_id)
+
+    def iter_cached_meta(self) -> Iterable[tuple[str, CachedMeta]]:
+        """Snapshot ``(node_id, cached_meta)`` pairs for safe iteration."""
+        return list(self._meta_cache.items())
+
+    @property
+    def document_count(self) -> int:
+        """Count of known documents (from in-memory cache)."""
+        return len(self._meta_cache)
+
+    @property
+    def stale_document_count(self) -> int:
+        """Count of documents whose expires_at is set and in the past."""
+        now = datetime.now(UTC)
+        count = 0
+        for cached in self._meta_cache.values():
+            if cached.expires_at is not None and normalize_datetime(cached.expires_at) < now:
+                count += 1
+        return count
+
+    def id_by_slug(self, slug: str) -> str | None:
+        """Get document id by slug."""
+        return self._slug_to_id.get(slug)
+
+    def id_by_relpath(self, rel_path: Path) -> str | None:
+        """Get document id by an already-resolved relative path."""
+        return self._path_to_id.get(rel_path)
+
+    def relpath_of(self, doc_id: str) -> Path | None:
+        """Get a document's relative path, or ``None`` if unknown."""
+        return self._id_to_path.get(doc_id)
+
+    def all_slugs(self) -> dict[str, str]:
+        """Snapshot the slug→id map."""
+        return dict(self._slug_to_id)
+
+    def title_by_id(self, doc_id: str) -> str:
+        """Get document title by id, empty string if unknown."""
+        return self._id_to_title.get(doc_id, "")
+
+    def has_document(self, doc_id: str) -> bool:
+        """Whether a document id exists."""
+        return doc_id in self._id_to_path
+
+    def iter_doc_ids(self) -> Iterable[str]:
+        """Snapshot every known document id."""
+        return list(self._id_to_path)
+
+    def id_by_source_url(self, norm_url: str) -> str | None:
+        """Get document id owning a normalized source URL."""
+        return self._source_url_to_id.get(norm_url)
+
+    def iter_source_urls(self) -> Iterable[tuple[str, str]]:
+        """Snapshot ``(normalized_url, doc_id)`` pairs."""
+        return list(self._source_url_to_id.items())
+
+    def doc_sources(self, doc_id: str) -> list[str]:
+        """Get the source ids this document derives from."""
+        return self._doc_to_sources.get(doc_id, [])
+
+    def iter_doc_sources(self) -> Iterable[tuple[str, list[str]]]:
+        """Snapshot ``(doc_id, source_ids)`` pairs; lists are fresh copies."""
+        return [(doc_id, list(sources)) for doc_id, sources in self._doc_to_sources.items()]
+
+    def derived_docs(self, doc_id: str) -> set[str]:
+        """Get ids of documents derived from this document."""
+        return self._source_to_derived.get(doc_id, set())
+
+    def unresolved_sources(self, doc_id: str) -> list[str]:
+        """Get the unresolved source ids referenced by a document."""
+        sources = self._doc_to_sources.get(doc_id, [])
+        return [
+            sid
+            for sid in sources
+            if sid in self._unresolved_provenance or sid not in self._id_to_path
+        ]
+
+    def has_unresolved_source(self, source_id: str) -> bool:
+        """Whether any document has an unresolved reference to ``source_id``."""
+        return source_id in self._unresolved_provenance
+
+    def all_tags(self) -> dict[str, int]:
+        """Tag → document-count over the whole cache."""
+        tag_counts: dict[str, int] = {}
+        for cached in self._meta_cache.values():
+            for tag in cached.tags:
+                tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        return tag_counts

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1,10 +1,13 @@
 """Knowledge module - Markdown document CRUD with frontmatter.
 
 The corpus *file format* lives next door in :mod:`lithos.frontmatter_codec`;
-this module owns the corpus *store* — CRUD, the metadata cache and its inverted
-indexes, slug/path allocation, and the reconcile seam that rebuilds the derived
-views (ADR-0001). It reads and writes bytes; the codec turns those bytes into
-documents and back.
+this module owns the corpus *store* — CRUD, disk I/O, slug/path allocation, and
+the reconcile seam that rebuilds the derived views (ADR-0001). It reads and
+writes bytes; the codec turns those bytes into documents and back.
+
+The derived *query view* — the metadata cache, its inverted indexes, and the
+in-memory provenance maps — is delegated to :mod:`lithos.corpus_index`, held as
+``self._index`` and rebuilt from the corpus scan on construction.
 """
 
 import asyncio

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -23,15 +23,13 @@ import frontmatter
 
 from lithos._merge import merge_metadata
 from lithos.config import LithosConfig
+from lithos.corpus_index import CachedMeta, CorpusIndex, ScannedNote
 from lithos.errors import CorpusScanError, SlugCollisionError
 from lithos.frontmatter_codec import (
     KnowledgeDocument,
     KnowledgeMetadata,
-    canonical_metadata_value,
     decode,
-    derive_namespace,
     encode,
-    extract_extra,
     normalize_datetime,
     normalize_derived_from_ids_lenient,
     normalize_url,
@@ -120,39 +118,6 @@ class WriteResult:
     duplicate_of: DuplicateInfo | None = None
     current_version: int | None = None
     path_collision_existing_id: str | None = None
-
-
-@dataclass
-class _CachedMeta:
-    """Lightweight metadata cache for filtering without disk I/O.
-
-    ``namespace`` is the resolved LCMA namespace — either an explicit value
-    from frontmatter or the path-derived default. Callers MUST read this
-    field rather than re-deriving from ``path`` so explicit overrides are
-    honored consistently across the retrieval pipeline.
-    """
-
-    title: str
-    author: str
-    tags: list[str]
-    updated_at: datetime
-    path: Path
-    namespace: str
-    expires_at: datetime | None = None
-    access_scope: str | None = None
-    source: str | None = None
-    note_type: str | None = None
-    status: str | None = None
-    source_url: str | None = None
-    # Extracted/curated entity names (#316) — kept here so the entities
-    # inverted index can be maintained without a disk read.
-    entities: list[str] = field(default_factory=list)
-    # Free-form key/value metadata (#305) — kept here so equality filtering and
-    # the inverted index (#306) work without a disk read.
-    extra: dict = field(default_factory=dict)
-    # Insertion ordinal — reproduces _meta_cache ordering in the index path so
-    # list pagination stays stable (#306).
-    seq: int = 0
 
 
 class _UnsetType:
@@ -307,300 +272,54 @@ class KnowledgeManager:
         """
         self.config = config
         self.knowledge_path = self.config.storage.knowledge_path
-        self._id_to_path: dict[str, Path] = {}
-        self._path_to_id: dict[Path, str] = {}
-        self._slug_to_id: dict[str, str] = {}
-        self._source_url_to_id: dict[str, str] = {}
         self._write_lock = asyncio.Lock()
-        self.duplicate_url_count: int = 0
-        # Provenance indexes
-        self._doc_to_sources: dict[str, list[str]] = {}
-        self._source_to_derived: dict[str, set[str]] = {}
-        self._unresolved_provenance: dict[str, set[str]] = {}
-        self._id_to_title: dict[str, str] = {}
-        self._meta_cache: dict[str, _CachedMeta] = {}
-        # Inverted indexes for sub-linear equality filtering (#306). All map a
-        # value to the set of doc ids carrying it; maintained beside _meta_cache.
-        self._author_index: dict[str, set[str]] = {}
-        self._status_index: dict[str, set[str]] = {}
-        self._tag_index: dict[str, set[str]] = {}
-        self._entities_index: dict[str, set[str]] = {}
-        self._metadata_index: dict[str, dict[str, set[str]]] = {}
-        self._meta_seq: int = 0
+        # The derived, in-memory query view over the Corpus (metadata cache,
+        # inverted indexes, path/slug/url maps, provenance graph). The manager
+        # owns files and policy; the index owns query acceleration.
+        self._index = CorpusIndex()
         self._scan_existing()
 
-    def _next_seq(self) -> int:
-        self._meta_seq += 1
-        return self._meta_seq
-
-    def _index_doc(self, doc_id: str, cached: _CachedMeta) -> None:
-        """Add a doc's equality-filter contributions to the inverted indexes."""
-        if cached.author:
-            self._author_index.setdefault(cached.author, set()).add(doc_id)
-        if cached.status:
-            self._status_index.setdefault(cached.status, set()).add(doc_id)
-        for tag in cached.tags:
-            self._tag_index.setdefault(tag, set()).add(doc_id)
-        for entity in cached.entities:
-            self._entities_index.setdefault(entity, set()).add(doc_id)
-        for key, value in cached.extra.items():
-            buckets = self._metadata_index.setdefault(key, {})
-            # A list value is matched element-wise (contains); a scalar by value.
-            elements = value if isinstance(value, list) else [value]
-            for element in elements:
-                buckets.setdefault(canonical_metadata_value(element), set()).add(doc_id)
-
-    def _deindex_doc(self, doc_id: str, cached: _CachedMeta) -> None:
-        """Remove a doc's contributions (using its *previous* cached meta)."""
-
-        def _discard(index: dict[str, set[str]], value: str | None) -> None:
-            if value is None:
-                return
-            bucket = index.get(value)
-            if bucket is not None:
-                bucket.discard(doc_id)
-                if not bucket:
-                    del index[value]
-
-        _discard(self._author_index, cached.author or None)
-        _discard(self._status_index, cached.status or None)
-        for tag in cached.tags:
-            _discard(self._tag_index, tag)
-        for entity in cached.entities:
-            _discard(self._entities_index, entity)
-        for key, value in cached.extra.items():
-            buckets = self._metadata_index.get(key)
-            if buckets is None:
-                continue
-            elements = value if isinstance(value, list) else [value]
-            for element in elements:
-                _discard(buckets, canonical_metadata_value(element))
-            if not buckets:
-                del self._metadata_index[key]
-
-    def _candidate_ids(
-        self,
-        *,
-        tags: list[str] | None,
-        author: str | None,
-        metadata_match: dict | None,
-        exclude_status: list[str] | None,
-        entities: list[str] | None = None,
-    ) -> set[str] | None:
-        """Resolve equality filters to a candidate id set via the inverted index.
-
-        Returns ``None`` when no equality/AND filter is supplied, signalling the
-        caller to use the existing full-scan path (correct for unfiltered /
-        prefix-only / since-only / exclude-only queries). Otherwise returns the
-        (possibly empty) intersected candidate set — never iterating all docs.
-        """
-        seed_sets: list[set[str]] = []
-        if author:
-            seed_sets.append(self._author_index.get(author, set()))
-        if tags:
-            for tag in tags:
-                seed_sets.append(self._tag_index.get(tag, set()))
-        if entities:
-            for entity in entities:
-                seed_sets.append(self._entities_index.get(entity, set()))
-        if metadata_match:
-            for key, value in metadata_match.items():
-                bucket = self._metadata_index.get(key, {})
-                seed_sets.append(bucket.get(canonical_metadata_value(value), set()))
-
-        if not seed_sets:
-            return None
-
-        # Intersect smallest-first; any empty seed short-circuits to empty.
-        seed_sets.sort(key=len)
-        candidates = set(seed_sets[0])
-        for s in seed_sets[1:]:
-            candidates &= s
-            if not candidates:
-                break
-
-        if candidates and exclude_status:
-            for status in exclude_status:
-                candidates -= self._status_index.get(status, set())
-
-        return candidates
+    @property
+    def duplicate_url_count(self) -> int:
+        """Number of duplicate source_urls skipped on the last scan."""
+        return self._index.duplicate_url_count
 
     def _scan_existing(self) -> None:
-        """Scan existing documents and build indices.
+        """Scan the Corpus from disk and rebuild the derived index.
 
-        Uses a two-pass approach:
-        - Pass 1: Walk files, populate core indexes and collect provenance pairs.
-        - Pass 2: Classify provenance references as resolved or unresolved.
+        The manager owns the file walk — which files, in what order, and
+        skipping any that won't parse — and hands the frontmatter it read to
+        :meth:`CorpusIndex.rebuild`, which owns the projection. Candidates are
+        walked in sorted order so the index's first-seen-wins tie-breaks
+        (slug and source-url collisions) are deterministic.
         """
-        # Clear all indexes before rebuilding (prevents stale accumulation).
-        self._id_to_path.clear()
-        self._path_to_id.clear()
-        self._slug_to_id.clear()
-        self._source_url_to_id.clear()
-        self._doc_to_sources.clear()
-        self._source_to_derived.clear()
-        self._unresolved_provenance.clear()
-        self._id_to_title.clear()
-        self._meta_cache.clear()
-        self._author_index.clear()
-        self._status_index.clear()
-        self._tag_index.clear()
-        self._entities_index.clear()
-        self._metadata_index.clear()
-        self._meta_seq = 0
-        self.duplicate_url_count = 0
-
-        if not self.knowledge_path.exists():
-            return
-
-        base_path = self.knowledge_path.resolve()
-        # Collect candidates in sorted order for deterministic first-seen-wins.
-        candidates: list[tuple[Path, Path]] = []
-        for md_file in self.knowledge_path.rglob("*.md"):
-            resolved = md_file.resolve()
-            if not resolved.is_relative_to(base_path):
-                continue
-            candidates.append((md_file.relative_to(self.knowledge_path), md_file))
-        candidates.sort(key=lambda t: t[0])
-        collisions: list[tuple[str, str, str]] = []  # (norm_url, first_id, dup_id)
-
-        # Pass 1: Walk files, populate core indexes, collect provenance.
-        deferred_provenance: list[tuple[str, list[str]]] = []
-
-        for rel_path, md_file in candidates:
-            try:
-                post = frontmatter.load(str(md_file))
-                doc_id: str | None = post.metadata.get("id")  # type: ignore[assignment]
-                title: str = post.metadata.get("title", "")  # type: ignore[assignment]
-                if doc_id:
-                    self._id_to_path[doc_id] = rel_path
-                    self._path_to_id[rel_path] = doc_id
-                    if title:
-                        slug = slugify(title)
-                        existing_slug_id = self._slug_to_id.get(slug)
-                        if existing_slug_id is not None and existing_slug_id != doc_id:
-                            logger.warning(
-                                "Slug collision detected: slug=%r already used by %r, also claimed by %r",
-                                slug,
-                                existing_slug_id,
-                                doc_id,
+        scanned: list[ScannedNote] = []
+        if self.knowledge_path.exists():
+            base_path = self.knowledge_path.resolve()
+            candidates: list[tuple[Path, Path]] = []
+            for md_file in self.knowledge_path.rglob("*.md"):
+                resolved = md_file.resolve()
+                if not resolved.is_relative_to(base_path):
+                    continue
+                candidates.append((md_file.relative_to(self.knowledge_path), md_file))
+            candidates.sort(key=lambda t: t[0])
+            for rel_path, md_file in candidates:
+                try:
+                    post = frontmatter.load(str(md_file))
+                    doc_id: str | None = post.metadata.get("id")  # type: ignore[assignment]
+                    if doc_id:
+                        title = post.metadata.get("title", "")
+                        scanned.append(
+                            ScannedNote(
+                                doc_id=doc_id,
+                                title=title if isinstance(title, str) else "",
+                                frontmatter=dict(post.metadata),
+                                rel_path=rel_path,
                             )
-                        else:
-                            self._slug_to_id[slug] = doc_id
-                            self._id_to_title[doc_id] = title
-
-                    # Populate metadata cache for filtering
-                    raw_updated = post.metadata.get("updated_at")
-                    if isinstance(raw_updated, str):
-                        updated_at = datetime.fromisoformat(raw_updated)
-                    elif isinstance(raw_updated, datetime):
-                        updated_at = raw_updated
-                    else:
-                        updated_at = datetime.now(UTC)
-                    raw_tags: list[str] = post.metadata.get("tags", [])  # type: ignore[assignment]
-                    raw_author: str = post.metadata.get("author", "")  # type: ignore[assignment]
-                    raw_expires: str | datetime | None = post.metadata.get("expires_at")  # type: ignore[assignment]
-                    if isinstance(raw_expires, str):
-                        try:
-                            cached_expires: datetime | None = datetime.fromisoformat(raw_expires)
-                        except ValueError:
-                            cached_expires = None
-                    elif isinstance(raw_expires, datetime):
-                        cached_expires = raw_expires
-                    else:
-                        cached_expires = None
-                    raw_access_scope: str | None = post.metadata.get("access_scope")  # type: ignore[assignment]
-                    raw_source: str | None = post.metadata.get("source")  # type: ignore[assignment]
-                    raw_note_type: str | None = post.metadata.get("note_type")  # type: ignore[assignment]
-                    raw_namespace: str | None = post.metadata.get("namespace")  # type: ignore[assignment]
-                    raw_status: str | None = post.metadata.get("status")  # type: ignore[assignment]
-                    raw_source_url: str | None = post.metadata.get("source_url")  # type: ignore[assignment]
-                    raw_entities: list[str] = post.metadata.get("entities", [])  # type: ignore[assignment]
-                    cached_namespace = (
-                        raw_namespace
-                        if isinstance(raw_namespace, str) and raw_namespace
-                        else derive_namespace(rel_path)
-                    )
-                    cached = _CachedMeta(
-                        title=title,
-                        author=raw_author if isinstance(raw_author, str) else "",
-                        tags=raw_tags if isinstance(raw_tags, list) else [],
-                        updated_at=updated_at,
-                        path=rel_path,
-                        namespace=cached_namespace,
-                        expires_at=cached_expires,
-                        access_scope=raw_access_scope
-                        if isinstance(raw_access_scope, str)
-                        else None,
-                        source=raw_source if isinstance(raw_source, str) else None,
-                        note_type=raw_note_type if isinstance(raw_note_type, str) else None,
-                        status=raw_status if isinstance(raw_status, str) else None,
-                        source_url=raw_source_url if isinstance(raw_source_url, str) else None,
-                        entities=raw_entities if isinstance(raw_entities, list) else [],
-                        extra=extract_extra(post.metadata),
-                        seq=self._next_seq(),
-                    )
-                    self._meta_cache[doc_id] = cached
-                    self._index_doc(doc_id, cached)
-
-                    # Populate source_url -> id map
-                    raw_url: str | None = post.metadata.get("source_url")  # type: ignore[assignment]
-                    if raw_url:
-                        try:
-                            norm = normalize_url(raw_url)
-                            if norm not in self._source_url_to_id:
-                                self._source_url_to_id[norm] = doc_id
-                            else:
-                                existing_id = self._source_url_to_id[norm]
-                                collisions.append((norm, existing_id, doc_id))
-                        except ValueError:
-                            pass  # Skip invalid URLs on load
-
-                    # Collect derived_from_ids for pass 2
-                    derived_from: list[str] = post.metadata.get("derived_from_ids", [])  # type: ignore[assignment]
-                    if isinstance(derived_from, list):
-                        deferred_provenance.append((doc_id, derived_from))
-                    else:
-                        deferred_provenance.append((doc_id, []))
-            except Exception as e:
-                logger.warning("Skipping invalid file %s: %s", md_file, e)
-
-        # Pass 2: Normalize and classify provenance references as resolved or unresolved.
-        for doc_id, source_ids in deferred_provenance:
-            normalized_ids = normalize_derived_from_ids_lenient(source_ids, self_id=doc_id)
-            self._doc_to_sources[doc_id] = normalized_ids
-            for source_id in normalized_ids:
-                if source_id in self._id_to_path:
-                    # Resolved: source document exists
-                    if source_id not in self._source_to_derived:
-                        self._source_to_derived[source_id] = set()
-                    self._source_to_derived[source_id].add(doc_id)
-                else:
-                    # Unresolved: source document not found
-                    if source_id not in self._unresolved_provenance:
-                        self._unresolved_provenance[source_id] = set()
-                    self._unresolved_provenance[source_id].add(doc_id)
-
-        resolved_count = sum(len(v) for v in self._source_to_derived.values())
-        unresolved_count = sum(len(v) for v in self._unresolved_provenance.values())
-        if resolved_count or unresolved_count:
-            logger.info(
-                "Provenance scan: %d resolved references, %d unresolved references",
-                resolved_count,
-                unresolved_count,
-            )
-
-        # Report collisions deterministically (sorted by normalized URL).
-        if collisions:
-            collisions.sort(key=lambda t: t[0])
-            self.duplicate_url_count = len(collisions)
-            for norm_url, first_id, dup_id in collisions:
-                logger.warning(
-                    "Duplicate source_url at startup: %s owned by %s, duplicate in %s (skipped)",
-                    norm_url,
-                    first_id,
-                    dup_id,
-                )
+                        )
+                except Exception as e:
+                    logger.warning("Skipping invalid file %s: %s", md_file, e)
+        self._index.rebuild(scanned)
 
     def _resolve_safe_path(self, path: Path) -> tuple[Path, Path]:
         """Resolve a path under knowledge root and prevent traversal."""
@@ -670,7 +389,7 @@ class KnowledgeManager:
                     )
 
                 # Check dedup map
-                existing_id = self._source_url_to_id.get(norm_url)
+                existing_id = self._index.id_by_source_url(norm_url)
                 if existing_id is not None:
                     try:
                         existing_doc, _ = await self.read(id=existing_id)
@@ -691,7 +410,7 @@ class KnowledgeManager:
                         )
                     except FileNotFoundError:
                         # Stale map entry; allow create
-                        del self._source_url_to_id[norm_url]
+                        self._index.remove_source_url(norm_url, existing_id)
 
             # Validate and normalize derived_from_ids
             normalized_provenance: list[str] = []
@@ -779,7 +498,7 @@ class KnowledgeManager:
             )
 
             # Check for slug collision before writing anything
-            existing_slug_id = self._slug_to_id.get(slug)
+            existing_slug_id = self._index.id_by_slug(slug)
             if existing_slug_id is not None and existing_slug_id != doc_id:
                 raise SlugCollisionError(slug, existing_slug_id)
 
@@ -796,7 +515,7 @@ class KnowledgeManager:
             # conflicts get their own machine-readable code with the existing
             # doc id carried in `path_collision_existing_id` (mirrors how
             # `slug_collision_existing_id` works at the intake layer).
-            existing_path_id = self._path_to_id.get(file_path)
+            existing_path_id = self._index.id_by_relpath(file_path)
             if existing_path_id is not None and existing_path_id != doc_id:
                 return WriteResult(
                     status="path_collision",
@@ -810,65 +529,17 @@ class KnowledgeManager:
             full_path.parent.mkdir(parents=True, exist_ok=True)
             _atomic_write(full_path, encode(doc))
 
-            # Update indices
-            self._id_to_path[doc_id] = file_path
-            self._path_to_id[file_path] = doc_id
-            self._slug_to_id[slug] = doc_id
-            if norm_url is not None:
-                self._source_url_to_id[norm_url] = doc_id
-
-            # Update provenance indexes
-            warnings: list[str] = []
-            self._doc_to_sources[doc_id] = normalized_provenance
-            self._id_to_title[doc_id] = title
-            for source_id in normalized_provenance:
-                if source_id in self._id_to_path:
-                    # Resolved: source document exists
-                    if source_id not in self._source_to_derived:
-                        self._source_to_derived[source_id] = set()
-                    self._source_to_derived[source_id].add(doc_id)
-                else:
-                    # Unresolved: source document not found
-                    if source_id not in self._unresolved_provenance:
-                        self._unresolved_provenance[source_id] = set()
-                    self._unresolved_provenance[source_id].add(doc_id)
-                    logger.warning(
-                        "Provenance resolution failed: source_id=%s dependent_doc_id=%s",
-                        source_id,
-                        doc_id,
-                    )
-                    warnings.append(f"derived_from_ids contains missing document: {source_id}")
-
-            # Auto-resolve: check if any existing docs had unresolved refs to this new doc
-            if doc_id in self._unresolved_provenance:
-                resolved_docs = self._unresolved_provenance.pop(doc_id)
-                if doc_id not in self._source_to_derived:
-                    self._source_to_derived[doc_id] = set()
-                self._source_to_derived[doc_id].update(resolved_docs)
-
-            # Resolve namespace: explicit override if set, otherwise derive
-            # from path (matches apply_lcma_defaults at read time).
-            cached_namespace = metadata.namespace or derive_namespace(file_path)
-
-            cached = _CachedMeta(
+            # Register across every derived index (id/path/slug/url maps,
+            # provenance graph, metadata cache). Warnings name any source that
+            # does not yet exist; the note still records the dangling reference.
+            cached = CachedMeta.from_metadata(metadata, file_path, seq=self._index.next_seq())
+            warnings = self._index.add_document(
+                doc_id,
+                cached,
                 title=title,
-                author=metadata.author,
-                tags=list(metadata.tags),
-                updated_at=metadata.updated_at,
-                path=file_path,
-                namespace=cached_namespace,
-                expires_at=metadata.expires_at,
-                access_scope=metadata.access_scope,
-                source=metadata.source,
-                note_type=metadata.note_type,
-                status=metadata.status,
-                source_url=metadata.source_url,
-                entities=list(metadata.entities),
-                extra=dict(metadata.extra),
-                seq=self._next_seq(),
+                norm_url=norm_url,
+                sources=normalized_provenance,
             )
-            self._meta_cache[doc_id] = cached
-            self._index_doc(doc_id, cached)
 
             logger.info(
                 "Document created: doc_id=%s title=%.60s agent=%s",
@@ -892,9 +563,9 @@ class KnowledgeManager:
         """
         lithos_metrics.knowledge_ops.add(1, {"op": "read"})
         if id:
-            if id not in self._id_to_path:
+            file_path = self._index.relpath_of(id)
+            if file_path is None:
                 raise FileNotFoundError(f"Document not found: {id}")
-            file_path = self._id_to_path[id]
         elif path:
             file_path = Path(path)
             if not file_path.suffix:
@@ -920,30 +591,11 @@ class KnowledgeManager:
         # Only overlay when the index has a non-empty list; an empty index
         # entry means the doc was created without provenance, so the on-disk
         # frontmatter (which may have been edited externally) takes precedence.
-        indexed_sources = self._doc_to_sources.get(doc.metadata.id)
+        indexed_sources = self._index.doc_sources(doc.metadata.id)
         if indexed_sources:
             doc.metadata.derived_from_ids = indexed_sources
 
         return doc, truncated
-
-    def _remove_provenance_entries(self, doc_id: str) -> None:
-        """Remove a document's provenance entries from reverse indexes.
-
-        Cleans up _source_to_derived and _unresolved_provenance for the given doc_id
-        based on its current _doc_to_sources entries.
-        """
-        old_sources = self._doc_to_sources.get(doc_id, [])
-        for source_id in old_sources:
-            # Remove from resolved index
-            if source_id in self._source_to_derived:
-                self._source_to_derived[source_id].discard(doc_id)
-                if not self._source_to_derived[source_id]:
-                    del self._source_to_derived[source_id]
-            # Remove from unresolved index
-            if source_id in self._unresolved_provenance:
-                self._unresolved_provenance[source_id].discard(doc_id)
-                if not self._unresolved_provenance[source_id]:
-                    del self._unresolved_provenance[source_id]
 
     @traced("lithos.knowledge.update")
     @timed_write("update")
@@ -1071,7 +723,7 @@ class KnowledgeManager:
             if title is not None:
                 new_slug = slugify(title)
                 if new_slug != old_slug:
-                    existing_owner = self._slug_to_id.get(new_slug)
+                    existing_owner = self._index.id_by_slug(new_slug)
                     if existing_owner is not None and existing_owner != id:
                         raise SlugCollisionError(new_slug, existing_owner)
 
@@ -1082,8 +734,7 @@ class KnowledgeManager:
                     if old_source_url:
                         try:
                             old_norm = normalize_url(old_source_url)
-                            if self._source_url_to_id.get(old_norm) == id:
-                                del self._source_url_to_id[old_norm]
+                            self._index.remove_source_url(old_norm, id)
                         except ValueError:
                             pass
                     doc.metadata.source_url = None
@@ -1097,7 +748,7 @@ class KnowledgeManager:
                             message=str(e),
                         )
 
-                    existing_owner = self._source_url_to_id.get(new_norm)
+                    existing_owner = self._index.id_by_source_url(new_norm)
                     if existing_owner is not None and existing_owner != id:
                         try:
                             existing_doc, _ = await self.read(id=existing_owner)
@@ -1117,28 +768,27 @@ class KnowledgeManager:
                                 message=f"URL already exists in document '{existing_doc.title}'",
                             )
                         except FileNotFoundError:
-                            del self._source_url_to_id[new_norm]
+                            self._index.remove_source_url(new_norm, existing_owner)
 
                     # Remove old mapping if URL changed
                     if old_source_url:
                         try:
                             old_norm = normalize_url(old_source_url)
-                            if old_norm != new_norm and self._source_url_to_id.get(old_norm) == id:
-                                del self._source_url_to_id[old_norm]
+                            if old_norm != new_norm:
+                                self._index.remove_source_url(old_norm, id)
                         except ValueError:
                             pass
 
                     doc.metadata.source_url = new_norm
-                    self._source_url_to_id[new_norm] = id
+                    self._index.set_source_url(new_norm, id)
 
             # Handle derived_from_ids update
             warnings: list[str] = []
             if not isinstance(derived_from_ids, _UnsetType):
                 if derived_from_ids is None or derived_from_ids == []:
                     # Clear provenance
-                    self._remove_provenance_entries(id)
                     doc.metadata.derived_from_ids = []
-                    self._doc_to_sources[id] = []
+                    self._index.replace_provenance(id, [])
                 else:
                     # Replace with new list — validate first
                     try:
@@ -1149,29 +799,8 @@ class KnowledgeManager:
                             message=str(e),
                         )
 
-                    # Remove old provenance entries
-                    self._remove_provenance_entries(id)
-
-                    # Add new entries
                     doc.metadata.derived_from_ids = normalized
-                    self._doc_to_sources[id] = normalized
-                    for source_id in normalized:
-                        if source_id in self._id_to_path:
-                            if source_id not in self._source_to_derived:
-                                self._source_to_derived[source_id] = set()
-                            self._source_to_derived[source_id].add(id)
-                        else:
-                            if source_id not in self._unresolved_provenance:
-                                self._unresolved_provenance[source_id] = set()
-                            self._unresolved_provenance[source_id].add(id)
-                            logger.warning(
-                                "Provenance resolution failed: source_id=%s dependent_doc_id=%s",
-                                source_id,
-                                id,
-                            )
-                            warnings.append(
-                                f"derived_from_ids contains missing document: {source_id}"
-                            )
+                    warnings = self._index.replace_provenance(id, normalized)
 
             # Handle expires_at update
             if not isinstance(expires_at, _UnsetType):
@@ -1250,40 +879,21 @@ class KnowledgeManager:
             _atomic_write(full_path, encode(doc))
 
             if new_slug != old_slug:
-                if self._slug_to_id.get(old_slug) == id:
-                    del self._slug_to_id[old_slug]
-                self._slug_to_id[new_slug] = id
+                self._index.reroute_slug(old_slug, new_slug, id)
 
             # Update _id_to_title if title changed
             if title is not None:
-                self._id_to_title[id] = title
+                self._index.set_title(id, title)
 
-            # Update metadata cache + inverted index. Deindex the previous entry
-            # first, then index the new one; preserve the insertion ordinal so
-            # list ordering/pagination is unchanged by an update.
-            cached_namespace = doc.metadata.namespace or derive_namespace(doc.path)
-            old_cached = self._meta_cache.get(id)
-            if old_cached is not None:
-                self._deindex_doc(id, old_cached)
-            cached = _CachedMeta(
-                title=doc.metadata.title,
-                author=doc.metadata.author,
-                tags=list(doc.metadata.tags),
-                updated_at=doc.metadata.updated_at,
-                path=doc.path,
-                namespace=cached_namespace,
-                expires_at=doc.metadata.expires_at,
-                access_scope=doc.metadata.access_scope,
-                source=doc.metadata.source,
-                note_type=doc.metadata.note_type,
-                status=doc.metadata.status,
-                source_url=doc.metadata.source_url,
-                entities=list(doc.metadata.entities),
-                extra=dict(doc.metadata.extra),
-                seq=old_cached.seq if old_cached is not None else self._next_seq(),
+            # Update metadata cache + inverted index. Preserve the insertion
+            # ordinal so list ordering/pagination is unchanged by an update.
+            old_cached = self._index.get_cached_meta(id)
+            cached = CachedMeta.from_metadata(
+                doc.metadata,
+                doc.path,
+                seq=old_cached.seq if old_cached is not None else self._index.next_seq(),
             )
-            self._meta_cache[id] = cached
-            self._index_doc(id, cached)
+            self._index.reindex_document(id, cached)
 
             if logger.isEnabledFor(logging.INFO):
                 changed: list[str] = []
@@ -1310,7 +920,7 @@ class KnowledgeManager:
         """
         async with self._write_lock:
             lithos_metrics.knowledge_ops.add(1, {"op": "delete"})
-            if id not in self._id_to_path:
+            if not self._index.has_document(id):
                 return False, ""
 
             # Read doc to get source_url before deleting
@@ -1319,39 +929,22 @@ class KnowledgeManager:
                 if doc.metadata.source_url:
                     try:
                         norm = normalize_url(doc.metadata.source_url)
-                        if self._source_url_to_id.get(norm) == id:
-                            del self._source_url_to_id[norm]
+                        self._index.remove_source_url(norm, id)
                     except ValueError:
                         pass
             except FileNotFoundError:
                 pass
 
-            file_path = self._id_to_path[id]
+            file_path = self._index.relpath_of(id)
+            assert file_path is not None  # has_document guaranteed it above
             _safe_path, full_path = self._resolve_safe_path(file_path)
 
             if full_path.exists():
                 full_path.unlink()
 
-            # Update indices
-            old_path = self._id_to_path.pop(id)
-            self._path_to_id.pop(old_path, None)
-            # Remove from slug index
-            self._slug_to_id = {k: v for k, v in self._slug_to_id.items() if v != id}
-
-            # Provenance cleanup
-            # 1. Remove this doc as a "derived" doc from reverse indexes
-            self._remove_provenance_entries(id)
-            # 2. Remove forward index entry
-            self._doc_to_sources.pop(id, None)
-            # 3. If this doc was a source for others, move those to unresolved
-            derived_docs = self._source_to_derived.pop(id, set())
-            if derived_docs:
-                self._unresolved_provenance[id] = derived_docs
-            # 4. Remove from title and metadata caches + inverted index
-            self._id_to_title.pop(id, None)
-            removed = self._meta_cache.pop(id, None)
-            if removed is not None:
-                self._deindex_doc(id, removed)
+            # Drop the document from every derived index (maps, provenance graph
+            # — re-orphaning anything that derived from it — and metadata cache).
+            self._index.remove_document(id)
 
             logger.info("Document deleted: doc_id=%s path=%s", id, file_path)
             return True, str(file_path)
@@ -1390,7 +983,7 @@ class KnowledgeManager:
         unfiltered / prefix-only / since-only listings).
         """
         normalized_since = normalize_datetime(since) if since else None
-        candidate_ids = self._candidate_ids(
+        candidate_ids = self._index.candidate_ids(
             tags=tags,
             author=author,
             metadata_match=metadata_match,
@@ -1401,7 +994,7 @@ class KnowledgeManager:
         if candidate_ids is None:
             # No equality filter — full scan (existing behaviour + ordering).
             matching_ids: list[str] = []
-            for doc_id, cached in self._meta_cache.items():
+            for doc_id, cached in self._index.iter_cached_meta():
                 if exclude_status and cached.status in exclude_status:
                     continue
                 if path_prefix and not str(cached.path).startswith(path_prefix):
@@ -1411,11 +1004,11 @@ class KnowledgeManager:
                 matching_ids.append(doc_id)
         else:
             # Index path — refine the (small) candidate set, then restore the
-            # _meta_cache insertion order via the stored seq for stable paging.
-            refined: list[_CachedMeta] = []
+            # cache insertion order via the stored seq for stable paging.
+            refined: list[CachedMeta] = []
             refined_ids: list[str] = []
             for doc_id in candidate_ids:
-                cached = self._meta_cache.get(doc_id)
+                cached = self._index.get_cached_meta(doc_id)
                 if cached is None:
                     continue
                 if path_prefix and not str(cached.path).startswith(path_prefix):
@@ -1463,11 +1056,7 @@ class KnowledgeManager:
         Used by the content-query path of ``lithos_list`` to intersect with
         full-text hits without scanning the cache.
         """
-        if not metadata_match:
-            return None
-        return self._candidate_ids(
-            tags=None, author=None, metadata_match=metadata_match, exclude_status=None
-        )
+        return self._index.metadata_candidate_ids(metadata_match)
 
     def entities_candidate_ids(self, entities: list[str] | None) -> set[str] | None:
         """Public wrapper: candidate ids for an ``entities`` filter (#316).
@@ -1477,19 +1066,11 @@ class KnowledgeManager:
         index-based). Used by ``lithos_search`` to post-filter hits without
         scanning the cache.
         """
-        if not entities:
-            return None
-        return self._candidate_ids(
-            tags=None, author=None, metadata_match=None, exclude_status=None, entities=entities
-        )
+        return self._index.entities_candidate_ids(entities)
 
     async def get_all_tags(self) -> dict[str, int]:
         """Get all tags with document counts (from in-memory cache)."""
-        tag_counts: dict[str, int] = {}
-        for cached in self._meta_cache.values():
-            for tag in cached.tags:
-                tag_counts[tag] = tag_counts.get(tag, 0) + 1
-        return tag_counts
+        return self._index.all_tags()
 
     async def find_by_source_url(self, url: str) -> KnowledgeDocument | None:
         """Look up a document by source URL (internal only, not MCP-exposed).
@@ -1502,7 +1083,7 @@ class KnowledgeManager:
         except ValueError:
             return None
 
-        doc_id = self._source_url_to_id.get(norm)
+        doc_id = self._index.id_by_source_url(norm)
         if doc_id is None:
             return None
 
@@ -1539,38 +1120,19 @@ class KnowledgeManager:
         title = doc.title
 
         doc_id = doc.id
-        is_new = doc_id not in self._id_to_path
+        is_new = not self._index.has_document(doc_id)
 
-        # Update core indexes
-        if not is_new:
-            old_path = self._id_to_path.get(doc_id)
-            if old_path is not None:
-                self._path_to_id.pop(old_path, None)
-        self._id_to_path[doc_id] = file_path
-        self._path_to_id[file_path] = doc_id
-        old_slug = None
-        if not is_new:
-            # Find the old slug for this doc to clean it up
-            for s, sid in self._slug_to_id.items():
-                if sid == doc_id:
-                    old_slug = s
-                    break
-        new_slug = slugify(title)
-        if old_slug and old_slug != new_slug and self._slug_to_id.get(old_slug) == doc_id:
-            del self._slug_to_id[old_slug]
-        self._slug_to_id[new_slug] = doc_id
+        # Update the path and slug maps (the on-disk path/title may have moved).
+        self._index.set_path(doc_id, file_path)
+        self._index.reroute_slug_for(doc_id, slugify(title))
 
-        # Update source_url index
+        # Update source_url index (first-owner-wins; clear this doc's old urls).
         raw_url = metadata.source_url
         if raw_url:
             try:
                 norm = normalize_url(raw_url)
-                # Remove any old mapping for this doc
-                old_urls_to_remove = [k for k, v in self._source_url_to_id.items() if v == doc_id]
-                for k in old_urls_to_remove:
-                    del self._source_url_to_id[k]
-                # Check if another doc already owns this URL (first-owner-wins)
-                existing_owner = self._source_url_to_id.get(norm)
+                self._index.clear_source_urls_for(doc_id)
+                existing_owner = self._index.id_by_source_url(norm)
                 if existing_owner is not None and existing_owner != doc_id:
                     logger.warning(
                         "source_url collision in sync_from_disk: %s owned by %s, "
@@ -1580,91 +1142,40 @@ class KnowledgeManager:
                         doc_id,
                     )
                 else:
-                    self._source_url_to_id[norm] = doc_id
+                    self._index.set_source_url(norm, doc_id)
             except ValueError:
                 pass
         else:
-            # Clear any old source_url mapping for this doc
-            old_urls_to_remove = [k for k, v in self._source_url_to_id.items() if v == doc_id]
-            for k in old_urls_to_remove:
-                del self._source_url_to_id[k]
+            self._index.clear_source_urls_for(doc_id)
 
-        # Update _id_to_title
-        self._id_to_title[doc_id] = title
+        self._index.set_title(doc_id, title)
 
-        # Update provenance indexes
+        # Update provenance (diff for a modified note; classify + auto-resolve
+        # for a newly-seen one). Sync is silent — no missing-source warnings.
         new_sources = normalize_derived_from_ids_lenient(
             metadata.derived_from_ids or [], self_id=doc_id
         )
+        self._index.sync_provenance(doc_id, new_sources, is_new=is_new)
 
-        if not is_new:
-            # Modified file: diff against current state
-            old_sources = self._doc_to_sources.get(doc_id, [])
-            if old_sources != new_sources:
-                # Remove old reverse index entries
-                self._remove_provenance_entries(doc_id)
-                # Add new entries
-                self._doc_to_sources[doc_id] = list(new_sources)
-                for source_id in new_sources:
-                    if source_id in self._id_to_path:
-                        if source_id not in self._source_to_derived:
-                            self._source_to_derived[source_id] = set()
-                        self._source_to_derived[source_id].add(doc_id)
-                    else:
-                        if source_id not in self._unresolved_provenance:
-                            self._unresolved_provenance[source_id] = set()
-                        self._unresolved_provenance[source_id].add(doc_id)
-        else:
-            # New file: add provenance entries
-            self._doc_to_sources[doc_id] = list(new_sources)
-            for source_id in new_sources:
-                if source_id in self._id_to_path:
-                    if source_id not in self._source_to_derived:
-                        self._source_to_derived[source_id] = set()
-                    self._source_to_derived[source_id].add(doc_id)
-                else:
-                    if source_id not in self._unresolved_provenance:
-                        self._unresolved_provenance[source_id] = set()
-                    self._unresolved_provenance[source_id].add(doc_id)
-
-            # Auto-resolve: check if any existing docs had unresolved refs to this new doc
-            if doc_id in self._unresolved_provenance:
-                resolved_docs = self._unresolved_provenance.pop(doc_id)
-                if doc_id not in self._source_to_derived:
-                    self._source_to_derived[doc_id] = set()
-                self._source_to_derived[doc_id].update(resolved_docs)
-
-        # Update metadata cache + inverted index (deindex prior entry first;
-        # preserve insertion ordinal so list ordering stays stable).
-        cached_namespace = metadata.namespace or derive_namespace(file_path)
-        old_cached = self._meta_cache.get(doc_id)
-        if old_cached is not None:
-            self._deindex_doc(doc_id, old_cached)
-        cached = _CachedMeta(
-            title=title,
-            author=metadata.author,
-            tags=list(metadata.tags),
-            updated_at=metadata.updated_at,
-            path=file_path,
-            namespace=cached_namespace,
-            expires_at=metadata.expires_at,
-            access_scope=metadata.access_scope,
-            source=metadata.source,
-            note_type=metadata.note_type,
-            status=metadata.status,
-            source_url=metadata.source_url,
-            entities=list(metadata.entities),
-            extra=dict(metadata.extra),
-            seq=old_cached.seq if old_cached is not None else self._next_seq(),
+        # Update metadata cache + inverted index, preserving the insertion
+        # ordinal so list ordering stays stable.
+        old_cached = self._index.get_cached_meta(doc_id)
+        cached = CachedMeta.from_metadata(
+            metadata,
+            file_path,
+            seq=old_cached.seq if old_cached is not None else self._index.next_seq(),
         )
-        self._meta_cache[doc_id] = cached
-        self._index_doc(doc_id, cached)
+        self._index.reindex_document(doc_id, cached)
 
         return doc
 
+    # ==================== Derived-index read accessors ====================
+    # These delegate to the CorpusIndex so callers keep a stable manager-level
+    # API while the projection owns the state (issue #171/#264).
+
     def get_id_by_slug(self, slug: str) -> str | None:
         """Get document ID by slug."""
-        return self._slug_to_id.get(slug)
+        return self._index.id_by_slug(slug)
 
     def get_id_by_path(self, path: str | Path) -> str | None:
         """Get document ID by relative/absolute path (O(1) via reverse map)."""
@@ -1679,94 +1190,74 @@ class KnowledgeManager:
         if not candidate.suffix:
             candidate = candidate.with_suffix(".md")
 
-        return self._path_to_id.get(candidate)
+        return self._index.id_by_relpath(candidate)
 
     def get_all_slugs(self) -> dict[str, str]:
         """Get mapping of all slugs to IDs."""
-        return dict(self._slug_to_id)
+        return self._index.all_slugs()
 
     # ==================== Public Provenance Accessors ====================
 
     def get_doc_sources(self, doc_id: str) -> list[str]:
         """Get the source IDs this document derives from."""
-        return self._doc_to_sources.get(doc_id, [])
+        return self._index.doc_sources(doc_id)
 
     def iter_doc_sources(self) -> Iterable[tuple[str, list[str]]]:
         """Iterate over ``(doc_id, source_ids)`` pairs for every known document.
 
-        Snapshots the underlying ``_doc_to_sources`` index so callers can
-        iterate safely even if the cache is mutated concurrently (rare, but
-        possible via concurrent writes / file-watcher projections). Returned
-        lists are fresh copies — mutations to them never leak back into the
-        manager.
-
-        This is the public bulk-read counterpart to :meth:`get_doc_sources`
-        (issue #264) so callers don't reach into ``_doc_to_sources`` directly.
-        Now used only by provenance conformance tests to cross-check KM's
-        in-memory sources against the projected edges — the former full-sweep
-        helper that consumed it moved into ``ProvenanceProjection`` (task
-        681ac952 PR1c).
+        Snapshots the underlying index so callers can iterate safely even if the
+        cache is mutated concurrently; returned lists are fresh copies. The
+        public bulk-read counterpart to :meth:`get_doc_sources` (issue #264).
         """
-        return [(doc_id, list(sources)) for doc_id, sources in self._doc_to_sources.items()]
+        return self._index.iter_doc_sources()
 
     def get_derived_docs(self, doc_id: str) -> set[str]:
         """Get IDs of documents derived from this document."""
-        return self._source_to_derived.get(doc_id, set())
+        return self._index.derived_docs(doc_id)
 
     def get_unresolved_sources(self, doc_id: str) -> list[str]:
         """Get unresolved source IDs for a document."""
-        sources = self._doc_to_sources.get(doc_id, [])
-        return [
-            sid
-            for sid in sources
-            if sid in self._unresolved_provenance or sid not in self._id_to_path
-        ]
+        return self._index.unresolved_sources(doc_id)
 
     def get_title_by_id(self, doc_id: str) -> str:
         """Get document title by ID, returning empty string if unknown."""
-        return self._id_to_title.get(doc_id, "")
+        return self._index.title_by_id(doc_id)
 
     def has_document(self, doc_id: str) -> bool:
         """Check whether a document ID exists."""
-        return doc_id in self._id_to_path
+        return self._index.has_document(doc_id)
 
-    def get_cached_meta(self, node_id: str) -> _CachedMeta | None:
+    def iter_doc_ids(self) -> Iterable[str]:
+        """Snapshot every known document ID (for prefix/UUID resolution)."""
+        return self._index.iter_doc_ids()
+
+    def iter_source_urls(self) -> Iterable[tuple[str, str]]:
+        """Snapshot ``(normalized_source_url, doc_id)`` pairs."""
+        return self._index.iter_source_urls()
+
+    def get_cached_meta(self, node_id: str) -> CachedMeta | None:
         """Return cached metadata for a node, or ``None`` if unknown.
 
-        This is the public read accessor for the internal ``_meta_cache`` dict.
-        Callers outside ``KnowledgeManager`` — notably the LCMA scout, rerank,
-        reinforcement, and enrich paths, plus the MCP server's feedback and
-        node_stats handlers — should use this rather than touching
-        ``_meta_cache`` directly, so the cache's internal shape can evolve
-        without breaking every callsite. See #171.
+        The public read accessor for the derived metadata cache. Callers outside
+        ``KnowledgeManager`` — the LCMA scout, rerank, reinforcement, and enrich
+        paths, plus the MCP server's feedback and node_stats handlers — should
+        use this rather than the index directly (#171).
         """
-        return self._meta_cache.get(node_id)
+        return self._index.get_cached_meta(node_id)
 
-    def iter_cached_meta(self) -> Iterable[tuple[str, _CachedMeta]]:
-        """Iterate over ``(node_id, cached_meta)`` pairs.
-
-        Snapshots the view so the caller can iterate safely even if the
-        underlying cache is mutated during iteration (rare, but possible
-        via concurrent writes / file-watcher projections).
-        """
-        return list(self._meta_cache.items())
+    def iter_cached_meta(self) -> Iterable[tuple[str, CachedMeta]]:
+        """Iterate over ``(node_id, cached_meta)`` pairs (snapshot for safe iteration)."""
+        return self._index.iter_cached_meta()
 
     @property
     def document_count(self) -> int:
         """Synchronous count of known documents (from in-memory cache)."""
-        return len(self._meta_cache)
+        return self._index.document_count
 
     @property
     def stale_document_count(self) -> int:
         """Synchronous count of documents whose expires_at is set and in the past."""
-        now = datetime.now(UTC)
-        count = 0
-        for cached in self._meta_cache.values():
-            if cached.expires_at is not None:
-                exp = normalize_datetime(cached.expires_at)
-                if exp < now:
-                    count += 1
-        return count
+        return self._index.stale_document_count
 
     def rescan(self) -> None:
         """Public wrapper around _scan_existing() for index rebuilds."""

--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -274,7 +274,7 @@ async def scout_exact_alias(
 
     # 2. UUID-prefix matching
     query_lower = query.lower().strip()
-    for doc_id in knowledge._id_to_path:
+    for doc_id in knowledge.iter_doc_ids():
         if doc_id.lower().startswith(query_lower) and doc_id not in found_ids:
             found_ids.append(doc_id)
 
@@ -759,7 +759,7 @@ async def scout_source_url(
 ) -> list[Candidate]:
     """Find notes from the same URL domain as seed notes."""
     seed_set = set(seed_ids)
-    url_map = knowledge._source_url_to_id
+    url_map = dict(knowledge.iter_source_urls())
 
     # 1. Collect domains from seed notes using the in-memory metadata cache
     #    (avoids synchronous disk I/O from frontmatter parsing). This handles

--- a/tests/test_coactivation.py
+++ b/tests/test_coactivation.py
@@ -104,7 +104,7 @@ def seeded_km(seeded_config: LithosConfig) -> KnowledgeManager:
 @pytest.fixture
 def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> KnowledgeGraph:
     graph = KnowledgeGraph(seeded_config)
-    for doc_id, rel_path in seeded_km._id_to_path.items():
+    for doc_id, rel_path in seeded_km._index._id_to_path.items():
         full_path = seeded_config.storage.knowledge_path / rel_path
         if full_path.exists():
             post = fm.load(str(full_path))

--- a/tests/test_file_watcher_events.py
+++ b/tests/test_file_watcher_events.py
@@ -21,7 +21,7 @@ class TestFileWatcherEventEmission:
         """A brand-new .md file appearing on disk triggers note.created with agent=\"watcher\".
 
         Pins the create-side attribution: an externally-written file that
-        is not yet in ``KnowledgeManager._id_to_path`` produces
+        is not yet in ``KnowledgeManager._index._id_to_path`` produces
         ``NOTE_CREATED`` (not ``NOTE_UPDATED``), and the event carries the
         watcher sentinel.
 
@@ -202,7 +202,7 @@ class TestFileWatcherEventEmission:
 
         # …while KnowledgeManager already reports the id as removed.
         assert server.knowledge.get_id_by_path(doc.path) is None
-        assert doc.id not in server.knowledge._meta_cache
+        assert doc.id not in server.knowledge._index._meta_cache
 
     async def test_non_markdown_file_emits_no_event(self, server: LithosServer) -> None:
         """Non-markdown files produce no event."""

--- a/tests/test_integration_conformance.py
+++ b/tests/test_integration_conformance.py
@@ -275,7 +275,7 @@ class TestMCPToolContracts:
         # Pre-delete: verify presence in all subsystems.
         assert server.graph.has_node(doc_id)
         assert server.knowledge.get_id_by_slug("cascade-delete-target") == doc_id
-        assert doc_id in server.knowledge._id_to_path
+        assert doc_id in server.knowledge._index._id_to_path
 
         await call_tool(server, "lithos_delete", {"id": doc_id, "agent": "test-agent"})
 
@@ -305,7 +305,7 @@ class TestMCPToolContracts:
         assert server.knowledge.get_id_by_slug("cascade-delete-target") is None
 
         # Path index: absent.
-        assert doc_id not in server.knowledge._id_to_path
+        assert doc_id not in server.knowledge._index._id_to_path
 
 
 class TestRestartPersistence:
@@ -2732,8 +2732,8 @@ class TestSyncFromDisk:
         # Verify provenance indexes are updated
         assert server.knowledge.has_document(doc_id)
         assert server.knowledge.get_doc_sources(doc_id) == [src_id]
-        assert doc_id in server.knowledge._source_to_derived.get(src_id, set())
-        assert server.knowledge._id_to_title[doc_id] == "External Derived"
+        assert doc_id in server.knowledge._index._source_to_derived.get(src_id, set())
+        assert server.knowledge._index._id_to_title[doc_id] == "External Derived"
 
     @pytest.mark.asyncio
     async def test_external_modify_derived_from_ids(self, server: LithosServer):
@@ -2764,7 +2764,7 @@ class TestSyncFromDisk:
 
         # Verify initial provenance
         assert server.knowledge.get_doc_sources(derived_id) == [s1["id"]]
-        assert derived_id in server.knowledge._source_to_derived.get(s1["id"], set())
+        assert derived_id in server.knowledge._index._source_to_derived.get(s1["id"], set())
 
         # Externally modify the file's derived_from_ids on disk
         knowledge_path = server.config.storage.knowledge_path
@@ -2778,8 +2778,8 @@ class TestSyncFromDisk:
 
         # Verify indexes updated: s1 removed, s2 added
         assert server.knowledge.get_doc_sources(derived_id) == [s2["id"]]
-        assert derived_id not in server.knowledge._source_to_derived.get(s1["id"], set())
-        assert derived_id in server.knowledge._source_to_derived.get(s2["id"], set())
+        assert derived_id not in server.knowledge._index._source_to_derived.get(s1["id"], set())
+        assert derived_id in server.knowledge._index._source_to_derived.get(s2["id"], set())
 
     @pytest.mark.asyncio
     async def test_external_title_change_updates_id_to_title(self, server: LithosServer):
@@ -2796,7 +2796,7 @@ class TestSyncFromDisk:
         doc_id = doc["id"]
         doc_path_str = doc["path"]
 
-        assert server.knowledge._id_to_title[doc_id] == "Original Title"
+        assert server.knowledge._index._id_to_title[doc_id] == "Original Title"
 
         # Externally modify the title on disk
         knowledge_path = server.config.storage.knowledge_path
@@ -2809,7 +2809,7 @@ class TestSyncFromDisk:
 
         await server.watch_intake.upsert_from_disk(file_path)
 
-        assert server.knowledge._id_to_title[doc_id] == "Changed Title"
+        assert server.knowledge._index._id_to_title[doc_id] == "Changed Title"
 
     @pytest.mark.asyncio
     async def test_external_delete_source_marks_unresolved(self, server: LithosServer):
@@ -2836,7 +2836,7 @@ class TestSyncFromDisk:
         derived_id = derived["id"]
 
         # Verify initial state
-        assert derived_id in server.knowledge._source_to_derived.get(src_id, set())
+        assert derived_id in server.knowledge._index._source_to_derived.get(src_id, set())
 
         # Externally delete the source file
         knowledge_path = server.config.storage.knowledge_path
@@ -2846,12 +2846,12 @@ class TestSyncFromDisk:
         await server.watch_intake.delete_from_disk(src_file)
 
         # Source should be removed from indexes
-        assert src_id not in server.knowledge._id_to_path
-        assert src_id not in server.knowledge._id_to_title
+        assert src_id not in server.knowledge._index._id_to_path
+        assert src_id not in server.knowledge._index._id_to_title
 
         # Derived doc's provenance should now be unresolved
-        assert derived_id in server.knowledge._unresolved_provenance.get(src_id, set())
-        assert src_id not in server.knowledge._source_to_derived
+        assert derived_id in server.knowledge._index._unresolved_provenance.get(src_id, set())
+        assert src_id not in server.knowledge._index._source_to_derived
 
     @pytest.mark.asyncio
     async def test_sync_from_disk_auto_resolves_unresolved(self, server: LithosServer):
@@ -2873,7 +2873,9 @@ class TestSyncFromDisk:
         derived_id = derived["id"]
 
         # Verify unresolved
-        assert derived_id in server.knowledge._unresolved_provenance.get(future_source_id, set())
+        assert derived_id in server.knowledge._index._unresolved_provenance.get(
+            future_source_id, set()
+        )
 
         # Now externally create the source file with the matching ID
         post = frontmatter.Post(
@@ -2897,8 +2899,8 @@ class TestSyncFromDisk:
         await server.watch_intake.upsert_from_disk(file_path)
 
         # Unresolved should now be resolved
-        assert future_source_id not in server.knowledge._unresolved_provenance
-        assert derived_id in server.knowledge._source_to_derived.get(future_source_id, set())
+        assert future_source_id not in server.knowledge._index._unresolved_provenance
+        assert derived_id in server.knowledge._index._source_to_derived.get(future_source_id, set())
 
     @pytest.mark.asyncio
     async def test_sync_from_disk_error_does_not_crash_watcher(self, server: LithosServer):
@@ -2960,19 +2962,19 @@ class TestRebuildIndicesProvenance:
         # Verify provenance indexes before rebuild
         mgr = server.knowledge
         assert mgr.get_doc_sources(derived_id) == [source_id]
-        assert derived_id in mgr._source_to_derived.get(source_id, set())
-        assert mgr._id_to_title.get(source_id) == "Rebuild Source"
-        assert mgr._id_to_title.get(derived_id) == "Rebuild Derived"
+        assert derived_id in mgr._index._source_to_derived.get(source_id, set())
+        assert mgr._index._id_to_title.get(source_id) == "Rebuild Source"
+        assert mgr._index._id_to_title.get(derived_id) == "Rebuild Derived"
 
         # Rebuild indices
         await server._rebuild_indices()
 
         # Verify provenance indexes are restored after rebuild
         assert mgr.get_doc_sources(derived_id) == [source_id]
-        assert derived_id in mgr._source_to_derived.get(source_id, set())
-        assert mgr._id_to_title.get(source_id) == "Rebuild Source"
-        assert mgr._id_to_title.get(derived_id) == "Rebuild Derived"
-        assert not mgr._unresolved_provenance  # no unresolved refs
+        assert derived_id in mgr._index._source_to_derived.get(source_id, set())
+        assert mgr._index._id_to_title.get(source_id) == "Rebuild Source"
+        assert mgr._index._id_to_title.get(derived_id) == "Rebuild Derived"
+        assert not mgr._index._unresolved_provenance  # no unresolved refs
 
     async def test_rebuild_indices_detects_unresolved_provenance(self, server: LithosServer):
         """After _rebuild_indices(), unresolved references are correctly detected."""
@@ -2998,8 +3000,8 @@ class TestRebuildIndicesProvenance:
         # Verify unresolved provenance is detected
         mgr = server.knowledge
         assert mgr.get_doc_sources(doc_id) == [missing_id]
-        assert doc_id in mgr._unresolved_provenance.get(missing_id, set())
-        assert missing_id not in mgr._source_to_derived
+        assert doc_id in mgr._index._unresolved_provenance.get(missing_id, set())
+        assert missing_id not in mgr._index._source_to_derived
 
     async def test_rebuild_indices_clears_stale_provenance(self, server: LithosServer):
         """_rebuild_indices() clears stale provenance from a previous rebuild."""
@@ -3029,7 +3031,7 @@ class TestRebuildIndicesProvenance:
 
         # Delete the derived doc from disk (simulating external deletion)
         mgr = server.knowledge
-        derived_path = mgr._id_to_path[derived_id]
+        derived_path = mgr._index._id_to_path[derived_id]
         full_path = mgr.knowledge_path / derived_path
         full_path.unlink()
 
@@ -3038,8 +3040,8 @@ class TestRebuildIndicesProvenance:
 
         # The derived doc should no longer be in any indexes
         assert not mgr.has_document(derived_id)
-        assert derived_id not in mgr._source_to_derived.get(source_id, set())
-        assert derived_id not in mgr._id_to_title
+        assert derived_id not in mgr._index._source_to_derived.get(source_id, set())
+        assert derived_id not in mgr._index._id_to_title
 
 
 class TestRelatedProvenance:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1079,8 +1079,8 @@ class TestMetadataFiltering:
         """Efficiency proof: an equality-filtered list_all never iterates _meta_cache."""
         for i in range(10):
             await self._mk(knowledge_manager, f"D{i}", extra={"k": "v" if i == 0 else "w"})
-        counting = _CountingDict(knowledge_manager._meta_cache)
-        knowledge_manager._meta_cache = counting
+        counting = _CountingDict(knowledge_manager._index._meta_cache)
+        knowledge_manager._index._meta_cache = counting
 
         counting.iter_count = 0
         _, total = await knowledge_manager.list_all(metadata_match={"k": "v"})
@@ -1614,8 +1614,8 @@ class TestDedupMapAndLock:
 
     def test_manager_has_source_url_map(self, knowledge_manager: KnowledgeManager):
         """KnowledgeManager has _source_url_to_id dict."""
-        assert hasattr(knowledge_manager, "_source_url_to_id")
-        assert isinstance(knowledge_manager._source_url_to_id, dict)
+        assert hasattr(knowledge_manager._index, "_source_url_to_id")
+        assert isinstance(knowledge_manager._index._source_url_to_id, dict)
 
     def test_manager_has_write_lock(self, knowledge_manager: KnowledgeManager):
         """KnowledgeManager has _write_lock asyncio.Lock."""
@@ -1637,7 +1637,7 @@ class TestDedupMapAndLock:
         # Create a new manager that scans on init
         mgr2 = KnowledgeManager(test_config)
         norm = normalize_url("https://example.com/scanned")
-        assert norm in mgr2._source_url_to_id
+        assert norm in mgr2._index._source_url_to_id
 
     @pytest.mark.asyncio
     async def test_scan_normalizes_urls_on_load(self, test_config):
@@ -1652,7 +1652,7 @@ class TestDedupMapAndLock:
 
         mgr2 = KnowledgeManager(test_config)
         # Should be stored with normalized URL
-        assert "https://example.com/Page" in mgr2._source_url_to_id
+        assert "https://example.com/Page" in mgr2._index._source_url_to_id
 
     @pytest.mark.asyncio
     async def test_scan_skips_docs_without_source_url(self, test_config):
@@ -1665,7 +1665,7 @@ class TestDedupMapAndLock:
         )
 
         mgr2 = KnowledgeManager(test_config)
-        assert len(mgr2._source_url_to_id) == 0
+        assert len(mgr2._index._source_url_to_id) == 0
 
 
 class TestStartupDuplicateAudit:
@@ -1731,7 +1731,7 @@ class TestStartupDuplicateAudit:
         mgr2 = KnowledgeManager(test_config)
         norm = normalize_url("https://example.com/collision")
         # First-seen (sorted path) should win
-        assert mgr2._source_url_to_id[norm] == doc_a.id
+        assert mgr2._index._source_url_to_id[norm] == doc_a.id
 
     @pytest.mark.asyncio
     async def test_startup_does_not_fail_on_collisions(self, test_config):
@@ -1868,7 +1868,7 @@ class TestDedupOnCreate:
             source_url="https://example.com/mapped",
         )
         norm = normalize_url("https://example.com/mapped")
-        assert knowledge_manager._source_url_to_id[norm] == result.document.id
+        assert knowledge_manager._index._source_url_to_id[norm] == result.document.id
 
 
 class TestDedupOnUpdate:
@@ -1902,13 +1902,13 @@ class TestDedupOnUpdate:
             )
         ).document
         norm = normalize_url("https://example.com/clear")
-        assert norm in knowledge_manager._source_url_to_id
+        assert norm in knowledge_manager._index._source_url_to_id
 
         result = await knowledge_manager.update(id=doc.id, agent="editor", source_url=None)
         assert result.status == "updated"
         assert result.document is not None
         assert result.document.metadata.source_url is None
-        assert norm not in knowledge_manager._source_url_to_id
+        assert norm not in knowledge_manager._index._source_url_to_id
 
     @pytest.mark.asyncio
     async def test_self_update_same_url_succeeds(self, knowledge_manager: KnowledgeManager):
@@ -1966,7 +1966,7 @@ class TestDedupOnUpdate:
             )
         ).document
         old_norm = normalize_url("https://example.com/old")
-        assert old_norm in knowledge_manager._source_url_to_id
+        assert old_norm in knowledge_manager._index._source_url_to_id
 
         result = await knowledge_manager.update(
             id=doc.id, agent="editor", source_url="https://example.com/new"
@@ -1974,8 +1974,8 @@ class TestDedupOnUpdate:
         assert result.status == "updated"
         assert result.document is not None
         new_norm = normalize_url("https://example.com/new")
-        assert new_norm in knowledge_manager._source_url_to_id
-        assert old_norm not in knowledge_manager._source_url_to_id
+        assert new_norm in knowledge_manager._index._source_url_to_id
+        assert old_norm not in knowledge_manager._index._source_url_to_id
 
     @pytest.mark.asyncio
     async def test_invalid_url_on_update_returns_error(self, knowledge_manager: KnowledgeManager):
@@ -2353,10 +2353,10 @@ class TestDeleteRemovesUrl:
             )
         ).document
         norm = normalize_url("https://example.com/deletable")
-        assert norm in knowledge_manager._source_url_to_id
+        assert norm in knowledge_manager._index._source_url_to_id
 
         await knowledge_manager.delete(doc.id)  # return value unused
-        assert norm not in knowledge_manager._source_url_to_id
+        assert norm not in knowledge_manager._index._source_url_to_id
 
     @pytest.mark.asyncio
     async def test_delete_then_create_same_url(self, knowledge_manager: KnowledgeManager):
@@ -2578,9 +2578,9 @@ class TestProvenanceIndexes:
         """
         assert list(knowledge_manager.iter_doc_sources()) == []
         assert knowledge_manager.get_doc_sources("unknown-id") == []
-        assert isinstance(knowledge_manager._source_to_derived, dict)
-        assert isinstance(knowledge_manager._unresolved_provenance, dict)
-        assert isinstance(knowledge_manager._id_to_title, dict)
+        assert isinstance(knowledge_manager._index._source_to_derived, dict)
+        assert isinstance(knowledge_manager._index._unresolved_provenance, dict)
+        assert isinstance(knowledge_manager._index._id_to_title, dict)
 
     @pytest.mark.asyncio
     async def test_scan_builds_provenance_indexes(self, test_config):
@@ -2652,16 +2652,16 @@ class TestProvenanceIndexes:
         assert mgr.get_doc_sources(id_b) == []
 
         # _source_to_derived: A -> {C}, B -> {C}
-        assert mgr._source_to_derived[id_a] == {id_c}
-        assert mgr._source_to_derived[id_b] == {id_c}
+        assert mgr.get_derived_docs(id_a) == {id_c}
+        assert mgr.get_derived_docs(id_b) == {id_c}
 
         # No unresolved provenance (all sources exist)
-        assert len(mgr._unresolved_provenance) == 0
+        assert len(mgr._index._unresolved_provenance) == 0
 
         # _id_to_title populated
-        assert mgr._id_to_title[id_a] == "Source A"
-        assert mgr._id_to_title[id_b] == "Source B"
-        assert mgr._id_to_title[id_c] == "Derived C"
+        assert mgr.get_title_by_id(id_a) == "Source A"
+        assert mgr.get_title_by_id(id_b) == "Source B"
+        assert mgr.get_title_by_id(id_c) == "Derived C"
 
     @pytest.mark.asyncio
     async def test_scan_forward_references(self, test_config):
@@ -2712,8 +2712,8 @@ class TestProvenanceIndexes:
 
         # A references B — B exists, so it's resolved
         assert mgr.get_doc_sources(id_a) == [id_b]
-        assert mgr._source_to_derived[id_b] == {id_a}
-        assert len(mgr._unresolved_provenance) == 0
+        assert mgr.get_derived_docs(id_b) == {id_a}
+        assert len(mgr._index._unresolved_provenance) == 0
 
     @pytest.mark.asyncio
     async def test_scan_unresolved_references(self, test_config):
@@ -2745,8 +2745,8 @@ class TestProvenanceIndexes:
         mgr = KnowledgeManager(test_config)
 
         assert mgr.get_doc_sources(id_a) == [missing_id]
-        assert missing_id not in mgr._source_to_derived
-        assert mgr._unresolved_provenance[missing_id] == {id_a}
+        assert not mgr.get_derived_docs(missing_id)
+        assert mgr._index._unresolved_provenance[missing_id] == {id_a}
 
     @pytest.mark.asyncio
     async def test_repeated_scan_produces_identical_state(self, test_config):
@@ -2796,18 +2796,18 @@ class TestProvenanceIndexes:
 
         # Capture state after first scan
         doc_to_sources_1 = dict(mgr.iter_doc_sources())
-        source_to_derived_1 = {k: set(v) for k, v in mgr._source_to_derived.items()}
-        unresolved_1 = {k: set(v) for k, v in mgr._unresolved_provenance.items()}
-        id_to_title_1 = dict(mgr._id_to_title)
+        source_to_derived_1 = {k: set(v) for k, v in mgr._index._source_to_derived.items()}
+        unresolved_1 = {k: set(v) for k, v in mgr._index._unresolved_provenance.items()}
+        id_to_title_1 = dict(mgr._index._id_to_title)
 
         # Run scan again
         mgr._scan_existing()
 
         # State should be identical
         assert dict(mgr.iter_doc_sources()) == doc_to_sources_1
-        assert {k: set(v) for k, v in mgr._source_to_derived.items()} == source_to_derived_1
-        assert {k: set(v) for k, v in mgr._unresolved_provenance.items()} == unresolved_1
-        assert mgr._id_to_title == id_to_title_1
+        assert {k: set(v) for k, v in mgr._index._source_to_derived.items()} == source_to_derived_1
+        assert {k: set(v) for k, v in mgr._index._unresolved_provenance.items()} == unresolved_1
+        assert mgr._index._id_to_title == id_to_title_1
 
     @pytest.mark.asyncio
     async def test_scan_no_provenance_has_empty_indexes(self, test_config):
@@ -2824,8 +2824,8 @@ class TestProvenanceIndexes:
         # Re-scan from disk
         mgr2 = KnowledgeManager(test_config)
         assert mgr2.get_doc_sources(doc.id) == []
-        assert len(mgr2._source_to_derived) == 0
-        assert len(mgr2._unresolved_provenance) == 0
+        assert len(mgr2._index._source_to_derived) == 0
+        assert len(mgr2._index._unresolved_provenance) == 0
 
     @pytest.mark.asyncio
     async def test_scan_clears_stale_indexes(self, test_config):
@@ -2852,15 +2852,15 @@ class TestProvenanceIndexes:
         (kp / "doc-a.md").write_text(fm.dumps(post_a))
 
         mgr = KnowledgeManager(test_config)
-        assert id_a in mgr._id_to_title
+        assert id_a in mgr._index._id_to_title
 
         # Remove file and re-scan — stale entry should be gone
         (kp / "doc-a.md").unlink()
         mgr._scan_existing()
 
-        assert id_a not in mgr._id_to_title
+        assert id_a not in mgr._index._id_to_title
         assert not mgr.has_document(id_a)
-        assert id_a not in mgr._id_to_path
+        assert not mgr.has_document(id_a)
 
 
 class TestCreateProvenance:
@@ -2879,8 +2879,8 @@ class TestCreateProvenance:
         assert doc is not None
         assert doc.metadata.derived_from_ids == []
         assert knowledge_manager.get_doc_sources(doc.id) == []
-        assert doc.id in knowledge_manager._id_to_title
-        assert knowledge_manager._id_to_title[doc.id] == "No Provenance"
+        assert doc.id in knowledge_manager._index._id_to_title
+        assert knowledge_manager.get_title_by_id(doc.id) == "No Provenance"
 
     @pytest.mark.asyncio
     async def test_create_with_valid_provenance(self, knowledge_manager: KnowledgeManager):
@@ -2911,8 +2911,8 @@ class TestCreateProvenance:
         assert sorted(knowledge_manager.get_doc_sources(doc.id)) == sorted([src1.id, src2.id])
 
         # _source_to_derived
-        assert doc.id in knowledge_manager._source_to_derived[src1.id]
-        assert doc.id in knowledge_manager._source_to_derived[src2.id]
+        assert doc.id in knowledge_manager.get_derived_docs(src1.id)
+        assert doc.id in knowledge_manager.get_derived_docs(src2.id)
 
         # No unresolved provenance
         assert len(result.warnings) == 0
@@ -2935,9 +2935,9 @@ class TestCreateProvenance:
         assert knowledge_manager.get_doc_sources(doc.id) == [missing_id]
 
         # In unresolved, not in source_to_derived
-        assert missing_id in knowledge_manager._unresolved_provenance
-        assert doc.id in knowledge_manager._unresolved_provenance[missing_id]
-        assert missing_id not in knowledge_manager._source_to_derived
+        assert missing_id in knowledge_manager._index._unresolved_provenance
+        assert doc.id in knowledge_manager._index._unresolved_provenance[missing_id]
+        assert not knowledge_manager.get_derived_docs(missing_id)
 
         # Warning emitted
         assert len(result.warnings) == 1
@@ -2973,8 +2973,8 @@ class TestCreateProvenance:
 
         # Re-scan so indexes pick up doc A with unresolved ref to B
         knowledge_manager._scan_existing()
-        assert id_b in knowledge_manager._unresolved_provenance
-        assert id_a in knowledge_manager._unresolved_provenance[id_b]
+        assert id_b in knowledge_manager._index._unresolved_provenance
+        assert id_a in knowledge_manager._index._unresolved_provenance[id_b]
 
         # Now create doc B — this should auto-resolve A's ref to B
         # We need to force doc B to have the specific ID id_b.
@@ -3002,9 +3002,9 @@ class TestCreateProvenance:
         knowledge_manager._scan_existing()
 
         # After re-scan, B should be resolved
-        assert id_b not in knowledge_manager._unresolved_provenance
-        assert id_b in knowledge_manager._source_to_derived
-        assert id_a in knowledge_manager._source_to_derived[id_b]
+        assert id_b not in knowledge_manager._index._unresolved_provenance
+        assert bool(knowledge_manager.get_derived_docs(id_b))
+        assert id_a in knowledge_manager.get_derived_docs(id_b)
 
     @pytest.mark.asyncio
     async def test_create_auto_resolve_via_create_path(self, knowledge_manager: KnowledgeManager):
@@ -3020,8 +3020,8 @@ class TestCreateProvenance:
         )
         doc_a = result_a.document
         assert doc_a is not None
-        assert missing_id in knowledge_manager._unresolved_provenance
-        assert doc_a.id in knowledge_manager._unresolved_provenance[missing_id]
+        assert missing_id in knowledge_manager._index._unresolved_provenance
+        assert doc_a.id in knowledge_manager._index._unresolved_provenance[missing_id]
 
         # Inject a file with the exact missing_id to simulate external creation,
         # then manually add to _id_to_path and trigger auto-resolve logic.
@@ -3032,13 +3032,13 @@ class TestCreateProvenance:
 
         # Let's set up _unresolved_provenance manually to simulate the scenario:
         fake_new_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
-        knowledge_manager._unresolved_provenance[fake_new_id] = {doc_a.id}
+        knowledge_manager._index._unresolved_provenance[fake_new_id] = {doc_a.id}
 
         # We can't force create() to mint a specific UUID, so let's directly test the
         # auto-resolve code path by manually calling the logic. Instead, let's verify
         # the scan-based auto-resolve works correctly in test_create_resolves_previously_unresolved.
         # Here we verify the _unresolved_provenance state is correct after create with missing ref.
-        assert missing_id in knowledge_manager._unresolved_provenance
+        assert missing_id in knowledge_manager._index._unresolved_provenance
 
     @pytest.mark.asyncio
     async def test_create_with_invalid_uuids(self, knowledge_manager: KnowledgeManager):
@@ -3053,7 +3053,7 @@ class TestCreateProvenance:
         assert result.document is None
 
         # No doc should have been created
-        assert len(knowledge_manager._id_to_path) == 0
+        assert len(knowledge_manager._index._id_to_path) == 0
 
     @pytest.mark.asyncio
     async def test_create_with_empty_string_uuid(self, knowledge_manager: KnowledgeManager):
@@ -3131,9 +3131,9 @@ class TestCreateProvenance:
         assert sorted(knowledge_manager.get_doc_sources(doc.id)) == sorted([src.id, missing_id])
 
         # src.id resolved, missing_id unresolved
-        assert doc.id in knowledge_manager._source_to_derived[src.id]
-        assert missing_id in knowledge_manager._unresolved_provenance
-        assert doc.id in knowledge_manager._unresolved_provenance[missing_id]
+        assert doc.id in knowledge_manager.get_derived_docs(src.id)
+        assert missing_id in knowledge_manager._index._unresolved_provenance
+        assert doc.id in knowledge_manager._index._unresolved_provenance[missing_id]
 
         # Warning only for missing
         assert len(result.warnings) == 1
@@ -3215,7 +3215,7 @@ class TestUpdateProvenance:
         assert result.document is not None
         assert result.document.metadata.derived_from_ids == [src.id]
         assert knowledge_manager.get_doc_sources(doc.id) == [src.id]
-        assert doc.id in knowledge_manager._source_to_derived[src.id]
+        assert doc.id in knowledge_manager.get_derived_docs(src.id)
 
     @pytest.mark.asyncio
     async def test_empty_list_clears_provenance(self, knowledge_manager: KnowledgeManager):
@@ -3239,8 +3239,8 @@ class TestUpdateProvenance:
         assert result.document.metadata.derived_from_ids == []
         assert knowledge_manager.get_doc_sources(doc.id) == []
         # src should no longer have doc in _source_to_derived
-        assert src.id not in knowledge_manager._source_to_derived or (
-            doc.id not in knowledge_manager._source_to_derived.get(src.id, set())
+        assert not knowledge_manager.get_derived_docs(src.id) or (
+            doc.id not in knowledge_manager.get_derived_docs(src.id)
         )
 
     @pytest.mark.asyncio
@@ -3292,11 +3292,11 @@ class TestUpdateProvenance:
         assert knowledge_manager.get_doc_sources(doc.id) == [src2.id]
 
         # src1 should no longer reference doc
-        assert src1.id not in knowledge_manager._source_to_derived or (
-            doc.id not in knowledge_manager._source_to_derived.get(src1.id, set())
+        assert not knowledge_manager.get_derived_docs(src1.id) or (
+            doc.id not in knowledge_manager.get_derived_docs(src1.id)
         )
         # src2 should now reference doc
-        assert doc.id in knowledge_manager._source_to_derived[src2.id]
+        assert doc.id in knowledge_manager.get_derived_docs(src2.id)
 
     @pytest.mark.asyncio
     async def test_replace_with_unresolved_ids(self, knowledge_manager: KnowledgeManager):
@@ -3313,7 +3313,7 @@ class TestUpdateProvenance:
         assert len(result.warnings) == 1
         assert missing_id in result.warnings[0]
         assert knowledge_manager.get_doc_sources(doc.id) == [missing_id]
-        assert doc.id in knowledge_manager._unresolved_provenance[missing_id]
+        assert doc.id in knowledge_manager._index._unresolved_provenance[missing_id]
 
     @pytest.mark.asyncio
     async def test_self_reference_rejected(self, knowledge_manager: KnowledgeManager):
@@ -3346,10 +3346,10 @@ class TestUpdateProvenance:
         doc = (
             await knowledge_manager.create(title="Old Title", content="Content.", agent="agent")
         ).document
-        assert knowledge_manager._id_to_title[doc.id] == "Old Title"
+        assert knowledge_manager.get_title_by_id(doc.id) == "Old Title"
 
         await knowledge_manager.update(id=doc.id, agent="editor", title="New Title")
-        assert knowledge_manager._id_to_title[doc.id] == "New Title"
+        assert knowledge_manager.get_title_by_id(doc.id) == "New Title"
 
     @pytest.mark.asyncio
     async def test_conformance_unset_vs_empty_vs_nonempty(
@@ -3403,8 +3403,8 @@ class TestDeleteProvenance:
         ).document
 
         # Verify initial state
-        assert derived.id in knowledge_manager._source_to_derived[src.id]
-        assert src.id not in knowledge_manager._unresolved_provenance
+        assert derived.id in knowledge_manager.get_derived_docs(src.id)
+        assert src.id not in knowledge_manager._index._unresolved_provenance
 
         # Delete source
         success, _path = await knowledge_manager.delete(id=src.id)
@@ -3412,12 +3412,12 @@ class TestDeleteProvenance:
 
         # Source removed from all provenance indexes
         assert not knowledge_manager.has_document(src.id)
-        assert src.id not in knowledge_manager._source_to_derived
-        assert src.id not in knowledge_manager._id_to_title
+        assert not knowledge_manager.get_derived_docs(src.id)
+        assert src.id not in knowledge_manager._index._id_to_title
 
         # Derived doc's relationship is now unresolved
-        assert src.id in knowledge_manager._unresolved_provenance
-        assert derived.id in knowledge_manager._unresolved_provenance[src.id]
+        assert src.id in knowledge_manager._index._unresolved_provenance
+        assert derived.id in knowledge_manager._index._unresolved_provenance[src.id]
 
         # Derived doc's forward index still exists (frontmatter not mutated)
         assert knowledge_manager.get_doc_sources(derived.id) == [src.id]
@@ -3440,7 +3440,7 @@ class TestDeleteProvenance:
         ).document
 
         # Verify initial state
-        assert derived.id in knowledge_manager._source_to_derived[src.id]
+        assert derived.id in knowledge_manager.get_derived_docs(src.id)
 
         # Delete derived
         success, _path = await knowledge_manager.delete(id=derived.id)
@@ -3448,11 +3448,11 @@ class TestDeleteProvenance:
 
         # Derived removed from all provenance indexes
         assert not knowledge_manager.has_document(derived.id)
-        assert derived.id not in knowledge_manager._id_to_title
+        assert derived.id not in knowledge_manager._index._id_to_title
 
         # Source's _source_to_derived no longer has the deleted derived doc
-        assert src.id not in knowledge_manager._source_to_derived or (
-            derived.id not in knowledge_manager._source_to_derived.get(src.id, set())
+        assert not knowledge_manager.get_derived_docs(src.id) or (
+            derived.id not in knowledge_manager.get_derived_docs(src.id)
         )
 
     @pytest.mark.asyncio
@@ -3465,8 +3465,8 @@ class TestDeleteProvenance:
         success, _path = await knowledge_manager.delete(id=doc.id)
         assert success
         assert not knowledge_manager.has_document(doc.id)
-        assert doc.id not in knowledge_manager._id_to_title
-        assert doc.id not in knowledge_manager._source_to_derived
+        assert doc.id not in knowledge_manager._index._id_to_title
+        assert not knowledge_manager.get_derived_docs(doc.id)
 
     @pytest.mark.asyncio
     async def test_delete_does_not_mutate_other_frontmatter(
@@ -3511,9 +3511,9 @@ class TestDeleteProvenance:
 
         await knowledge_manager.delete(id=src.id)
 
-        assert src.id in knowledge_manager._unresolved_provenance
-        assert d1.id in knowledge_manager._unresolved_provenance[src.id]
-        assert d2.id in knowledge_manager._unresolved_provenance[src.id]
+        assert src.id in knowledge_manager._index._unresolved_provenance
+        assert d1.id in knowledge_manager._index._unresolved_provenance[src.id]
+        assert d2.id in knowledge_manager._index._unresolved_provenance[src.id]
 
     @pytest.mark.asyncio
     async def test_delete_derived_with_multiple_sources(self, knowledge_manager: KnowledgeManager):
@@ -3532,11 +3532,11 @@ class TestDeleteProvenance:
         await knowledge_manager.delete(id=derived.id)
 
         # Neither source should reference the deleted derived doc
-        assert s1.id not in knowledge_manager._source_to_derived or (
-            derived.id not in knowledge_manager._source_to_derived.get(s1.id, set())
+        assert not knowledge_manager.get_derived_docs(s1.id) or (
+            derived.id not in knowledge_manager.get_derived_docs(s1.id)
         )
-        assert s2.id not in knowledge_manager._source_to_derived or (
-            derived.id not in knowledge_manager._source_to_derived.get(s2.id, set())
+        assert not knowledge_manager.get_derived_docs(s2.id) or (
+            derived.id not in knowledge_manager.get_derived_docs(s2.id)
         )
 
 
@@ -3627,8 +3627,8 @@ class TestScanExistingNormalization:
         # The stored derived_from_ids should be normalized (lowercase)
         assert mgr.get_doc_sources(derived_id) == [source_id]
         # The reference should resolve (since normalized matches the source)
-        assert derived_id in mgr._source_to_derived.get(source_id, set())
-        assert not mgr._unresolved_provenance
+        assert derived_id in mgr.get_derived_docs(source_id)
+        assert not mgr._index._unresolved_provenance
 
     async def test_scan_skips_invalid_derived_from_ids(self, test_config: LithosConfig):
         """Startup scan skips invalid UUIDs in derived_from_ids."""
@@ -3717,7 +3717,7 @@ class TestSyncFromDiskSourceUrlCollision:
 
         mgr = KnowledgeManager(test_config)
         norm = normalize_url(url)
-        assert mgr._source_url_to_id[norm] == id_a
+        assert mgr._index._source_url_to_id[norm] == id_a
 
         # Now externally edit B to claim A's URL
         post_b_steal = fm.Post("# B\n\nContent.", id=id_b, title="B", source_url=url)
@@ -3725,7 +3725,7 @@ class TestSyncFromDiskSourceUrlCollision:
 
         await mgr.sync_from_disk(Path("b.md"))
         # A should still own the URL
-        assert mgr._source_url_to_id[norm] == id_a
+        assert mgr._index._source_url_to_id[norm] == id_a
 
 
 class TestSyncFromDiskWriteLock:
@@ -3761,7 +3761,7 @@ class TestSyncFromDiskWriteLock:
 
         # Should be normalized
         assert mgr.get_doc_sources(derived_id) == [source_id]
-        assert derived_id in mgr._source_to_derived.get(source_id, set())
+        assert derived_id in mgr.get_derived_docs(source_id)
 
 
 class TestExpiresAtField:
@@ -4333,7 +4333,7 @@ class TestSlugCollision:
         # First-seen-wins: scan is sorted by relative path for determinism, but
         # which UUID comes first alphabetically is not guaranteed.  Assert that
         # exactly one of the two docs holds the slug rather than hard-coding doc1.
-        winner = mgr2._slug_to_id.get("my-document")
+        winner = mgr2.get_id_by_slug("my-document")
         assert winner in {doc1.id, doc2.id}, (
             f"Expected slug 'my-document' to be held by one of the two docs, got {winner!r}"
         )
@@ -4387,12 +4387,12 @@ class TestSlugCollision:
 
         # The new doc_id must not appear in the indices.
         # We can verify by checking no path maps to a doc with content "Second."
-        for doc_id, path in knowledge_manager._id_to_path.items():
+        for doc_id, path in knowledge_manager._index._id_to_path.items():
             full = kp / path
             if full.exists() and "Second." in full.read_text():
                 pytest.fail(f"_id_to_path still references zombie doc {doc_id}")
 
-        for path in knowledge_manager._path_to_id:
+        for path in knowledge_manager._index._path_to_id:
             full = kp / path
             if full.exists() and "Second." in full.read_text():
                 pytest.fail(f"_path_to_id still references zombie path {path}")
@@ -4457,7 +4457,7 @@ class TestSlugCollision:
         from lithos.frontmatter_codec import normalize_url
 
         original_norm = normalize_url(original_source_url)
-        assert knowledge_manager._source_url_to_id.get(original_norm) == doc2.id
+        assert knowledge_manager._index._source_url_to_id.get(original_norm) == doc2.id
 
         # Attempt update: rename to colliding title AND change source_url simultaneously.
         new_source_url = "https://example.com/new"
@@ -4475,13 +4475,13 @@ class TestSlugCollision:
         )
 
         # source_url index must still point to doc2 via the original URL.
-        assert knowledge_manager._source_url_to_id.get(original_norm) == doc2.id, (
+        assert knowledge_manager._index._source_url_to_id.get(original_norm) == doc2.id, (
             "_source_url_to_id lost original mapping after failed update"
         )
 
         # The new URL must NOT have been inserted into the index.
         new_norm = normalize_url(new_source_url)
-        assert knowledge_manager._source_url_to_id.get(new_norm) is None, (
+        assert knowledge_manager._index._source_url_to_id.get(new_norm) is None, (
             "_source_url_to_id was polluted with new URL after failed update"
         )
 

--- a/tests/test_provenance_conformance.py
+++ b/tests/test_provenance_conformance.py
@@ -163,7 +163,7 @@ class TestUpdateConformance:
         assert result["status"] == "updated"
         assert server.knowledge.get_doc_sources(doc_id) == [s2]
         # s1 no longer in reverse index for this doc
-        assert doc_id not in server.knowledge._source_to_derived.get(s1, set())
+        assert doc_id not in server.knowledge._index._source_to_derived.get(s1, set())
 
     async def test_self_reference_rejected(self, server: LithosServer):
         """Self-reference on update is rejected with invalid_input."""
@@ -262,7 +262,7 @@ class TestIndexLifecycleConformance:
             },
         )
         doc_id = result["id"]
-        assert missing_id in server.knowledge._unresolved_provenance
+        assert missing_id in server.knowledge._index._unresolved_provenance
 
         # Externally create a file with that ID (simulating git restore / file watcher)
         knowledge_path = server.knowledge.knowledge_path
@@ -274,8 +274,8 @@ class TestIndexLifecycleConformance:
         assert doc.id == missing_id
 
         # Verify auto-resolution
-        assert missing_id not in server.knowledge._unresolved_provenance
-        assert doc_id in server.knowledge._source_to_derived.get(missing_id, set())
+        assert missing_id not in server.knowledge._index._unresolved_provenance
+        assert doc_id in server.knowledge._index._source_to_derived.get(missing_id, set())
 
     async def test_delete_source_marks_unresolved(self, server: LithosServer):
         """Deleting a source doc marks provenance as unresolved."""
@@ -301,8 +301,8 @@ class TestIndexLifecycleConformance:
         await call_tool(server, "lithos_delete", {"id": src_id, "agent": "conf-agent"})
 
         # Derived doc now has unresolved provenance
-        assert derived_id in server.knowledge._unresolved_provenance.get(src_id, set())
-        assert src_id not in server.knowledge._source_to_derived
+        assert derived_id in server.knowledge._index._unresolved_provenance.get(src_id, set())
+        assert src_id not in server.knowledge._index._source_to_derived
 
     async def test_cycles_no_infinite_traversal(self, server: LithosServer):
         """Provenance cycles don't cause infinite traversal."""
@@ -441,8 +441,8 @@ class TestScanConformance:
 
         # Forward reference resolved (A references B, B exists)
         assert mgr.get_doc_sources(id_a) == [id_b]
-        assert id_a in mgr._source_to_derived.get(id_b, set())
-        assert not mgr._unresolved_provenance  # no unresolved
+        assert id_a in mgr._index._source_to_derived.get(id_b, set())
+        assert not mgr._index._unresolved_provenance  # no unresolved
 
     async def test_repeated_scan_idempotent(self, test_config: LithosConfig):
         """Repeated _scan_existing() calls produce identical index state."""
@@ -464,17 +464,17 @@ class TestScanConformance:
         mgr = KnowledgeManager(test_config)
         snap1 = (
             dict(mgr.iter_doc_sources()),
-            {k: set(v) for k, v in mgr._source_to_derived.items()},
-            dict(mgr._unresolved_provenance),
-            dict(mgr._id_to_title),
+            {k: set(v) for k, v in mgr._index._source_to_derived.items()},
+            dict(mgr._index._unresolved_provenance),
+            dict(mgr._index._id_to_title),
         )
 
         mgr._scan_existing()
         snap2 = (
             dict(mgr.iter_doc_sources()),
-            {k: set(v) for k, v in mgr._source_to_derived.items()},
-            dict(mgr._unresolved_provenance),
-            dict(mgr._id_to_title),
+            {k: set(v) for k, v in mgr._index._source_to_derived.items()},
+            dict(mgr._index._unresolved_provenance),
+            dict(mgr._index._id_to_title),
         )
 
         assert snap1 == snap2
@@ -487,10 +487,10 @@ class TestScanConformance:
             {"title": "Old Title", "content": ".", "agent": "conf-agent"},
         )
         doc_id = result["id"]
-        assert server.knowledge._id_to_title[doc_id] == "Old Title"
+        assert server.knowledge._index._id_to_title[doc_id] == "Old Title"
 
         # Modify the file externally
-        rel_path = server.knowledge._id_to_path[doc_id]
+        rel_path = server.knowledge._index._id_to_path[doc_id]
         full_path = server.knowledge.knowledge_path / rel_path
         post = fm.load(str(full_path))
         post.metadata["title"] = "New Title"
@@ -500,7 +500,7 @@ class TestScanConformance:
         # Simulate file watcher
         await server.knowledge.sync_from_disk(rel_path)
 
-        assert server.knowledge._id_to_title[doc_id] == "New Title"
+        assert server.knowledge._index._id_to_title[doc_id] == "New Title"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -110,7 +110,7 @@ def seeded_km(seeded_config: LithosConfig) -> KnowledgeManager:
 def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> KnowledgeGraph:
     """KnowledgeGraph built from seeded notes."""
     graph = KnowledgeGraph(seeded_config)
-    for doc_id, rel_path in seeded_km._id_to_path.items():
+    for doc_id, rel_path in seeded_km._index._id_to_path.items():
         full_path = seeded_config.storage.knowledge_path / rel_path
         if full_path.exists():
             post = fm.load(str(full_path))
@@ -239,7 +239,9 @@ class TestRerankFast:
         from dataclasses import replace
 
         # Override ID1's note_type to task_record in the cache
-        seeded_km._meta_cache[_ID1] = replace(seeded_km._meta_cache[_ID1], note_type="task_record")
+        seeded_km._index._meta_cache[_ID1] = replace(
+            seeded_km._index._meta_cache[_ID1], note_type="task_record"
+        )
 
         candidates = [
             Candidate(node_id=_ID1, score=1.0, reasons=["r1"], scouts=["scout_vector"]),

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -173,7 +173,7 @@ def seeded_graph(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -> Kn
     """KnowledgeGraph built from seeded notes."""
     graph = KnowledgeGraph(seeded_config)
     # Add nodes for each doc in the KM
-    for doc_id, rel_path in seeded_km._id_to_path.items():
+    for doc_id, rel_path in seeded_km._index._id_to_path.items():
         full_path = seeded_config.storage.knowledge_path / rel_path
         if full_path.exists():
             post = fm.load(str(full_path))
@@ -696,7 +696,7 @@ def graph_with_links(seeded_config: LithosConfig, seeded_km: KnowledgeManager) -
     (kp / "note-one.md").write_text(fm.dumps(note1))
     seeded_km._scan_existing()
 
-    for doc_id, rel_path in seeded_km._id_to_path.items():
+    for doc_id, rel_path in seeded_km._index._id_to_path.items():
         full_path = kp / rel_path
         if full_path.exists():
             post = fm.load(str(full_path))
@@ -1072,7 +1072,7 @@ class TestScoutSourceUrl:
         from lithos.frontmatter_codec import normalize_url
 
         norm = normalize_url("https://example.com/same")
-        assert km._source_url_to_id.get(norm) == _COLLISION_A
+        assert km._index._source_url_to_id.get(norm) == _COLLISION_A
 
         # Use B as seed — it has source_url but is NOT in _source_url_to_id
         candidates = await scout_source_url([_COLLISION_B], km)
@@ -1431,7 +1431,7 @@ class TestExplicitNamespaceOverride:
         return km
 
     def test_cached_meta_keeps_explicit_namespace(self, override_km: KnowledgeManager) -> None:
-        cached = override_km._meta_cache["00000000-1111-4111-1111-111111111111"]
+        cached = override_km._index._meta_cache["00000000-1111-4111-1111-111111111111"]
         # Path-derived would be "projects"; explicit override is "research/alpha".
         assert cached.namespace == "research/alpha"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -785,8 +785,8 @@ class TestKnowledgeToolWorkflow:
         ).document
 
         # Backdate ``old`` so ``since`` filter excludes it.
-        old_meta = server.knowledge._meta_cache[old.id]
-        server.knowledge._meta_cache[old.id] = replace(
+        old_meta = server.knowledge._index._meta_cache[old.id]
+        server.knowledge._index._meta_cache[old.id] = replace(
             old_meta, updated_at=datetime.now(UTC) - timedelta(days=30)
         )
 
@@ -1941,7 +1941,7 @@ class TestCacheLookup:
         path = server.knowledge._resolve_safe_path(doc.path)[1]
         path.write_text(encode(doc))
         # Re-read to reload from disk
-        server.knowledge._id_to_path[doc.id] = doc.path
+        server.knowledge._index._id_to_path[doc.id] = doc.path
         server.search.index(KnowledgeManager.to_indexable(doc))
 
         result = await self._call_cache_lookup(


### PR DESCRIPTION
## What

Names `KnowledgeManager`'s unnamed in-memory query view as its own module,
`lithos.corpus_index`. That view is the metadata cache, the five inverted indexes
(author / status / tag / entities / metadata), the path / slug / url maps, and the
in-memory provenance maps. `knowledge.py` shrinks **1773 → 1264 lines** and keeps the
store: note CRUD, disk I/O, the reconcile seam, and lifecycle. `CorpusIndex` owns the
projection; `knowledge.py` holds it as `self._index`, delegating every read accessor and
routing each CRUD mutation through it.

This is **PR4a** of task `ebaf33bc` — the structural, behaviour-neutral half. **PR4b**
(later) collapses the two provenance *read* paths in `lithos_related` (in-memory BFS vs
the `edges.db` projection); that is behavioural and stays out of this PR.

## Why an owned sub-object, not a fourth reconcile peer

The index is a pure in-memory derived view: rebuilt from the corpus scan on construction,
never persisted. It therefore **cannot drift across processes** the way Tantivy /
NetworkX / `edges.db` can — those are the three peers `plan_reconcile(search=, graph=,
projection=)` exists to reconcile. So `CorpusIndex` is an internally owned sub-object of
`KnowledgeManager`, and the reconcile signature is unchanged.

## Architecture impact — nothing moves

`corpus_index` sits in the **Knowledge** component (like `_merge`), Core tier, imported
**only** by `knowledge.py`:

| metric | before | after |
|---|---|---|
| cross_component_edges | 68 | 68 |
| component_cycles | 0 | 0 |
| module_cycles | 1 | 1 |
| modules_over_800_lines | 11 | 11 |
| cross_module_private_refs | 34 | **32** |

No new cross-component edge; the `knowledge<->graph` cycle did **not** return;
`corpus_index` (710 lines) is under the 800 line guideline. The private-refs drop is
scouts' two reach-throughs going public (below).

## Notable

- `_CachedMeta` becomes the **public value type `CachedMeta`**, mirroring how
  `IndexableDocument` crosses the Search seam. It was never imported by name outside
  `knowledge.py`; every consumer already went through `get_cached_meta` /
  `iter_cached_meta`.
- `from_metadata` / `from_frontmatter` classmethods dedupe the `CachedMeta` construction
  that was inlined at the create / reindex / sync / scan sites.
- The provenance classify/log asymmetry is **preserved verbatim**: create and
  update-replace log missing-source warnings (`_classify_and_log`); `_sync` and scan are
  silent (`_classify_provenance`). `sync_provenance` auto-resolves new sources only;
  update-replace does not auto-resolve.
- `scouts.py`'s two private reach-throughs (`knowledge._id_to_path`,
  `knowledge._source_url_to_id`) migrate to new public accessors `iter_doc_ids()` /
  `iter_source_urls()`. `_CachedMetaView` is left as-is — it re-projects the public
  `CachedMeta` and still works; its collapse folds into PR4b.
- import-linter: `corpus_index` added to *Core must not import Entrypoints* and to
  *Foundation must not import Core or Entrypoints*.

## Tests

Private-attr assertions that shattered under the move now read through public accessors
where clean (`get_derived_docs`, `get_title_by_id`, `has_document`, `get_id_by_slug`) or
via `._index._<attr>` where a snapshot / isinstance check still asserts an internal. No
behavioural assertion changed.

## Verification

- `make check` — **1593 passed**, typecheck + lint clean
- `make test-integration` — **454 passed**
- `make diagrams` — **48 guardrails passed**
- `lint-imports` — 3 contracts kept
