### PR TITLE
refactor: give provenance BFS an owner + collapse the scouts cached-meta view (PR4b, task ebaf33bc)

### DIFF
--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -22,7 +22,7 @@
         "max_function": "lithos.coordination.CoordinationService.create_task"
       },
       "Entrypoints": {
-        "functions_over_10": 17,
+        "functions_over_10": 16,
         "max_complexity": 65,
         "max_function": "lithos.tools.notes.register.lithos_write"
       },
@@ -47,7 +47,7 @@
         "max_function": "lithos.intake.CorpusIntake.write"
       },
       "Knowledge": {
-        "functions_over_10": 6,
+        "functions_over_10": 7,
         "max_complexity": 62,
         "max_function": "lithos.knowledge.KnowledgeManager.update"
       },
@@ -120,7 +120,7 @@
         "qualname": "lithos.tools.notes.register.lithos_note_update"
       }
     ],
-    "total_functions": 719
+    "total_functions": 720
   },
   "domain": {
     "associations": 26,
@@ -341,13 +341,13 @@
       },
       "Entrypoints": {
         "classes": 4,
-        "functions": 138,
+        "functions": 137,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5981,
+        "lines": 5915,
         "modules": 13,
         "public_symbols": 30,
-        "sloc": 4807
+        "sloc": 4751
       },
       "Errors": {
         "classes": 9,
@@ -391,23 +391,23 @@
       },
       "Knowledge": {
         "classes": 9,
-        "functions": 85,
+        "functions": 87,
         "largest_module": "lithos.knowledge",
-        "largest_module_lines": 1267,
-        "lines": 2007,
+        "largest_module_lines": 1273,
+        "lines": 2067,
         "modules": 3,
         "public_symbols": 9,
-        "sloc": 1602
+        "sloc": 1654
       },
       "LCMA": {
-        "classes": 5,
+        "classes": 4,
         "functions": 128,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4535,
+        "lines": 4513,
         "modules": 9,
         "public_symbols": 20,
-        "sloc": 3658
+        "sloc": 3639
       },
       "Logging": {
         "classes": 1,
@@ -465,13 +465,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23773,
+    "total_lines": 23745,
     "total_modules": 40,
-    "total_sloc": 19124
+    "total_sloc": 19101
   },
   "tests": {
-    "ratio": 1.85,
-    "src_lines": 23773,
-    "test_lines": 44047
+    "ratio": 1.87,
+    "src_lines": 23745,
+    "test_lines": 44345
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -38,13 +38,13 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | CognitiveMemory | 1 | 998 | 820 | 1 | 12 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5981 | 4807 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 17 |
+| Entrypoints | 13 | 5915 | 4751 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 16 |
 | Errors | 2 | 210 | 151 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
-| Knowledge | 3 | 2007 | 1602 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 6 |
-| LCMA | 9 | 4535 | 3658 | 1 | 11 | 0.92 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
+| Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
+| LCMA | 9 | 4513 | 3639 | 1 | 11 | 0.92 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **40**, lines: **23773**, SLOC: **19124**
+- Modules: **40**, lines: **23745**, SLOC: **19101**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -69,7 +69,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **719**, cyclomatic > 10: **65**
+- Functions: **720**, cyclomatic > 10: **65**
 
 Top 10 most complex functions:
 
@@ -152,4 +152,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.85** (44047 test lines / 23773 source lines)
+- Test-to-source line ratio: **1.87** (44345 test lines / 23745 source lines)

--- a/src/lithos/corpus_index.py
+++ b/src/lithos/corpus_index.py
@@ -24,11 +24,13 @@ manager reads files and hands over frontmatter.
 
 from __future__ import annotations
 
+import collections
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 from lithos.frontmatter_codec import (
     KnowledgeMetadata,
@@ -700,6 +702,58 @@ class CorpusIndex:
     def has_unresolved_source(self, source_id: str) -> bool:
         """Whether any document has an unresolved reference to ``source_id``."""
         return source_id in self._unresolved_provenance
+
+    def provenance_neighbours(
+        self, start_id: str, direction: Literal["sources", "derived"], depth: int
+    ) -> list[dict[str, str]]:
+        """BFS over the in-memory ``derived_from`` maps from *start_id*.
+
+        ``direction='sources'`` walks the edges *start_id* derives from, guarding
+        that each hop resolves to a known document; ``direction='derived'`` walks
+        the documents derived from *start_id*. *depth* is the maximum hop count
+        (callers clamp it to 1-3). *start_id* is excluded; the result is sorted by
+        id with titles resolved, so the set iteration in the ``derived`` direction
+        stays deterministic.
+        """
+        visited: set[str] = {start_id}
+        frontier: collections.deque[str] = collections.deque()
+
+        # Seed the frontier with immediate neighbours.
+        if direction == "sources":
+            for nid in self.doc_sources(start_id):
+                if self.has_document(nid) and nid not in visited:
+                    frontier.append(nid)
+                    visited.add(nid)
+        else:  # "derived"
+            for nid in self.derived_docs(start_id):
+                if nid not in visited:
+                    frontier.append(nid)
+                    visited.add(nid)
+
+        current_depth = 1
+        result_ids: list[str] = list(frontier)
+
+        while current_depth < depth and frontier:
+            next_frontier: list[str] = []
+            for node_id in frontier:
+                if direction == "sources":
+                    for nid in self.doc_sources(node_id):
+                        if self.has_document(nid) and nid not in visited:
+                            next_frontier.append(nid)
+                            visited.add(nid)
+                else:
+                    for nid in self.derived_docs(node_id):
+                        if nid not in visited:
+                            next_frontier.append(nid)
+                            visited.add(nid)
+            frontier = collections.deque(next_frontier)
+            result_ids.extend(next_frontier)
+            current_depth += 1
+
+        return sorted(
+            [{"id": nid, "title": self.title_by_id(nid)} for nid in result_ids],
+            key=lambda n: n["id"],
+        )
 
     def all_tags(self) -> dict[str, int]:
         """Tag → document-count over the whole cache."""

--- a/src/lithos/knowledge.py
+++ b/src/lithos/knowledge.py
@@ -1222,6 +1222,12 @@ class KnowledgeManager:
         """Get unresolved source IDs for a document."""
         return self._index.unresolved_sources(doc_id)
 
+    def provenance_neighbours(
+        self, start_id: str, direction: Literal["sources", "derived"], depth: int
+    ) -> list[dict[str, str]]:
+        """BFS the provenance ``derived_from`` maps; see :meth:`CorpusIndex.provenance_neighbours`."""
+        return self._index.provenance_neighbours(start_id, direction, depth)
+
     def get_title_by_id(self, doc_id: str) -> str:
         """Get document title by ID, returning empty string if unknown."""
         return self._index.title_by_id(doc_id)

--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -24,6 +23,7 @@ from lithos.lcma.utils import Candidate
 
 if TYPE_CHECKING:
     from lithos.coordination import CoordinationService
+    from lithos.corpus_index import CachedMeta
     from lithos.graph import KnowledgeGraph
     from lithos.knowledge import KnowledgeManager
     from lithos.lcma.stats import StatsStore
@@ -906,44 +906,22 @@ async def scout_contradictions(
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class _CachedMetaView:
-    """Typed view of cached metadata for gating decisions."""
-
-    namespace: str
-    access_scope: str
-    author: str
-    source: str | None
-    tags: list[str]
-    path: object  # Path, but kept loose to avoid an import cycle
-    status: str | None = None
-
-
 def _passes_status_filter(
-    view: _CachedMetaView | None,
+    meta: CachedMeta | None,
     exclude_status: list[str] | None = None,
 ) -> bool:
-    """Return False when the view's status is in the exclusion list."""
-    if exclude_status is None or view is None:
+    """Return False when the note's status is in the exclusion list."""
+    if exclude_status is None or meta is None:
         return True
-    return view.status not in exclude_status
+    return meta.status not in exclude_status
 
 
-def _get_cached_meta(knowledge: KnowledgeManager, doc_id: str) -> _CachedMetaView | None:
-    """Read lightweight metadata from KnowledgeManager's in-memory cache.
+def _get_cached_meta(knowledge: KnowledgeManager, doc_id: str) -> CachedMeta | None:
+    """Read the public cached-metadata value for gating decisions.
 
-    The namespace comes directly from the cache (which honors explicit
-    frontmatter overrides) — never re-derived from path here.
+    Namespace comes directly from the cache (which honors explicit frontmatter
+    overrides) — never re-derived from path here. ``access_scope`` may be ``None``
+    for a note with no explicit scope; :func:`_passes_access_scope` treats that
+    identically to ``"shared"``, so no normalisation is needed at the seam.
     """
-    cached = knowledge.get_cached_meta(doc_id)
-    if cached is None:
-        return None
-    return _CachedMetaView(
-        namespace=cached.namespace,
-        access_scope=cached.access_scope or "shared",
-        author=cached.author,
-        source=cached.source,
-        tags=list(cached.tags),
-        path=cached.path,
-        status=cached.status,
-    )
+    return knowledge.get_cached_meta(doc_id)

--- a/src/lithos/tools/read_search.py
+++ b/src/lithos/tools/read_search.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 import dataclasses
 import hashlib
 import logging
@@ -19,7 +18,6 @@ from lithos.telemetry import get_current_span, tool_metrics
 from lithos.tools._seam import tool_span
 
 if TYPE_CHECKING:
-    from lithos.knowledge import KnowledgeManager
     from lithos.server import LithosServer
 
 logger = logging.getLogger(__name__)
@@ -31,70 +29,6 @@ logger = logging.getLogger(__name__)
 _CONTENT_QUERY_FTS_CAP = 1_000_000
 
 _RELATED_INCLUDES = ("links", "provenance", "edges")
-
-
-def _bfs_provenance(
-    knowledge: KnowledgeManager, start_id: str, direction: str, depth: int
-) -> list[dict[str, str]]:
-    """BFS traversal over provenance indexes.
-
-    Args:
-        knowledge: The corpus manager owning the provenance indexes.
-        start_id: Starting document ID (excluded from results).
-        direction: "sources" or "derived".
-        depth: Maximum traversal depth (already clamped to 1-3).
-
-    Returns:
-        Sorted list of {id, title} dicts for discovered nodes.
-    """
-    visited: set[str] = {start_id}
-    frontier: collections.deque[str] = collections.deque()
-
-    # Seed the frontier with immediate neighbours
-    if direction == "sources":
-        for nid in knowledge.get_doc_sources(start_id):
-            if knowledge.has_document(nid) and nid not in visited:
-                frontier.append(nid)
-                visited.add(nid)
-    else:  # "derived"
-        for nid in knowledge.get_derived_docs(start_id):
-            if nid not in visited:
-                frontier.append(nid)
-                visited.add(nid)
-
-    current_depth = 1
-    result_ids: list[str] = list(frontier)
-
-    while current_depth < depth and frontier:
-        next_frontier: list[str] = []
-        for node_id in frontier:
-            if direction == "sources":
-                neighbours = knowledge.get_doc_sources(node_id)
-                for nid in neighbours:
-                    if knowledge.has_document(nid) and nid not in visited:
-                        next_frontier.append(nid)
-                        visited.add(nid)
-            else:
-                neighbours = knowledge.get_derived_docs(node_id)
-                for nid in neighbours:
-                    if nid not in visited:
-                        next_frontier.append(nid)
-                        visited.add(nid)
-        frontier = collections.deque(next_frontier)
-        result_ids.extend(next_frontier)
-        current_depth += 1
-
-    # Sort by ID for deterministic output, resolve titles
-    return sorted(
-        [
-            {
-                "id": nid,
-                "title": knowledge.get_title_by_id(nid),
-            }
-            for nid in result_ids
-        ],
-        key=lambda n: n["id"],
-    )
 
 
 def register(mcp: FastMCP, server: LithosServer) -> None:
@@ -709,8 +643,8 @@ def register(mcp: FastMCP, server: LithosServer) -> None:
 
         # --- provenance (frontmatter derived_from_ids) -------------
         if "provenance" in selected:
-            sources = _bfs_provenance(server.knowledge, id, "sources", depth)
-            derived = _bfs_provenance(server.knowledge, id, "derived", depth)
+            sources = server.knowledge.provenance_neighbours(id, "sources", depth)
+            derived = server.knowledge.provenance_neighbours(id, "derived", depth)
             unresolved_sources = sorted(server.knowledge.get_unresolved_sources(id))
             result["provenance"] = {
                 "sources": sources,

--- a/tests/test_corpus_index.py
+++ b/tests/test_corpus_index.py
@@ -1,0 +1,298 @@
+"""Direct unit tests for :class:`lithos.corpus_index.CorpusIndex`.
+
+CorpusIndex is a pure in-memory projection — no disk, no async — so these tests
+drive its public surface directly, without a KnowledgeManager. They pin the
+behaviour KnowledgeManager relies on: document lifecycle, provenance
+classification/auto-resolve, source-URL collision counting, whole-corpus
+rebuild, and the ``provenance_neighbours`` BFS relocated here in PR4b.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lithos.corpus_index import CachedMeta, CorpusIndex, ScannedNote
+
+MISSING_SOURCE_WARNING = "derived_from_ids contains missing document: {}"
+
+
+def _meta(idx: CorpusIndex, *, title: str = "", path: str = "n.md", **fm: object) -> CachedMeta:
+    """Build a CachedMeta the cheap way, from a frontmatter dict."""
+    fm.setdefault("title", title)
+    return CachedMeta.from_frontmatter(dict(fm), Path(path), seq=idx.next_seq())
+
+
+def _add(
+    idx: CorpusIndex,
+    doc_id: str,
+    *,
+    title: str,
+    sources: list[str] | None = None,
+    path: str | None = None,
+    norm_url: str | None = None,
+    **fm: object,
+) -> list[str]:
+    """Register a document and return the create-path warnings."""
+    rel = path or f"{doc_id}.md"
+    cached = _meta(idx, title=title, path=rel, **fm)
+    return idx.add_document(doc_id, cached, title=title, norm_url=norm_url, sources=sources or [])
+
+
+# ---------------------------------------------------------------------------
+# provenance_neighbours — the BFS relocated from tools/read_search.py (PR4b)
+# ---------------------------------------------------------------------------
+
+
+def _chain_a_b_c() -> CorpusIndex:
+    """A derives from B, B derives from C (added in dependency order)."""
+    idx = CorpusIndex()
+    _add(idx, "C", title="Cee")
+    _add(idx, "B", title="Bee", sources=["C"])
+    _add(idx, "A", title="Aay", sources=["B"])
+    return idx
+
+
+def test_provenance_neighbours_sources_single_hop():
+    # Arrange
+    idx = _chain_a_b_c()
+
+    # Act
+    result = idx.provenance_neighbours("A", "sources", 1)
+
+    # Assert
+    assert result == [{"id": "B", "title": "Bee"}]
+
+
+def test_provenance_neighbours_sources_multi_hop_is_transitive():
+    # Arrange
+    idx = _chain_a_b_c()
+
+    # Act
+    depth2 = idx.provenance_neighbours("A", "sources", 2)
+    depth3 = idx.provenance_neighbours("A", "sources", 3)
+
+    # Assert — depth 2 reaches C through B; depth 3 finds nothing further
+    assert depth2 == [{"id": "B", "title": "Bee"}, {"id": "C", "title": "Cee"}]
+    assert depth3 == depth2
+
+
+def test_provenance_neighbours_derived_direction_walks_reverse_edges():
+    # Arrange
+    idx = _chain_a_b_c()
+
+    # Act
+    one_hop = idx.provenance_neighbours("C", "derived", 1)
+    two_hop = idx.provenance_neighbours("C", "derived", 2)
+
+    # Assert
+    assert one_hop == [{"id": "B", "title": "Bee"}]
+    assert two_hop == [{"id": "A", "title": "Aay"}, {"id": "B", "title": "Bee"}]
+
+
+def test_provenance_neighbours_excludes_start_and_sorts_by_id():
+    # Arrange — one doc derived from two sources
+    idx = CorpusIndex()
+    _add(idx, "src-z", title="Zed")
+    _add(idx, "src-a", title="Ann")
+    _add(idx, "doc", title="Doc", sources=["src-z", "src-a"])
+
+    # Act
+    result = idx.provenance_neighbours("doc", "sources", 1)
+
+    # Assert — start excluded, output sorted by id
+    ids = [n["id"] for n in result]
+    assert ids == ["src-a", "src-z"]
+    assert "doc" not in ids
+
+
+def test_provenance_neighbours_sources_skips_dangling_reference():
+    # Arrange — a note pointing at a source that was never created
+    idx = CorpusIndex()
+    _add(idx, "A", title="Aay", sources=["ghost"])
+
+    # Act
+    result = idx.provenance_neighbours("A", "sources", 2)
+
+    # Assert — the has_document guard drops the dangling id
+    assert result == []
+    assert idx.unresolved_sources("A") == ["ghost"]
+
+
+def test_provenance_neighbours_empty_when_no_provenance():
+    # Arrange
+    idx = CorpusIndex()
+    _add(idx, "solo", title="Solo")
+
+    # Act / Assert
+    assert idx.provenance_neighbours("solo", "sources", 3) == []
+    assert idx.provenance_neighbours("solo", "derived", 3) == []
+
+
+def test_provenance_neighbours_dedupes_diamond():
+    # Arrange — diamond: A derives from B and C; both derive from D
+    idx = CorpusIndex()
+    _add(idx, "D", title="Dee")
+    _add(idx, "B", title="Bee", sources=["D"])
+    _add(idx, "C", title="Cee", sources=["D"])
+    _add(idx, "A", title="Aay", sources=["B", "C"])
+
+    # Act — D reachable via both B and C, must appear once
+    result = idx.provenance_neighbours("A", "sources", 3)
+
+    # Assert
+    ids = [n["id"] for n in result]
+    assert ids == ["B", "C", "D"]
+
+
+# ---------------------------------------------------------------------------
+# Document lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_add_document_registers_across_indexes():
+    # Arrange
+    idx = CorpusIndex()
+
+    # Act
+    warnings = _add(idx, "A", title="Alpha", path="alpha.md")
+
+    # Assert
+    assert warnings == []
+    assert idx.has_document("A")
+    assert idx.relpath_of("A") == Path("alpha.md")
+    assert idx.id_by_slug("alpha") == "A"
+    assert idx.id_by_relpath(Path("alpha.md")) == "A"
+    assert idx.title_by_id("A") == "Alpha"
+    assert idx.get_cached_meta("A") is not None
+
+
+def test_add_document_warns_on_dangling_source():
+    # Arrange / Act
+    idx = CorpusIndex()
+    warnings = _add(idx, "A", title="Alpha", sources=["nope"])
+
+    # Assert
+    assert warnings == [MISSING_SOURCE_WARNING.format("nope")]
+    assert idx.has_unresolved_source("nope")
+
+
+def test_add_document_auto_resolves_prior_danglers():
+    # Arrange — B references A before A exists
+    idx = CorpusIndex()
+    _add(idx, "B", title="Bee", sources=["A"])
+    assert idx.has_unresolved_source("A")
+
+    # Act — creating A promotes B's reference to resolved
+    _add(idx, "A", title="Aay")
+
+    # Assert
+    assert not idx.has_unresolved_source("A")
+    assert idx.derived_docs("A") == {"B"}
+
+
+def test_remove_document_clears_indexes_and_reorphans_derived():
+    # Arrange — B derives from A
+    idx = CorpusIndex()
+    _add(idx, "A", title="Aay")
+    _add(idx, "B", title="Bee", sources=["A"])
+    assert idx.derived_docs("A") == {"B"}
+
+    # Act — removing the source A re-orphans B's reference
+    idx.remove_document("A")
+
+    # Assert
+    assert not idx.has_document("A")
+    assert idx.id_by_slug("aay") is None
+    assert idx.get_cached_meta("A") is None
+    assert idx.derived_docs("A") == set()
+    assert idx.has_unresolved_source("A")
+
+
+def test_replace_provenance_swaps_sources_and_reports_missing():
+    # Arrange — A derives from B
+    idx = CorpusIndex()
+    _add(idx, "B", title="Bee")
+    _add(idx, "C", title="Cee")
+    _add(idx, "A", title="Aay", sources=["B"])
+    assert idx.derived_docs("B") == {"A"}
+
+    # Act — repoint A at C plus a missing id
+    warnings = idx.replace_provenance("A", ["C", "gone"])
+
+    # Assert
+    assert idx.doc_sources("A") == ["C", "gone"]
+    assert idx.derived_docs("B") == set()  # old reverse edge dropped
+    assert idx.derived_docs("C") == {"A"}
+    assert warnings == [MISSING_SOURCE_WARNING.format("gone")]
+
+
+# ---------------------------------------------------------------------------
+# rebuild — whole-corpus scan
+# ---------------------------------------------------------------------------
+
+
+def _note(doc_id: str, title: str, **fm: object) -> ScannedNote:
+    return ScannedNote(
+        doc_id=doc_id,
+        title=title,
+        frontmatter={"title": title, **fm},
+        rel_path=Path(f"{doc_id}.md"),
+    )
+
+
+def test_rebuild_populates_indexes_and_provenance_from_scan():
+    # Arrange — two notes, one derived from the other. rebuild() normalizes
+    # derived_from_ids through the lenient UUID validator (unlike add_document),
+    # so the ids must be real UUIDs to survive the scan.
+    a_id = "11111111-1111-4111-8111-111111111111"
+    b_id = "22222222-2222-4222-8222-222222222222"
+    idx = CorpusIndex()
+    scanned = [
+        _note(a_id, "Aay"),
+        _note(b_id, "Bee", derived_from_ids=[a_id]),
+    ]
+
+    # Act
+    idx.rebuild(scanned)
+
+    # Assert — core maps + cross-pass provenance wiring
+    assert idx.has_document(a_id) and idx.has_document(b_id)
+    assert idx.id_by_slug("bee") == b_id
+    assert idx.get_cached_meta(b_id) is not None
+    assert idx.doc_sources(b_id) == [a_id]
+    assert idx.derived_docs(a_id) == {b_id}
+    assert idx.provenance_neighbours(b_id, "sources", 1) == [{"id": a_id, "title": "Aay"}]
+
+
+def test_rebuild_clears_prior_state():
+    # Arrange
+    idx = CorpusIndex()
+    idx.rebuild([_note("A", "Aay"), _note("B", "Bee")])
+
+    # Act — a second scan with a smaller corpus
+    idx.rebuild([_note("A", "Aay")])
+
+    # Assert — the dropped note is gone, no accumulation
+    assert idx.has_document("A")
+    assert not idx.has_document("B")
+    assert idx.id_by_slug("bee") is None
+
+
+def test_rebuild_counts_source_url_collisions_first_writer_wins():
+    # Arrange — two notes claiming the same source_url
+    url = "https://example.com/page"
+    idx = CorpusIndex()
+
+    # Act
+    idx.rebuild(
+        [
+            _note("first", "First", source_url=url),
+            _note("second", "Second", source_url=url),
+        ]
+    )
+
+    # Assert — one duplicate counted, first note keeps ownership
+    assert idx.duplicate_url_count == 1
+    from lithos.frontmatter_codec import normalize_url
+
+    assert idx.source_url_owner(normalize_url(url)) == "first"


### PR DESCRIPTION
## What

**PR4b closes task `ebaf33bc`** — the behavioural half of the CorpusIndex extraction (PR4a was #393). It is **behaviour-neutral**. The design call — discussed and recorded on the task — was to collapse the *code* duplication, **not** the two stores.

The in-memory CorpusIndex provenance maps and the `edges.db` projection answer different questions: frontmatter-native lineage that works **LCMA-off** and is **multi-hop / sub-linear**, vs. the LCMA typed-edge table. Merging them onto `edges.db` would regress LCMA-off provenance and force BFS-over-SQLite (against the efficiency rule) — so both stay, and the collapse targets the code smell instead.

## Changes

**`_bfs_provenance` → `CorpusIndex.provenance_neighbours`.** The BFS was a free function in `tools/read_search.py` reaching into the manager, yet it already read *only* CorpusIndex-owned state (`doc_sources` / `derived_docs` / `has_document` / `title_by_id`), and `lithos_related` was its sole caller. It becomes a public method on the map owner. `KnowledgeManager` exposes a thin `provenance_neighbours` delegator; `lithos_related` calls it. `read_search.py` sheds its now-unused `collections` and `KnowledgeManager` imports. Logic is **verbatim** — the `sources` direction still guards `has_document` (dangling refs excluded), `derived` does not, and the result is still sorted by id with titles resolved.

**Delete scouts' `_CachedMetaView`.** It was a 7-field re-projection of the public `CachedMeta`; scouts now use `CachedMeta` directly. Its one transform — `access_scope or "shared"` — was **inert**: `_passes_access_scope` already treats `None` / `""` / `"shared"` identically, so no normalisation is needed at the seam.

## Size & metrics

`read_search.py` 796→730, `scouts.py` 949→927, `corpus_index.py` 710→764, `knowledge.py` 1267→1273 — **net −28 production lines**. Everything held:

| metric | value |
|---|---|
| cross_component_edges | 68 (unchanged) |
| component_cycles / module_cycles | 0 / 1 (unchanged) |
| modules_over_800_lines | 11 (unchanged) |
| cross_module_private_refs | 32 (unchanged) |
| tests_private_imports | 87 (unchanged — new suite reaches no privates) |

## Tests

New `tests/test_corpus_index.py` — **15 tests, public API only** (this is also the reviewer's requested direct `CorpusIndex` coverage from PR4a):
- `provenance_neighbours`: single/multi-hop, both directions, dangling-source guard, diamond dedup, start-exclusion + id-sort, empty case.
- Document lifecycle: `add_document` (index registration, dangling-source warnings, auto-resolve of prior danglers), `remove_document` (clear + re-orphan derived).
- `replace_provenance` (swap sources + report missing).
- `rebuild` (cross-pass provenance wiring, clear-on-rescan, source-url collision counting).

The existing `lithos_related` coverage in `test_integration_conformance.py` and `test_provenance_conformance.py` is the golden safety net for behaviour-neutrality — both pass unchanged.

## Follow-up (separate, not in this PR)

The two provenance representations remain dual-maintained by design. Whether to make the LCMA cognitive layer mandatory — which would let one store win — is a **product decision** tracked as task `49444309`, deliberately not folded into a provenance refactor.

## Verification

- `make check` — **1608 passed**, typecheck + lint clean
- `make test-integration` — **454 passed**
- `make diagrams` — **48 guardrails**
- `lint-imports` — 3 contracts kept
