### PR TITLE
feat: degraded-mode signal for retrieve (PR5b, task c36fbdb6)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1139,11 +1139,13 @@ PTS-style retrieval orchestrating seven scouts in parallel and reranking via a f
   ],
   "temperature": 0.5,
   "terrace_reached": 1,
-  "receipt_id": "rcpt_<short-uuid>"
+  "receipt_id": "rcpt_<short-uuid>",
+  "degraded": false,
+  "failed_scouts": []
 }
 ```
 
-The `id`/`title`/`snippet`/`score`/`path`/`source_url`/`updated_at`/`is_stale`/`derived_from_ids` keys mirror the `lithos_search` shape so clients that read only those fields work unchanged. `reasons`/`scouts`/`salience` are LCMA-only additive fields.
+The `id`/`title`/`snippet`/`score`/`path`/`source_url`/`updated_at`/`is_stale`/`derived_from_ids` keys mirror the `lithos_search` shape so clients that read only those fields work unchanged. `reasons`/`scouts`/`salience` are LCMA-only additive fields. `degraded`/`failed_scouts` are always present: `failed_scouts` lists the canonical names of any scouts whose backend raised (so one bad backend degrades rather than kills the retrieve), and `degraded` is `true` when that list is non-empty — letting a caller distinguish partial results from a genuinely empty corpus.
 
 **Receipt audit trail:** every call writes a row to `stats.db.receipts` with columns including `id`, `ts`, `query`, `namespace_filter`, `scouts_fired` (canonical names of every scout that ran cleanly — empty results still count as fired), `candidates_considered`, `final_nodes` (JSON array of `{id, reasons, scouts}` objects), `surface_conflicts`, `temperature`, and `terrace_reached`.
 

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -312,11 +312,11 @@
         "classes": 2,
         "functions": 27,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 998,
-        "lines": 998,
+        "largest_module_lines": 1000,
+        "lines": 1000,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 820
+        "sloc": 822
       },
       "Config": {
         "classes": 9,
@@ -464,13 +464,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23782,
+    "total_lines": 23784,
     "total_modules": 40,
-    "total_sloc": 19114
+    "total_sloc": 19116
   },
   "tests": {
     "ratio": 1.87,
-    "src_lines": 23782,
-    "test_lines": 44455
+    "src_lines": 23784,
+    "test_lines": 44504
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -53,7 +53,7 @@
       },
       "LCMA": {
         "functions_over_10": 16,
-        "max_complexity": 39,
+        "max_complexity": 41,
         "max_function": "lithos.lcma.retrieve._run_retrieve_impl"
       },
       "Logging": {
@@ -88,7 +88,7 @@
         "qualname": "lithos.knowledge.KnowledgeManager.update"
       },
       {
-        "complexity": 39,
+        "complexity": 41,
         "qualname": "lithos.lcma.retrieve._run_retrieve_impl"
       },
       {
@@ -120,7 +120,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 724
+    "total_functions": 725
   },
   "domain": {
     "associations": 26,
@@ -343,20 +343,20 @@
         "functions": 137,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5915,
+        "lines": 5919,
         "modules": 13,
         "public_symbols": 30,
-        "sloc": 4751
+        "sloc": 4755
       },
       "Errors": {
         "classes": 9,
         "functions": 11,
         "largest_module": "lithos.errors",
-        "largest_module_lines": 146,
-        "lines": 210,
+        "largest_module_lines": 147,
+        "lines": 211,
         "modules": 2,
         "public_symbols": 12,
-        "sloc": 151
+        "sloc": 152
       },
       "Events": {
         "classes": 3,
@@ -403,10 +403,10 @@
         "functions": 132,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1248,
-        "lines": 4511,
+        "lines": 4526,
         "modules": 9,
         "public_symbols": 22,
-        "sloc": 3620
+        "sloc": 3631
       },
       "Logging": {
         "classes": 1,
@@ -440,13 +440,13 @@
       },
       "Telemetry": {
         "classes": 8,
-        "functions": 68,
+        "functions": 69,
         "largest_module": "lithos.telemetry",
-        "largest_module_lines": 1183,
-        "lines": 1183,
+        "largest_module_lines": 1202,
+        "lines": 1202,
         "modules": 1,
         "public_symbols": 13,
-        "sloc": 909
+        "sloc": 925
       }
     },
     "max_module": "lithos.coordination",
@@ -464,13 +464,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23743,
+    "total_lines": 23782,
     "total_modules": 40,
-    "total_sloc": 19082
+    "total_sloc": 19114
   },
   "tests": {
     "ratio": 1.87,
-    "src_lines": 23743,
-    "test_lines": 44359
+    "src_lines": 23782,
+    "test_lines": 44455
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -35,7 +35,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Codec | 1 | 777 | 583 | 7 | 0 | 0.00 | 14 (`lithos.frontmatter_codec.KnowledgeMetadata.from_dict`) | 3 |
-| CognitiveMemory | 1 | 998 | 820 | 1 | 12 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 1000 | 822 | 1 | 12 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 13 | 5919 | 4755 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 16 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **40**, lines: **23782**, SLOC: **19114**
+- Modules: **40**, lines: **23784**, SLOC: **19116**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -151,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.87** (44455 test lines / 23782 source lines)
+- Test-to-source line ratio: **1.87** (44504 test lines / 23784 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -38,21 +38,21 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | CognitiveMemory | 1 | 998 | 820 | 1 | 12 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
 | Config | 1 | 371 | 281 | 10 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5915 | 4751 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 16 |
-| Errors | 2 | 210 | 151 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
+| Entrypoints | 13 | 5919 | 4755 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 16 |
+| Errors | 2 | 211 | 152 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1509 | 1223 | 7 | 3 | 0.30 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 9 | 4511 | 3620 | 1 | 11 | 0.92 | 39 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
+| LCMA | 9 | 4526 | 3631 | 1 | 11 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
-| Telemetry | 1 | 1183 | 909 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
+| Telemetry | 1 | 1202 | 925 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
 
 ## Size
 
-- Modules: **40**, lines: **23743**, SLOC: **19082**
+- Modules: **40**, lines: **23782**, SLOC: **19114**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -69,7 +69,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **724**, cyclomatic > 10: **60**
+- Functions: **725**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -77,7 +77,7 @@ Top 10 most complex functions:
 |---:|---|
 | 65 | `lithos.tools.notes.register.lithos_write` |
 | 62 | `lithos.knowledge.KnowledgeManager.update` |
-| 39 | `lithos.lcma.retrieve._run_retrieve_impl` |
+| 41 | `lithos.lcma.retrieve._run_retrieve_impl` |
 | 33 | `lithos.search.SearchEngine.graph_search` |
 | 30 | `lithos.tools.read_search.register.lithos_list` |
 | 26 | `lithos.knowledge.KnowledgeManager.create` |
@@ -151,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.87** (44359 test lines / 23743 source lines)
+- Test-to-source line ratio: **1.87** (44455 test lines / 23782 source lines)

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -327,9 +327,11 @@ class CognitiveMemory:
         around it.
 
         Errors:
-            - ``ScoutFailure`` is raised inside the orchestrator when a single
-              scout's backend fails, then **caught and logged** at one
-              documented boundary inside this method. Callers do not see it.
+            - ``ScoutFailure`` is raised when a single scout's backend fails,
+              then **caught, logged, and reported** at one documented boundary
+              inside the retrieve orchestrator (``_run_retrieve_impl``). Callers
+              never see the exception — the failed scout surfaces in the
+              envelope's ``degraded``/``failed_scouts`` fields instead.
             - ``CognitiveMemoryError`` (other subtypes — e.g. RetrieveTimeout)
               **propagates** to the caller. The MCP envelope translates it to
               an error response.

--- a/src/lithos/errors.py
+++ b/src/lithos/errors.py
@@ -121,10 +121,11 @@ class CognitiveMemoryError(LithosError):
 class ScoutFailure(CognitiveMemoryError):
     """A single retrieval scout's backend raised.
 
-    Caught and logged inside CognitiveMemory.retrieve so one bad scout does
-    not kill the whole retrieve. Carried as an exception type (rather than a
-    log line) so future code can branch on it — e.g. degraded-mode reporting
-    in the result envelope.
+    Caught inside the retrieve orchestrator so one bad scout does not kill the
+    whole retrieve. Carried as an exception type (rather than a bare log line) so
+    the boundary can both log it with context and report degraded mode — the
+    failed scout surfaces in the envelope's ``degraded``/``failed_scouts`` fields
+    and bumps the ``lcma_scout_failures`` counter.
 
     Attributes:
         scout: The canonical scout name (e.g. ``"scout_vector"``).

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -291,12 +291,17 @@ async def compute_temperature(
     return temperature
 
 
-def _log_scout_failure(name: str, cause: BaseException) -> None:
+def _log_scout_failure(name: str, cause: BaseException, *, failed_scouts: set[str]) -> None:
     """Record a per-scout backend failure (ADR-0005: one bad scout can't kill retrieve).
 
-    Raised-and-caught so the log line carries :class:`ScoutFailure` context. This is
-    the single seam where degraded-mode reporting will collect failed scouts.
+    Adds *name* to *failed_scouts* (surfaced as the retrieve envelope's
+    ``degraded``/``failed_scouts`` fields), bumps the ``lcma_scout_failures``
+    counter, and logs with :class:`ScoutFailure` context (raised-and-caught so the
+    log line carries that context).
     """
+    failed_scouts.add(name)
+    if _HAS_TELEMETRY and _lithos_metrics is not None:
+        _lithos_metrics.lcma_scout_failures.add(1, {"scout": name})
     try:
         raise ScoutFailure(scout=name, cause=cause) from cause
     except ScoutFailure as exc:
@@ -360,13 +365,15 @@ async def _run_retrieve_impl(
     this implementation function under its private name.
 
     Returns the response envelope with results, temperature, terrace_reached,
-    and receipt_id.
+    receipt_id, and the degraded-mode signal ``degraded`` (bool) / ``failed_scouts``
+    (canonical names of scouts that ran and raised).
 
     Errors:
         - Per-scout backend failures are wrapped in :class:`ScoutFailure` and
           caught at one documented boundary inside this function (so a single
           misbehaving backend cannot kill the whole retrieve). The audit trail
-          (``scouts_fired``) reflects which scouts ran cleanly.
+          (``scouts_fired``) reflects which scouts ran cleanly; ``failed_scouts``
+          reflects which ran and raised.
         - All other exceptions (e.g. ``StatsStore`` I/O failures) propagate
           to the caller; they are not wrapped in ``ScoutFailure``.
     """
@@ -375,6 +382,7 @@ async def _run_retrieve_impl(
 
     receipt_id = _generate_receipt_id()
     scouts_fired: list[str] = []
+    failed_scout_names: set[str] = set()
     final_nodes: list[dict[str, object]] = []
     final_node_ids: list[str] = []
     candidates_considered = 0
@@ -437,7 +445,7 @@ async def _run_retrieve_impl(
         # duration, not an individual latency (only Phase B latencies are per-scout).
         for spec, result in zip(phase_a, phase_a_results, strict=True):
             if isinstance(result, BaseException):
-                _log_scout_failure(spec.name, result)
+                _log_scout_failure(spec.name, result, failed_scouts=failed_scout_names)
                 continue
             _record_scout_success(
                 spec.name,
@@ -474,7 +482,7 @@ async def _run_retrieve_impl(
                 try:
                     result = await spec.run(seeded_ctx)
                 except Exception as exc:
-                    _log_scout_failure(spec.name, exc)
+                    _log_scout_failure(spec.name, exc, failed_scouts=failed_scout_names)
                     continue
                 _record_scout_success(
                     spec.name,
@@ -503,12 +511,14 @@ async def _run_retrieve_impl(
                     extra={"conflict_count": len(conflicts_found)},
                 )
             except Exception as exc:
-                _log_scout_failure(SCOUT_CONTRADICTIONS, exc)
+                _log_scout_failure(SCOUT_CONTRADICTIONS, exc, failed_scouts=failed_scout_names)
 
         # Record scouts_fired using canonical names in order. A scout appears here
         # iff it executed without raising — empty result sets still count as "fired"
-        # so the audit trail accurately reflects what the pipeline did.
+        # so the audit trail accurately reflects what the pipeline did. failed_scouts
+        # is the disjoint set that ran and raised (degraded-mode signal).
         scouts_fired = [s for s in ALL_SCOUT_NAMES if s in executed_scouts]
+        failed_scouts = [s for s in ALL_SCOUT_NAMES if s in failed_scout_names]
 
         # ── Merge & Normalise all candidates ──────────────────────
         merged = merge_and_normalize(all_candidates)
@@ -617,6 +627,11 @@ async def _run_retrieve_impl(
             "temperature": temperature,
             "terrace_reached": terrace_reached,
             "receipt_id": receipt_id,
+            # Degraded-mode signal: which scouts ran and raised (empty normally).
+            # A caller can tell partial results from a bad backend apart from a
+            # genuinely empty corpus. Always present for a stable envelope shape.
+            "degraded": bool(failed_scouts),
+            "failed_scouts": failed_scouts,
         }
         if surface_conflicts:
             envelope["conflicts"] = conflicts_found

--- a/src/lithos/telemetry.py
+++ b/src/lithos/telemetry.py
@@ -639,6 +639,7 @@ class _LithosMetrics:
         self._lcma_temperature_cold_start: Any = None
         self._lcma_scout_duration: Any = None
         self._lcma_scout_candidates: Any = None
+        self._lcma_scout_failures: Any = None
         self._lcma_salience_updates: Any = None
 
     @property
@@ -938,6 +939,24 @@ class _LithosMetrics:
                 description="Number of candidates returned per scout invocation",
             )
         return self._lcma_scout_candidates
+
+    @property
+    def lcma_scout_failures(self) -> Any:
+        """Counter incremented when a scout's backend raises during retrieve.
+
+        A rising rate signals degraded retrieval — one backend down while the
+        pipeline still returns partial results (cf. the retrieve envelope's
+        ``degraded``/``failed_scouts`` fields).
+
+        Attributes:
+            scout: the scout name (e.g. ``"scout_vector"``)
+        """
+        if self._lcma_scout_failures is None:
+            self._lcma_scout_failures = get_meter().create_counter(
+                "lithos.lcma.scout.failures",
+                description="Number of per-scout backend failures during run_retrieve",
+            )
+        return self._lcma_scout_failures
 
     @property
     def lcma_salience_updates(self) -> Any:

--- a/src/lithos/tools/read_search.py
+++ b/src/lithos/tools/read_search.py
@@ -304,7 +304,9 @@ def register(mcp: FastMCP, server: LithosServer) -> None:
 
         Returns:
             Dict with results list (superset of lithos_search result
-            schema), temperature, terrace_reached, and receipt_id.
+            schema), temperature, terrace_reached, receipt_id, and the
+            degraded-mode signal ``degraded`` (bool) / ``failed_scouts`` (names
+            of any scouts whose backend raised — empty when all scouts ran).
         """
         logger.info(
             "lithos_retrieve: called",
@@ -350,6 +352,8 @@ def register(mcp: FastMCP, server: LithosServer) -> None:
                 "receipt_id": result.get("receipt_id"),  # type: ignore[union-attr]
                 "temperature": result.get("temperature"),  # type: ignore[union-attr]
                 "terrace_reached": result.get("terrace_reached"),  # type: ignore[union-attr]
+                "degraded": result.get("degraded"),  # type: ignore[union-attr]
+                "failed_scouts": result.get("failed_scouts"),  # type: ignore[union-attr]
                 "agent_id": agent_id,
                 "task_id": task_id,
             },

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -1806,6 +1806,102 @@ class TestNewScoutsWiredInPhaseB:
         fired = json.loads(row["scouts_fired"])
         assert "scout_graph" not in fired
 
+        # ...and it surfaces as the degraded-mode signal in the envelope.
+        assert result["degraded"] is True
+        assert result["failed_scouts"] == ["scout_graph"]
+
+
+class TestDegradedMode:
+    """The retrieve envelope reports degraded mode when a scout backend raises."""
+
+    @pytest.mark.asyncio
+    async def test_healthy_retrieve_reports_not_degraded(
+        self,
+        seeded_km: KnowledgeManager,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        projection: ProvenanceProjection,
+        stats_store: StatsStore,
+    ) -> None:
+        """With every scout healthy, degraded is False and failed_scouts is empty
+        — and the fields are always present, not conditional."""
+        from lithos.search import SearchResult
+
+        tantivy_hits = [
+            SearchResult(id=_ID1, title="Alpha Note", snippet="", score=0.9, path="alpha-note.md"),
+        ]
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=[]),
+            patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
+        ):
+            result = await _run_retrieve_impl(
+                query="alpha",
+                search=seeded_search,
+                knowledge=seeded_km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                projection=projection,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        assert result["degraded"] is False
+        assert result["failed_scouts"] == []
+
+    @pytest.mark.asyncio
+    async def test_failing_scout_marks_degraded_and_increments_metric(
+        self,
+        seeded_km: KnowledgeManager,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        projection: ProvenanceProjection,
+        stats_store: StatsStore,
+    ) -> None:
+        """A Phase A scout that raises marks the retrieve degraded, names the scout
+        in failed_scouts, and bumps the lcma_scout_failures counter."""
+        from lithos.search import SearchResult
+
+        tantivy_hits = [
+            SearchResult(id=_ID1, title="Alpha Note", snippet="", score=0.9, path="alpha-note.md"),
+        ]
+        metrics = MagicMock()
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=[]),
+            patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
+            patch(
+                "lithos.lcma.scouts.scout_vector",
+                new=AsyncMock(side_effect=RuntimeError("vector boom")),
+            ),
+            patch("lithos.lcma.retrieve._HAS_TELEMETRY", True),
+            patch("lithos.lcma.retrieve._lithos_metrics", metrics),
+        ):
+            result = await _run_retrieve_impl(
+                query="alpha",
+                search=seeded_search,
+                knowledge=seeded_km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                projection=projection,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        # Degraded signal in the envelope; the pipeline still returned.
+        assert result["degraded"] is True
+        assert result["failed_scouts"] == ["scout_vector"]
+        assert "receipt_id" in result
+
+        # The scout-failure counter was bumped with the scout label.
+        metrics.lcma_scout_failures.add.assert_any_call(1, {"scout": "scout_vector"})
+
 
 class TestFinallyBlockRobustness:
     @pytest.mark.asyncio

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -1902,6 +1902,55 @@ class TestDegradedMode:
         # The scout-failure counter was bumped with the scout label.
         metrics.lcma_scout_failures.add.assert_any_call(1, {"scout": "scout_vector"})
 
+    @pytest.mark.asyncio
+    async def test_multiple_failed_scouts_ordered_canonically(
+        self,
+        seeded_km: KnowledgeManager,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        projection: ProvenanceProjection,
+        stats_store: StatsStore,
+    ) -> None:
+        """failed_scouts is ordered by ALL_SCOUT_NAMES, not by failure order — a
+        Phase A (vector) and a Phase B (graph) failure come out vector-then-graph."""
+        from lithos.search import SearchResult
+
+        # scout_lexical still returns a hit, so Phase A produces a seed and Phase B
+        # (where scout_graph runs and fails) actually executes.
+        tantivy_hits = [
+            SearchResult(id=_ID1, title="Alpha Note", snippet="", score=0.9, path="alpha-note.md"),
+        ]
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=[]),
+            patch.object(seeded_search, "full_text_search", return_value=tantivy_hits),
+            patch(
+                "lithos.lcma.scouts.scout_vector",
+                new=AsyncMock(side_effect=RuntimeError("vector boom")),
+            ),
+            patch(
+                "lithos.lcma.scouts.scout_graph",
+                new=AsyncMock(side_effect=RuntimeError("graph boom")),
+            ),
+        ):
+            result = await _run_retrieve_impl(
+                query="alpha",
+                search=seeded_search,
+                knowledge=seeded_km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                projection=projection,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        assert result["degraded"] is True
+        # scout_vector (Phase A) precedes scout_graph (Phase B) in ALL_SCOUT_NAMES.
+        assert result["failed_scouts"] == ["scout_vector", "scout_graph"]
+
 
 class TestFinallyBlockRobustness:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

The **behavioural half of task `c36fbdb6`**, closing it. PR5a (#396) left `ScoutFailure` raised, caught, and logged at a single `_log_scout_failure` seam — but with nowhere to go, so a scout whose backend **raised** was indistinguishable from one that returned `[]`. This wires that seam into a real degraded-mode contract (the thing `ScoutFailure`'s own docstring anticipated since it was introduced).

## Changes

- **Envelope.** `lithos_retrieve` now **always** returns `degraded` (bool) and `failed_scouts` (canonical names of scouts that ran and raised, ordered by `ALL_SCOUT_NAMES` like `scouts_fired`). Always-present = a stable shape, so a caller can tell *"one backend down, partial results"* apart from *"genuinely empty corpus"*. The tool returns the whole envelope, so this flows straight through.
- **Metric.** New `lithos.lcma.scout.failures` counter (labelled by scout), bumped in `_log_scout_failure`. This is the operational lever: a rising failure rate is exactly the signal that was missing when a ChromaDB outage **silently** degraded semantic search for ~33 minutes — you can now alert on it.
- `_log_scout_failure(name, cause, *, failed_scouts)` collects into a per-call set; the orchestrator orders it for the envelope. `failed_scouts` is disjoint from `scouts_fired` (a scout either ran clean or raised, never both).
- **Docs:** `ScoutFailure` docstring (the "future code" is now here), `_run_retrieve_impl` + `lithos_retrieve` return docs, `SPECIFICATION.md`'s retrieve envelope, and the completion log line all gain `degraded`/`failed_scouts`.

## Behaviour

**Additive only.** Healthy retrieves gain `degraded: false, failed_scouts: []`; no existing field changes. All architecture metrics held (edges 68, cycles 0/1, over-800 11, private-refs 31, tests-private 87).

## Tests

- Healthy retrieve reports `degraded: false` / `failed_scouts: []` (and the fields are always present, not conditional).
- A failing Phase A scout marks `degraded: true`, names the scout in `failed_scouts`, and bumps `lcma_scout_failures`.
- The existing failing-Phase-B test now also asserts the envelope signal.

## Verification

- `make check` — **1610 passed**, typecheck + lint clean
- `make test-integration` — **454 passed**
- `make diagrams` — **48 guardrails**
- `lint-imports` — 3 contracts kept

Closes task `c36fbdb6` (with PR5a #396).
