### PR TITLE
refactor: scout registry + shared gating for retrieve (PR5a, task c36fbdb6)

### DIFF
--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -16,8 +16,8 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.enrich` | L | 1 | 0 |
 | `lithos.lcma.entities` | M | 0 | 1 |
 | `lithos.lcma.migrations` | S | 1 | 1 |
-| `lithos.lcma.retrieve` | L | 0 | 1 |
-| `lithos.lcma.scouts` | L | 0 | 11 |
+| `lithos.lcma.retrieve` | M | 0 | 1 |
+| `lithos.lcma.scouts` | L | 2 | 11 |
 | `lithos.lcma.stats` | L | 1 | 0 |
 | `lithos.lcma.utils` | S | 1 | 1 |
 
@@ -51,6 +51,8 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 - def `scout_coactivation` — Find nodes frequently co-occurring with seed nodes in past retrievals.
 - def `scout_source_url` — Find notes from the same URL domain as seed notes.
 - def `scout_contradictions` — Query contradiction edges connected to seed nodes.
+- class `ScoutContext` — The uniform input every scout receives from the retrieve orchestrator.
+- class `ScoutSpec` — One entry in the scout registry.
 
 ### `lithos.lcma.stats`
 - class `StatsStore` — Lazily-created SQLite store for LCMA retrieval statistics.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -52,8 +52,8 @@
         "max_function": "lithos.knowledge.KnowledgeManager.update"
       },
       "LCMA": {
-        "functions_over_10": 21,
-        "max_complexity": 51,
+        "functions_over_10": 16,
+        "max_complexity": 39,
         "max_function": "lithos.lcma.retrieve._run_retrieve_impl"
       },
       "Logging": {
@@ -77,7 +77,7 @@
         "max_function": "lithos.telemetry.setup_telemetry"
       }
     },
-    "functions_over_10": 65,
+    "functions_over_10": 60,
     "top_functions": [
       {
         "complexity": 65,
@@ -88,7 +88,7 @@
         "qualname": "lithos.knowledge.KnowledgeManager.update"
       },
       {
-        "complexity": 51,
+        "complexity": 39,
         "qualname": "lithos.lcma.retrieve._run_retrieve_impl"
       },
       {
@@ -98,10 +98,6 @@
       {
         "complexity": 30,
         "qualname": "lithos.tools.read_search.register.lithos_list"
-      },
-      {
-        "complexity": 27,
-        "qualname": "lithos.lcma.scouts.scout_graph"
       },
       {
         "complexity": 26,
@@ -118,9 +114,13 @@
       {
         "complexity": 25,
         "qualname": "lithos.tools.notes.register.lithos_note_update"
+      },
+      {
+        "complexity": 23,
+        "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 720
+    "total_functions": 724
   },
   "domain": {
     "associations": 26,
@@ -251,7 +251,6 @@
       "lithos.lcma.enrich -> lithos.telemetry._LithosMetrics",
       "lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id",
       "lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics",
-      "lithos.lcma.scouts -> lithos.graph.KnowledgeGraph._resolve_link",
       "lithos.lcma.stats -> lithos.telemetry._LithosMetrics",
       "lithos.tools.agents -> lithos.server.LithosServer._emit",
       "lithos.tools.findings_stats -> lithos.server.LithosServer._cached_active_claims",
@@ -262,7 +261,7 @@
       "lithos.tools.tasks -> lithos.server.LithosServer._apply_task_feedback",
       "lithos.tools.tasks -> lithos.server.LithosServer._validate_task_feedback"
     ],
-    "cross_module_private_refs": 32,
+    "cross_module_private_refs": 31,
     "tests_private_detail": [
       "tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)",
       "tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)",
@@ -400,14 +399,14 @@
         "sloc": 1654
       },
       "LCMA": {
-        "classes": 4,
-        "functions": 128,
+        "classes": 7,
+        "functions": 132,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4513,
+        "lines": 4511,
         "modules": 9,
-        "public_symbols": 20,
-        "sloc": 3639
+        "public_symbols": 22,
+        "sloc": 3620
       },
       "Logging": {
         "classes": 1,
@@ -465,13 +464,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23745,
+    "total_lines": 23743,
     "total_modules": 40,
-    "total_sloc": 19101
+    "total_sloc": 19082
   },
   "tests": {
     "ratio": 1.87,
-    "src_lines": 23745,
-    "test_lines": 44345
+    "src_lines": 23743,
+    "test_lines": 44352
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -471,6 +471,6 @@
   "tests": {
     "ratio": 1.87,
     "src_lines": 23743,
-    "test_lines": 44352
+    "test_lines": 44359
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -151,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.87** (44352 test lines / 23743 source lines)
+- Test-to-source line ratio: **1.87** (44359 test lines / 23743 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -13,7 +13,7 @@ lower a budget after improving the code to lock in the gain.
 |---|---:|---:|---:|
 | `component_cycles` | 0 | 0 | 0 |
 | `cross_component_edges` | 68 | 68 | 0 |
-| `cross_module_private_refs` | 32 | 42 | 10 |
+| `cross_module_private_refs` | 31 | 42 | 11 |
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
@@ -44,7 +44,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 9 | 4513 | 3639 | 1 | 11 | 0.92 | 51 (`lithos.lcma.retrieve._run_retrieve_impl`) | 21 |
+| LCMA | 9 | 4511 | 3620 | 1 | 11 | 0.92 | 39 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **40**, lines: **23745**, SLOC: **19101**
+- Modules: **40**, lines: **23743**, SLOC: **19082**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -69,7 +69,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **720**, cyclomatic > 10: **65**
+- Functions: **724**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -77,21 +77,21 @@ Top 10 most complex functions:
 |---:|---|
 | 65 | `lithos.tools.notes.register.lithos_write` |
 | 62 | `lithos.knowledge.KnowledgeManager.update` |
-| 51 | `lithos.lcma.retrieve._run_retrieve_impl` |
+| 39 | `lithos.lcma.retrieve._run_retrieve_impl` |
 | 33 | `lithos.search.SearchEngine.graph_search` |
 | 30 | `lithos.tools.read_search.register.lithos_list` |
-| 27 | `lithos.lcma.scouts.scout_graph` |
 | 26 | `lithos.knowledge.KnowledgeManager.create` |
 | 26 | `lithos.server.LithosServer._validate_task_feedback` |
 | 25 | `lithos.cognitive_memory.CognitiveMemory.cache_lookup` |
 | 25 | `lithos.tools.notes.register.lithos_note_update` |
+| 23 | `lithos.search.TantivyIndex.search` |
 
 ## Seams
 
 Private-name reaches across module seams. Both counts can be pinned as
 `[budgets]` ratchets (`cross_module_private_refs`, `tests_private_imports`).
 
-- Cross-module private refs (src): **32**
+- Cross-module private refs (src): **31**
   - `lithos.tools.tasks -> lithos.server.LithosServer._emit (x8)`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._config (x2)`
   - `lithos.tools.read_search -> lithos.server.LithosServer._config (x2)`
@@ -105,7 +105,6 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.lcma.enrich -> lithos.telemetry._LithosMetrics`
   - `lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id`
   - `lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics`
-  - `lithos.lcma.scouts -> lithos.graph.KnowledgeGraph._resolve_link`
   - `lithos.lcma.stats -> lithos.telemetry._LithosMetrics`
   - `lithos.tools.agents -> lithos.server.LithosServer._emit`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._cached_active_claims`
@@ -152,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.87** (44345 test lines / 23745 source lines)
+- Test-to-source line ratio: **1.87** (44352 test lines / 23743 source lines)

--- a/src/lithos/graph.py
+++ b/src/lithos/graph.py
@@ -297,7 +297,7 @@ class KnowledgeGraph:
 
         # Add edges for wiki-links
         for link in doc.links:
-            target_node = self._resolve_link(link.target)
+            target_node = self.resolve_link(link.target)
             if target_node:
                 self.graph.add_edge(node_id, target_node, link_text=link.target)
             else:
@@ -411,7 +411,7 @@ class KnowledgeGraph:
             logger.debug("graph remove_document: doc_id=%s not found (no-op)", doc_id)
 
     @traced("lithos.graph.resolve_link")
-    def _resolve_link(self, target: str) -> str | None:
+    def resolve_link(self, target: str) -> str | None:
         """Resolve a wiki-link target to a node ID.
 
         Resolution precedence:

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import collections
+import dataclasses
 import itertools
 import logging
 import re
@@ -27,17 +28,10 @@ from typing import TYPE_CHECKING
 from lithos.errors import ScoutFailure
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
-    scout_coactivation,
+    SCOUT_CONTRADICTIONS,
+    SCOUT_REGISTRY,
+    ScoutContext,
     scout_contradictions,
-    scout_exact_alias,
-    scout_freshness,
-    scout_graph,
-    scout_lexical,
-    scout_provenance,
-    scout_source_url,
-    scout_tags_recency,
-    scout_task_context,
-    scout_vector,
 )
 from lithos.lcma.stats import StatsStore, _generate_receipt_id
 from lithos.lcma.utils import Candidate, merge_and_normalize
@@ -297,6 +291,47 @@ async def compute_temperature(
     return temperature
 
 
+def _log_scout_failure(name: str, cause: BaseException) -> None:
+    """Record a per-scout backend failure (ADR-0005: one bad scout can't kill retrieve).
+
+    Raised-and-caught so the log line carries :class:`ScoutFailure` context. This is
+    the single seam where degraded-mode reporting will collect failed scouts.
+    """
+    try:
+        raise ScoutFailure(scout=name, cause=cause) from cause
+    except ScoutFailure as exc:
+        logger.warning(
+            "run_retrieve: scout failed",
+            extra={"scout": name, "error": str(exc.cause)},
+            exc_info=True,
+        )
+
+
+def _record_scout_success(
+    name: str,
+    result: list[Candidate],
+    duration_ms: float,
+    *,
+    all_candidates: list[Candidate],
+    executed_scouts: set[str],
+) -> None:
+    """Fold one scout's candidates into the pool and mark it fired.
+
+    ``duration_ms`` is the scout's Phase B latency, or its share of the Phase A
+    wall-clock (all Phase A scouts share one gather duration). A scout that ran and
+    returned ``[]`` still counts as fired in the audit trail.
+    """
+    executed_scouts.add(name)
+    all_candidates.extend(result)
+    if _HAS_TELEMETRY and _lithos_metrics is not None:
+        _lithos_metrics.lcma_scout_duration.record(duration_ms, {"scout": name})
+        _lithos_metrics.lcma_scout_candidates.record(len(result), {"scout": name})
+    logger.debug(
+        "run_retrieve: scout completed",
+        extra={"scout": name, "candidates": len(result)},
+    )
+
+
 async def _run_retrieve_impl(
     *,
     query: str,
@@ -363,78 +398,53 @@ async def _run_retrieve_impl(
 
     try:
         # ── Phase A: parallel scouts ──────────────────────────────
-        # All scouts receive the same set of caller-supplied filters
-        # (namespace, scope, tags, path_prefix) so they enforce a
-        # consistent global view, regardless of which backend they wrap.
-        scout_kw = {
-            "namespace_filter": namespace_filter,
-            "agent_id": agent_id,
-            "task_id": task_id,
-            "tags": tags,
-            "path_prefix": path_prefix,
-        }
-
-        # Phase A scout list — keep names parallel to coros so we can mark
-        # each one as "executed" if it ran without raising. A scout that
-        # ran and returned [] still counts as fired in the audit trail.
-        from collections.abc import Awaitable
-
-        phase_a_names: list[str] = [
-            "scout_vector",
-            "scout_lexical",
-            "scout_exact_alias",
-            "scout_tags_recency",
-            "scout_freshness",
-        ]
-        phase_a_coros: list[Awaitable[list[Candidate]]] = [
-            scout_vector(query, search, knowledge, limit=limit, **scout_kw),
-            scout_lexical(query, search, knowledge, limit=limit, **scout_kw),
-            scout_exact_alias(query, graph, knowledge, limit=limit, **scout_kw),
-            scout_tags_recency(query, knowledge, limit=limit, **scout_kw),
-            scout_freshness(query, knowledge, limit=limit, **scout_kw),
-        ]
-        # task_context only when task_id provided
-        if task_id is not None:
-            phase_a_names.append("scout_task_context")
-            phase_a_coros.append(
-                scout_task_context(coordination, knowledge, limit=limit, **scout_kw)
-            )
-
-        _phase_a_start = time.perf_counter()
-        phase_a_results = await asyncio.gather(*phase_a_coros, return_exceptions=True)
-        _phase_a_elapsed = time.perf_counter() - _phase_a_start
-
-        # Collect successful results AND track which scouts ran cleanly.
+        # Every scout receives the same caller-supplied filters (namespace, scope,
+        # tags, path_prefix) via the shared ScoutContext, so they enforce a
+        # consistent global view regardless of which backend they wrap.
+        base_ctx = ScoutContext(
+            query=query,
+            seed_ids=[],
+            search=search,
+            knowledge=knowledge,
+            graph=graph,
+            projection=projection,
+            stats_store=stats_store,
+            coordination=coordination,
+            limit=limit,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
+        )
         executed_scouts: set[str] = set()
         all_candidates: list[Candidate] = []
-        for name, result in zip(phase_a_names, phase_a_results, strict=True):
+
+        # scout_task_context only participates when a task_id was supplied.
+        phase_a = [
+            spec
+            for spec in SCOUT_REGISTRY
+            if spec.phase == "A" and (not spec.requires_task_id or task_id is not None)
+        ]
+        _phase_a_start = time.perf_counter()
+        phase_a_results = await asyncio.gather(
+            *(spec.run(base_ctx) for spec in phase_a), return_exceptions=True
+        )
+        _phase_a_elapsed = time.perf_counter() - _phase_a_start
+
+        # Phase A scouts run concurrently, so they share one wall-clock
+        # (_phase_a_elapsed): each scout's telemetry records its *share* of that
+        # duration, not an individual latency (only Phase B latencies are per-scout).
+        for spec, result in zip(phase_a, phase_a_results, strict=True):
             if isinstance(result, BaseException):
-                # ADR-0005 contract: per-scout failures are caught here so a
-                # single misbehaving backend cannot kill the whole retrieve.
-                # Anything escaping is a CognitiveMemoryError and propagates
-                # to the caller.
-                try:
-                    raise ScoutFailure(scout=name, cause=result) from result
-                except ScoutFailure as scout_err:
-                    logger.warning(
-                        "run_retrieve: phase A scout failed",
-                        extra={"scout": name, "error": str(scout_err.cause)},
-                        exc_info=True,
-                    )
+                _log_scout_failure(spec.name, result)
                 continue
-            executed_scouts.add(name)
-            all_candidates.extend(result)
-            if _HAS_TELEMETRY and _lithos_metrics is not None:
-                # Phase A scouts run concurrently via asyncio.gather, so all scouts
-                # share the same wall-clock elapsed time (_phase_a_elapsed). This
-                # records each scout's *share* of the Phase A wall-clock duration,
-                # NOT its individual latency. Per-scout latencies are only meaningful
-                # for Phase B scouts, which run sequentially.
-                _lithos_metrics.lcma_scout_duration.record(_phase_a_elapsed * 1000, {"scout": name})
-                _lithos_metrics.lcma_scout_candidates.record(len(result), {"scout": name})
-            logger.debug(
-                "run_retrieve: phase A scout completed",
-                extra={"scout": name, "candidates": len(result)},
+            _record_scout_success(
+                spec.name,
+                result,
+                _phase_a_elapsed * 1000,
+                all_candidates=all_candidates,
+                executed_scouts=executed_scouts,
             )
 
         # ── Phase A normalisation for provenance seeding ──────────
@@ -458,127 +468,25 @@ async def _run_retrieve_impl(
             extra={"receipt_id": receipt_id, "seed_count": len(seed_ids)},
         )
         if seed_ids:
-            try:
+            seeded_ctx = dataclasses.replace(base_ctx, seed_ids=seed_ids)
+            for spec in (s for s in SCOUT_REGISTRY if s.phase == "B"):
                 _t = time.perf_counter()
-                prov_candidates = await scout_provenance(
-                    seed_ids, knowledge, limit=limit, **scout_kw
-                )
-                executed_scouts.add("scout_provenance")
-                all_candidates.extend(prov_candidates)
-                if _HAS_TELEMETRY and _lithos_metrics is not None:
-                    _lithos_metrics.lcma_scout_duration.record(
-                        (time.perf_counter() - _t) * 1000, {"scout": "scout_provenance"}
-                    )
-                    _lithos_metrics.lcma_scout_candidates.record(
-                        len(prov_candidates), {"scout": "scout_provenance"}
-                    )
-                logger.debug(
-                    "run_retrieve: phase B scout completed",
-                    extra={"scout": "scout_provenance", "candidates": len(prov_candidates)},
-                )
-            except Exception as exc:
-                # ADR-0005 contract: per-scout failures are caught here so a
-                # single misbehaving backend cannot kill the whole retrieve.
-                # Anything escaping is a CognitiveMemoryError and propagates
-                # to the caller.
                 try:
-                    raise ScoutFailure(scout="scout_provenance", cause=exc) from exc
-                except ScoutFailure:
-                    logger.warning(
-                        "run_retrieve: phase B scout failed",
-                        extra={"scout": "scout_provenance"},
-                        exc_info=True,
-                    )
+                    result = await spec.run(seeded_ctx)
+                except Exception as exc:
+                    _log_scout_failure(spec.name, exc)
+                    continue
+                _record_scout_success(
+                    spec.name,
+                    result,
+                    (time.perf_counter() - _t) * 1000,
+                    all_candidates=all_candidates,
+                    executed_scouts=executed_scouts,
+                )
 
-            try:
-                _t = time.perf_counter()
-                graph_candidates = await scout_graph(
-                    seed_ids, graph, projection, knowledge, limit=limit, **scout_kw
-                )
-                executed_scouts.add("scout_graph")
-                all_candidates.extend(graph_candidates)
-                if _HAS_TELEMETRY and _lithos_metrics is not None:
-                    _lithos_metrics.lcma_scout_duration.record(
-                        (time.perf_counter() - _t) * 1000, {"scout": "scout_graph"}
-                    )
-                    _lithos_metrics.lcma_scout_candidates.record(
-                        len(graph_candidates), {"scout": "scout_graph"}
-                    )
-                logger.debug(
-                    "run_retrieve: phase B scout completed",
-                    extra={"scout": "scout_graph", "candidates": len(graph_candidates)},
-                )
-            except Exception as exc:
-                # ADR-0005 contract: per-scout failures are caught here.
-                try:
-                    raise ScoutFailure(scout="scout_graph", cause=exc) from exc
-                except ScoutFailure:
-                    logger.warning(
-                        "run_retrieve: phase B scout failed",
-                        extra={"scout": "scout_graph"},
-                        exc_info=True,
-                    )
-
-            try:
-                _t = time.perf_counter()
-                coact_candidates = await scout_coactivation(
-                    seed_ids, stats_store, knowledge, limit=limit, **scout_kw
-                )
-                executed_scouts.add("scout_coactivation")
-                all_candidates.extend(coact_candidates)
-                if _HAS_TELEMETRY and _lithos_metrics is not None:
-                    _lithos_metrics.lcma_scout_duration.record(
-                        (time.perf_counter() - _t) * 1000, {"scout": "scout_coactivation"}
-                    )
-                    _lithos_metrics.lcma_scout_candidates.record(
-                        len(coact_candidates), {"scout": "scout_coactivation"}
-                    )
-                logger.debug(
-                    "run_retrieve: phase B scout completed",
-                    extra={"scout": "scout_coactivation", "candidates": len(coact_candidates)},
-                )
-            except Exception as exc:
-                # ADR-0005 contract: per-scout failures are caught here.
-                try:
-                    raise ScoutFailure(scout="scout_coactivation", cause=exc) from exc
-                except ScoutFailure:
-                    logger.warning(
-                        "run_retrieve: phase B scout failed",
-                        extra={"scout": "scout_coactivation"},
-                        exc_info=True,
-                    )
-
-            try:
-                _t = time.perf_counter()
-                src_url_candidates = await scout_source_url(
-                    seed_ids, knowledge, limit=limit, **scout_kw
-                )
-                executed_scouts.add("scout_source_url")
-                all_candidates.extend(src_url_candidates)
-                if _HAS_TELEMETRY and _lithos_metrics is not None:
-                    _lithos_metrics.lcma_scout_duration.record(
-                        (time.perf_counter() - _t) * 1000, {"scout": "scout_source_url"}
-                    )
-                    _lithos_metrics.lcma_scout_candidates.record(
-                        len(src_url_candidates), {"scout": "scout_source_url"}
-                    )
-                logger.debug(
-                    "run_retrieve: phase B scout completed",
-                    extra={"scout": "scout_source_url", "candidates": len(src_url_candidates)},
-                )
-            except Exception as exc:
-                # ADR-0005 contract: per-scout failures are caught here.
-                try:
-                    raise ScoutFailure(scout="scout_source_url", cause=exc) from exc
-                except ScoutFailure:
-                    logger.warning(
-                        "run_retrieve: phase B scout failed",
-                        extra={"scout": "scout_source_url"},
-                        exc_info=True,
-                    )
-
-        # Contradictions — only fire when surface_conflicts is True
-        conflicts_found: list[dict[str, object]] = []
+        # Contradictions — a conflict producer (not a candidate scout), fired only
+        # when surface_conflicts is set. Recorded in executed_scouts so it shows up
+        # in the scouts_fired audit trail (it was previously never recorded).
         if surface_conflicts:
             try:
                 conflicts_found = await scout_contradictions(
@@ -589,25 +497,17 @@ async def _run_retrieve_impl(
                     agent_id=agent_id,
                     task_id=task_id,
                 )
+                executed_scouts.add(SCOUT_CONTRADICTIONS)
                 logger.debug(
                     "run_retrieve: contradictions surfaced",
                     extra={"conflict_count": len(conflicts_found)},
                 )
             except Exception as exc:
-                # ADR-0005 contract: per-scout failures are caught here.
-                try:
-                    raise ScoutFailure(scout="scout_contradictions", cause=exc) from exc
-                except ScoutFailure:
-                    logger.warning(
-                        "run_retrieve: phase B scout failed",
-                        extra={"scout": "scout_contradictions"},
-                        exc_info=True,
-                    )
+                _log_scout_failure(SCOUT_CONTRADICTIONS, exc)
 
-        # Record scouts_fired using canonical names in order. A scout
-        # appears here iff it executed without raising — empty result
-        # sets still count as "fired" so the audit trail accurately
-        # reflects what the pipeline did.
+        # Record scouts_fired using canonical names in order. A scout appears here
+        # iff it executed without raising — empty result sets still count as "fired"
+        # so the audit trail accurately reflects what the pipeline did.
         scouts_fired = [s for s in ALL_SCOUT_NAMES if s in executed_scouts]
 
         # ── Merge & Normalise all candidates ──────────────────────

--- a/src/lithos/lcma/scouts.py
+++ b/src/lithos/lcma/scouts.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypedDict
 from urllib.parse import urlparse
 
 from lithos.lcma.utils import Candidate
@@ -43,19 +45,10 @@ SCOUT_TASK_CONTEXT = "scout_task_context"
 SCOUT_GRAPH = "scout_graph"
 SCOUT_COACTIVATION = "scout_coactivation"
 SCOUT_SOURCE_URL = "scout_source_url"
+SCOUT_CONTRADICTIONS = "scout_contradictions"
 
-ALL_SCOUT_NAMES = [
-    SCOUT_VECTOR,
-    SCOUT_LEXICAL,
-    SCOUT_EXACT_ALIAS,
-    SCOUT_TAGS_RECENCY,
-    SCOUT_FRESHNESS,
-    SCOUT_PROVENANCE,
-    SCOUT_TASK_CONTEXT,
-    SCOUT_GRAPH,
-    SCOUT_COACTIVATION,
-    SCOUT_SOURCE_URL,
-]
+# ``ALL_SCOUT_NAMES`` and the registry that drives the orchestrator are defined
+# at the foot of this module, once every scout function exists — see SCOUT_REGISTRY.
 
 # Keywords that trigger freshness boost
 _FRESHNESS_KEYWORDS = re.compile(r"\b(update|refresh|recheck|verify|latest)\b", re.IGNORECASE)
@@ -130,6 +123,44 @@ def _passes_path_prefix(meta_path: object | None, path_prefix: str | None) -> bo
     return str(meta_path).startswith(path_prefix)
 
 
+def _gate(
+    meta: CachedMeta | None,
+    *,
+    namespace_filter: list[str] | None,
+    agent_id: str | None,
+    task_id: str | None,
+    tags: list[str] | None = None,
+    path_prefix: str | None = None,
+    check_tags: bool = True,
+    check_path: bool = True,
+) -> bool:
+    """Apply the standard candidate-gating chain to one hit's cached metadata.
+
+    Consolidates the status → namespace → access_scope → tags → path_prefix chain
+    that every candidate-producing scout runs on each hit (the block was copied
+    verbatim in eight scouts). ``check_tags``/``check_path`` default on; the
+    contradiction scout turns them off because its request shape carries no
+    ``tags``/``path_prefix``. Returns True when the note passes every enabled
+    check.
+    """
+    if not _passes_status_filter(meta, ["quarantined"]):
+        return False
+    ns = meta.namespace if meta else None
+    if not _passes_namespace_filter(ns, namespace_filter):
+        return False
+    if not _passes_access_scope(
+        meta.access_scope if meta else None,
+        meta.author if meta else None,
+        meta.source if meta else None,
+        agent_id,
+        task_id,
+    ):
+        return False
+    if check_tags and not _passes_tags_filter(meta.tags if meta else None, tags):
+        return False
+    return not (check_path and not _passes_path_prefix(meta.path if meta else None, path_prefix))
+
+
 # ---------------------------------------------------------------------------
 # Scout implementations
 # ---------------------------------------------------------------------------
@@ -159,22 +190,14 @@ async def scout_vector(
     for r in results:
         doc_id = r.id
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -218,22 +241,14 @@ async def scout_lexical(
     for r in results:
         doc_id = r.id
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -267,8 +282,8 @@ async def scout_exact_alias(
     """Resolve query via wiki-link resolution, UUID-prefix, and slug matching."""
     found_ids: list[str] = []
 
-    # 1. KnowledgeGraph._resolve_link (node_id == doc_id in graph)
-    resolved = graph._resolve_link(query)
+    # 1. KnowledgeGraph.resolve_link (node_id == doc_id in graph)
+    resolved = graph.resolve_link(query)
     if resolved and knowledge.has_document(resolved):
         found_ids.append(resolved)
 
@@ -287,22 +302,14 @@ async def scout_exact_alias(
     candidates: list[Candidate] = []
     for doc_id in found_ids:
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -458,22 +465,14 @@ async def scout_provenance(
         if not knowledge.has_document(doc_id):
             continue
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         # All provenance hits get equal raw score
         candidates.append(
@@ -536,22 +535,14 @@ async def scout_task_context(
         if not knowledge.has_document(doc_id):
             continue
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -627,22 +618,14 @@ async def scout_graph(
         if not knowledge.has_document(nid):
             continue
         meta = _get_cached_meta(knowledge, nid)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -699,22 +682,14 @@ async def scout_coactivation(
         if not knowledge.has_document(node_id):
             continue
         meta = _get_cached_meta(knowledge, node_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -790,22 +765,14 @@ async def scout_source_url(
         if not knowledge.has_document(doc_id):
             continue
         meta = _get_cached_meta(knowledge, doc_id)
-        if not _passes_status_filter(meta, ["quarantined"]):
-            continue
-        ns = meta.namespace if meta else None
-        if not _passes_namespace_filter(ns, namespace_filter):
-            continue
-        if not _passes_access_scope(
-            meta.access_scope if meta else None,
-            meta.author if meta else None,
-            meta.source if meta else None,
-            agent_id,
-            task_id,
+        if not _gate(
+            meta,
+            namespace_filter=namespace_filter,
+            agent_id=agent_id,
+            task_id=task_id,
+            tags=tags,
+            path_prefix=path_prefix,
         ):
-            continue
-        if not _passes_tags_filter(meta.tags if meta else None, tags):
-            continue
-        if not _passes_path_prefix(meta.path if meta else None, path_prefix):
             continue
         candidates.append(
             Candidate(
@@ -871,17 +838,13 @@ async def scout_contradictions(
 
             # Apply gating filters on the counterpart
             meta = _get_cached_meta(knowledge, counterpart_id)
-            if not _passes_status_filter(meta, ["quarantined"]):
-                continue
-            ns = meta.namespace if meta else None
-            if not _passes_namespace_filter(ns, namespace_filter):
-                continue
-            if not _passes_access_scope(
-                meta.access_scope if meta else None,
-                meta.author if meta else None,
-                meta.source if meta else None,
-                agent_id,
-                task_id,
+            if not _gate(
+                meta,
+                namespace_filter=namespace_filter,
+                agent_id=agent_id,
+                task_id=task_id,
+                check_tags=False,
+                check_path=False,
             ):
                 continue
 
@@ -925,3 +888,138 @@ def _get_cached_meta(knowledge: KnowledgeManager, doc_id: str) -> CachedMeta | N
     identically to ``"shared"``, so no normalisation is needed at the seam.
     """
     return knowledge.get_cached_meta(doc_id)
+
+
+# ---------------------------------------------------------------------------
+# Scout registry — the single source of truth the orchestrator loops over
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoutContext:
+    """The uniform input every scout receives from the retrieve orchestrator.
+
+    Bundles the query inputs (``query`` for Phase A, ``seed_ids`` for Phase B),
+    the store dependencies, and the caller-supplied filters, so a registry entry
+    is invocable as ``run(ctx)`` regardless of which subset a given scout consumes.
+    """
+
+    query: str
+    seed_ids: list[str]
+    search: SearchEngine
+    knowledge: KnowledgeManager
+    graph: KnowledgeGraph
+    projection: ProvenanceProjection
+    stats_store: StatsStore
+    coordination: CoordinationService
+    limit: int
+    namespace_filter: list[str] | None = None
+    agent_id: str | None = None
+    task_id: str | None = None
+    tags: list[str] | None = None
+    path_prefix: str | None = None
+
+
+@dataclass(frozen=True)
+class ScoutSpec:
+    """One entry in the scout registry.
+
+    ``phase`` is ``"A"`` (parallel, query-seeded) or ``"B"`` (sequential, seeded
+    from Phase A output). ``run`` adapts the uniform :class:`ScoutContext` to the
+    scout's native call. ``requires_task_id`` marks a scout that only fires when
+    the caller supplied a ``task_id`` (scout_task_context).
+    """
+
+    name: str
+    phase: Literal["A", "B"]
+    run: Callable[[ScoutContext], Awaitable[list[Candidate]]]
+    requires_task_id: bool = False
+
+
+class _ScoutFilters(TypedDict):
+    """The caller-supplied filter kwargs shared by every scout signature."""
+
+    namespace_filter: list[str] | None
+    agent_id: str | None
+    task_id: str | None
+    tags: list[str] | None
+    path_prefix: str | None
+
+
+def _filters(ctx: ScoutContext) -> _ScoutFilters:
+    """The caller-supplied filters every scout forwards, as kwargs."""
+    return {
+        "namespace_filter": ctx.namespace_filter,
+        "agent_id": ctx.agent_id,
+        "task_id": ctx.task_id,
+        "tags": ctx.tags,
+        "path_prefix": ctx.path_prefix,
+    }
+
+
+# Order is load-bearing: it fixes Phase A gather order and Phase B execution order
+# (and therefore seed/candidate determinism). scout_task_context is last in Phase A
+# and only fires when a task_id is present.
+SCOUT_REGISTRY: list[ScoutSpec] = [
+    ScoutSpec(
+        SCOUT_VECTOR,
+        "A",
+        lambda c: scout_vector(c.query, c.search, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_LEXICAL,
+        "A",
+        lambda c: scout_lexical(c.query, c.search, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_EXACT_ALIAS,
+        "A",
+        lambda c: scout_exact_alias(c.query, c.graph, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_TAGS_RECENCY,
+        "A",
+        lambda c: scout_tags_recency(c.query, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_FRESHNESS,
+        "A",
+        lambda c: scout_freshness(c.query, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_TASK_CONTEXT,
+        "A",
+        lambda c: scout_task_context(c.coordination, c.knowledge, limit=c.limit, **_filters(c)),
+        requires_task_id=True,
+    ),
+    ScoutSpec(
+        SCOUT_PROVENANCE,
+        "B",
+        lambda c: scout_provenance(c.seed_ids, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+    ScoutSpec(
+        SCOUT_GRAPH,
+        "B",
+        lambda c: scout_graph(
+            c.seed_ids, c.graph, c.projection, c.knowledge, limit=c.limit, **_filters(c)
+        ),
+    ),
+    ScoutSpec(
+        SCOUT_COACTIVATION,
+        "B",
+        lambda c: scout_coactivation(
+            c.seed_ids, c.stats_store, c.knowledge, limit=c.limit, **_filters(c)
+        ),
+    ),
+    ScoutSpec(
+        SCOUT_SOURCE_URL,
+        "B",
+        lambda c: scout_source_url(c.seed_ids, c.knowledge, limit=c.limit, **_filters(c)),
+    ),
+]
+
+# scout_contradictions is not a candidate producer (it emits conflict rows, not
+# Candidates), so it stays outside the registry loop — but it IS a canonical scout
+# for audit purposes, appended here so ``scouts_fired`` can report it. It was
+# previously absent from ALL_SCOUT_NAMES, so it could never appear in a receipt.
+ALL_SCOUT_NAMES: list[str] = [spec.name for spec in SCOUT_REGISTRY] + [SCOUT_CONTRADICTIONS]

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -392,25 +392,26 @@ class TestRetrieve:
         await memory.start()
 
         # Make every scout return [] except scout_vector which raises. The
-        # scouts are imported into ``lithos.lcma.retrieve`` at module load,
-        # so we patch them in *that* namespace, not in lithos.lcma.scouts.
+        # orchestrator invokes scouts through SCOUT_REGISTRY, whose adapters
+        # resolve the scout functions in ``lithos.lcma.scouts`` — so we patch
+        # them there, not in lithos.lcma.retrieve.
         empty_scout = AsyncMock(return_value=[])
         # Stub the projection's edge_store.compute_temperature to a no-op
         # so we don't hit the real backend either.
 
         with (
             patch(
-                "lithos.lcma.retrieve.scout_vector",
+                "lithos.lcma.scouts.scout_vector",
                 new=AsyncMock(side_effect=RuntimeError("backend down")),
             ),
-            patch("lithos.lcma.retrieve.scout_lexical", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_provenance", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_graph", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_coactivation", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_source_url", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_lexical", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_freshness", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_provenance", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_graph", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_coactivation", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_source_url", new=empty_scout),
             caplog.at_level(logging.WARNING, logger="lithos.lcma.retrieve"),
         ):
             result = await memory.retrieve("alpha", limit=5)
@@ -419,10 +420,10 @@ class TestRetrieve:
         assert result["receipt_id"]
         assert result["results"] == []
 
-        # The phase A scout warning is present; the captured exc chain is a
+        # The scout-failure warning is present; the captured exc chain is a
         # ScoutFailure naming the failed scout.
-        scout_records = [r for r in caplog.records if "phase A scout failed" in r.getMessage()]
-        assert scout_records, "expected a phase A scout failure log record"
+        scout_records = [r for r in caplog.records if "scout failed" in r.getMessage()]
+        assert scout_records, "expected a scout failure log record"
         record = scout_records[0]
         assert record.exc_info is not None
         exc = record.exc_info[1]
@@ -444,11 +445,11 @@ class TestRetrieve:
         empty_scout = AsyncMock(return_value=[])
 
         with (
-            patch("lithos.lcma.retrieve.scout_vector", new=vector_spy),
-            patch("lithos.lcma.retrieve.scout_lexical", new=lexical_spy),
-            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_vector", new=vector_spy),
+            patch("lithos.lcma.scouts.scout_lexical", new=lexical_spy),
+            patch("lithos.lcma.scouts.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_freshness", new=empty_scout),
         ):
             await memory.retrieve(
                 "alpha",
@@ -493,17 +494,17 @@ class TestRetrieve:
 
         with (
             patch(
-                "lithos.lcma.retrieve.scout_vector",
+                "lithos.lcma.scouts.scout_vector",
                 new=AsyncMock(return_value=candidates),
             ),
-            patch("lithos.lcma.retrieve.scout_lexical", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_exact_alias", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_tags_recency", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_freshness", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_provenance", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_graph", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_coactivation", new=empty_scout),
-            patch("lithos.lcma.retrieve.scout_source_url", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_lexical", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_exact_alias", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_tags_recency", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_freshness", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_provenance", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_graph", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_coactivation", new=empty_scout),
+            patch("lithos.lcma.scouts.scout_source_url", new=empty_scout),
         ):
             result = await memory.retrieve("alpha", limit=5)
 

--- a/tests/test_lcma_retrieve_integration.py
+++ b/tests/test_lcma_retrieve_integration.py
@@ -230,9 +230,10 @@ class TestWorkingMemoryIntegration:
 
 class TestScoutsFiredReceipt:
     @pytest.mark.asyncio
-    async def test_scouts_fired_contains_all_seven(self, server: LithosServer) -> None:
-        """receipts.scouts_fired contains all seven scout names when conditions met."""
-        # We need task_id for task_context scout, and a refresh keyword for freshness
+    async def test_scouts_fired_recorded(self, server: LithosServer) -> None:
+        """receipts.scouts_fired records the scouts that ran (10 candidate scouts
+        plus the contradiction audit scout are the canonical set)."""
+        # task_id enables scout_task_context; a refresh keyword enables freshness.
         await _seed_notes(server)
 
         result = await call_tool(
@@ -255,9 +256,11 @@ class TestScoutsFiredReceipt:
             row = await cursor.fetchone()
             assert row is not None
             scouts_fired = json.loads(row[0])
-            # All seven scouts should have fired (search may return empty but still fire)
-            # We check that at least the scouts that don't depend on search results are present
             assert isinstance(scouts_fired, list)
+            # The search-independent Phase A scouts always fire (they query the
+            # corpus/coordination directly, so an empty backend can't stop them).
+            for name in ("scout_tags_recency", "scout_freshness", "scout_task_context"):
+                assert name in scouts_fired
 
 
 class TestLcmaDisabled:

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -1083,7 +1083,7 @@ class TestMaxContextNodes:
         with (
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=[]),
-            patch("lithos.lcma.retrieve.scout_provenance", new_callable=AsyncMock) as mock_prov,
+            patch("lithos.lcma.scouts.scout_provenance", new_callable=AsyncMock) as mock_prov,
         ):
             mock_prov.return_value = []
             await _run_retrieve_impl(
@@ -1768,7 +1768,7 @@ class TestNewScoutsWiredInPhaseB:
         with (
             patch.object(seeded_search, "semantic_search", return_value=[]),
             patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
-            patch("lithos.lcma.retrieve.scout_graph", side_effect=RuntimeError("graph boom")),
+            patch("lithos.lcma.scouts.scout_graph", side_effect=RuntimeError("graph boom")),
         ):
             result = await _run_retrieve_impl(
                 query="alpha",

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -1478,19 +1478,23 @@ class TestContradictionSurfacing:
         eids = [c["edge_id"] for c in conflicts]  # type: ignore[union-attr]
         assert edge_id in eids
 
-        # Receipt should also record conflicts_surfaced
+        # Receipt should also record conflicts_surfaced, and scout_contradictions
+        # must appear in scouts_fired now that it ran (it was silently absent from
+        # the audit trail before the registry fix — it was never in ALL_SCOUT_NAMES
+        # nor recorded in executed_scouts).
         import aiosqlite
 
         async with aiosqlite.connect(stats_store.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT conflicts_surfaced FROM receipts WHERE id = ?",
+                "SELECT conflicts_surfaced, scouts_fired FROM receipts WHERE id = ?",
                 (result["receipt_id"],),
             )
             row = await cursor.fetchone()
         assert row is not None
         surfaced = json.loads(row["conflicts_surfaced"])
         assert len(surfaced) >= 1
+        assert "scout_contradictions" in json.loads(row["scouts_fired"])
 
     @pytest.mark.asyncio
     async def test_surface_conflicts_false_is_noop(

--- a/tests/test_scouts.py
+++ b/tests/test_scouts.py
@@ -18,6 +18,7 @@ from lithos.knowledge import KnowledgeManager
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
     SCOUT_COACTIVATION,
+    SCOUT_CONTRADICTIONS,
     SCOUT_EXACT_ALIAS,
     SCOUT_FRESHNESS,
     SCOUT_GRAPH,
@@ -1231,8 +1232,12 @@ class TestScoutContradictions:
 
 
 class TestScoutConstants:
-    def test_all_scout_names_has_ten_entries(self) -> None:
-        assert len(ALL_SCOUT_NAMES) == 10
+    def test_all_scout_names_has_eleven_entries(self) -> None:
+        # 10 candidate scouts in SCOUT_REGISTRY + scout_contradictions (a
+        # conflict producer that lives outside the registry but is a canonical
+        # scout for audit purposes).
+        assert len(ALL_SCOUT_NAMES) == 11
+        assert SCOUT_CONTRADICTIONS in ALL_SCOUT_NAMES
 
     def test_canonical_names(self) -> None:
         assert SCOUT_VECTOR == "scout_vector"
@@ -1245,6 +1250,7 @@ class TestScoutConstants:
         assert SCOUT_GRAPH == "scout_graph"
         assert SCOUT_COACTIVATION == "scout_coactivation"
         assert SCOUT_SOURCE_URL == "scout_source_url"
+        assert SCOUT_CONTRADICTIONS == "scout_contradictions"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The **structural half of task `c36fbdb6`** — a scout registry + shared gating for the LCMA retrieve pipeline. **Behaviour-neutral** except one deliberate receipt-fidelity fix (below). **PR5b** builds the degraded-mode signal on the seam this leaves.

Before, adding a scout meant touching ~6 places across two files: the ~16-line candidate-gating block was **copied verbatim in eight scouts**, the orchestrator hand-maintained parallel name/coro lists for Phase A and **four near-identical ~28-line try/except blocks** for Phase B, and `ALL_SCOUT_NAMES` was a hand-kept list that had silently drifted.

## Changes

- **Shared gate.** The status → namespace → access_scope → tags → path_prefix chain becomes one `_gate(meta, ...)`; the eight identical copies collapse to a call each, and `scout_contradictions`' three-check subset reuses it via `check_tags`/`check_path` flags. The two genuinely-slimmed variants (`tags_recency`, `freshness`) stay inline.
- **Registry.** A `ScoutContext` bundles query/seed inputs + store deps + filters; `SCOUT_REGISTRY` is an ordered list of `ScoutSpec(name, phase, run, requires_task_id)` whose `run` adapters present a uniform `run(ctx) -> list[Candidate]` interface over the scouts' heterogeneous native signatures. **Scouts keep their native signatures, so `test_scouts.py` stays an unchanged behavioural oracle.**
- **Orchestrator.** `_run_retrieve_impl` loops over the registry — Phase A gathered in parallel, Phase B sequential — with one `_record_scout_success` and one `_log_scout_failure` seam replacing the copy-pasted blocks. Per-phase telemetry semantics preserved exactly. `retrieve.py` 781 → 681.
- **`ALL_SCOUT_NAMES` is now derived** from `SCOUT_REGISTRY` (+ `scout_contradictions`, a conflict producer that sits outside the candidate loop). This **structurally fixes the drift** — `scout_contradictions` was missing from the list, so it could never appear in a receipt's `scouts_fired`.
- **`resolve_link` public.** `KnowledgeGraph._resolve_link` → `resolve_link`, retiring the last private cross-module reach from scouts.

## Behaviour & metrics

**One intended behavioural change:** `scout_contradictions` now records itself in `executed_scouts`, so a `surface_conflicts` retrieve honestly lists it in `scouts_fired` (previously it ran but was never recorded). No candidate/result shape changes.

| metric | value |
|---|---|
| cross_component_edges | 68 (unchanged) |
| component_cycles / module_cycles | 0 / 1 (unchanged) |
| modules_over_800_lines | 11 (unchanged — scouts.py was already over) |
| cross_module_private_refs | 32 → **31** (resolve_link promotion) |
| tests_private_imports | 87 (unchanged) |

## Test churn (mechanical, from the refactor)

- 25 scout patch targets repointed `lithos.lcma.retrieve.scout_*` → `lithos.lcma.scouts.scout_*` (the orchestrator now reaches scouts through the registry, not a direct import).
- The `ALL_SCOUT_NAMES` count test 10 → 11 (it had encoded the missing-`contradictions` bug).
- One failure-log assertion updated for the unified `"scout failed"` message.

## Verification

- `make check` — **1608 passed**, typecheck + lint clean
- `make test-integration` — **454 passed**
- `make diagrams` — **48 guardrails**
- `lint-imports` — 3 contracts kept

## Next (PR5b, behavioural)

Wire `ScoutFailure` into a real degraded-mode contract: `degraded`/`failed_scouts` in the retrieve envelope + a scout-failure metric, collected at the `_log_scout_failure` seam this PR leaves.
