### PR TITLE
refactor: move task-feedback validate/apply onto CognitiveMemory (PR7, task 9c4641db)

### DIFF
--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -7,9 +7,9 @@
         "max_function": "lithos.frontmatter_codec.KnowledgeMetadata.from_dict"
       },
       "CognitiveMemory": {
-        "functions_over_10": 2,
-        "max_complexity": 25,
-        "max_function": "lithos.cognitive_memory.CognitiveMemory.cache_lookup"
+        "functions_over_10": 3,
+        "max_complexity": 26,
+        "max_function": "lithos.cognitive_memory.CognitiveMemory.validate_task_feedback"
       },
       "Config": {
         "functions_over_10": 1,
@@ -22,7 +22,7 @@
         "max_function": "lithos.coordination.CoordinationService.create_task"
       },
       "Entrypoints": {
-        "functions_over_10": 16,
+        "functions_over_10": 15,
         "max_complexity": 65,
         "max_function": "lithos.tools.notes.register.lithos_write"
       },
@@ -106,11 +106,11 @@
       },
       {
         "complexity": 26,
-        "qualname": "lithos.knowledge.KnowledgeManager.create"
+        "qualname": "lithos.cognitive_memory.CognitiveMemory.validate_task_feedback"
       },
       {
         "complexity": 26,
-        "qualname": "lithos.server.LithosServer._validate_task_feedback"
+        "qualname": "lithos.knowledge.KnowledgeManager.create"
       },
       {
         "complexity": 25,
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 717
+    "total_functions": 718
   },
   "domain": {
     "associations": 26,
@@ -267,11 +267,9 @@
       "lithos.tools.findings_stats -> lithos.server.LithosServer._cached_agent_count",
       "lithos.tools.findings_stats -> lithos.server.LithosServer._emit",
       "lithos.tools.notes -> lithos.knowledge._UNSET",
-      "lithos.tools.notes -> lithos.knowledge._UnsetType",
-      "lithos.tools.tasks -> lithos.server.LithosServer._apply_task_feedback",
-      "lithos.tools.tasks -> lithos.server.LithosServer._validate_task_feedback"
+      "lithos.tools.notes -> lithos.knowledge._UnsetType"
     ],
-    "cross_module_private_refs": 31,
+    "cross_module_private_refs": 29,
     "tests_private_detail": [
       "tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)",
       "tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)",
@@ -320,13 +318,13 @@
       },
       "CognitiveMemory": {
         "classes": 2,
-        "functions": 27,
+        "functions": 30,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 1000,
-        "lines": 1000,
+        "largest_module_lines": 1121,
+        "lines": 1121,
         "modules": 1,
         "public_symbols": 2,
-        "sloc": 822
+        "sloc": 920
       },
       "Config": {
         "classes": 9,
@@ -350,13 +348,13 @@
       },
       "Entrypoints": {
         "classes": 4,
-        "functions": 137,
+        "functions": 135,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5919,
+        "lines": 5813,
         "modules": 13,
         "public_symbols": 30,
-        "sloc": 4755
+        "sloc": 4668
       },
       "Errors": {
         "classes": 9,
@@ -484,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23648,
+    "total_lines": 23663,
     "total_modules": 41,
-    "total_sloc": 19006
+    "total_sloc": 19017
   },
   "tests": {
     "ratio": 1.88,
-    "src_lines": 23648,
-    "test_lines": 44526
+    "src_lines": 23663,
+    "test_lines": 44522
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -13,7 +13,7 @@ lower a budget after improving the code to lock in the gain.
 |---|---:|---:|---:|
 | `component_cycles` | 0 | 0 | 0 |
 | `cross_component_edges` | 71 | 71 | 0 |
-| `cross_module_private_refs` | 31 | 42 | 11 |
+| `cross_module_private_refs` | 29 | 42 | 13 |
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
@@ -35,10 +35,10 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Codec | 1 | 777 | 583 | 7 | 0 | 0.00 | 14 (`lithos.frontmatter_codec.KnowledgeMetadata.from_dict`) | 3 |
-| CognitiveMemory | 1 | 1000 | 822 | 1 | 12 | 0.92 | 25 (`lithos.cognitive_memory.CognitiveMemory.cache_lookup`) | 2 |
+| CognitiveMemory | 1 | 1121 | 920 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
 | Config | 1 | 371 | 281 | 11 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5919 | 4755 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 16 |
+| Entrypoints | 13 | 5813 | 4668 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 211 | 152 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **41**, lines: **23648**, SLOC: **19006**
+- Modules: **41**, lines: **23663**, SLOC: **19017**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **717**, cyclomatic > 10: **60**
+- Functions: **718**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -81,8 +81,8 @@ Top 10 most complex functions:
 | 41 | `lithos.lcma.retrieve._run_retrieve_impl` |
 | 33 | `lithos.search.SearchEngine.graph_search` |
 | 30 | `lithos.tools.read_search.register.lithos_list` |
+| 26 | `lithos.cognitive_memory.CognitiveMemory.validate_task_feedback` |
 | 26 | `lithos.knowledge.KnowledgeManager.create` |
-| 26 | `lithos.server.LithosServer._validate_task_feedback` |
 | 25 | `lithos.cognitive_memory.CognitiveMemory.cache_lookup` |
 | 25 | `lithos.tools.notes.register.lithos_note_update` |
 | 23 | `lithos.search.TantivyIndex.search` |
@@ -92,7 +92,7 @@ Top 10 most complex functions:
 Private-name reaches across module seams. Both counts can be pinned as
 `[budgets]` ratchets (`cross_module_private_refs`, `tests_private_imports`).
 
-- Cross-module private refs (src): **31**
+- Cross-module private refs (src): **29**
   - `lithos.tools.tasks -> lithos.server.LithosServer._emit (x8)`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._config (x2)`
   - `lithos.tools.read_search -> lithos.server.LithosServer._config (x2)`
@@ -113,8 +113,6 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._emit`
   - `lithos.tools.notes -> lithos.knowledge._UNSET`
   - `lithos.tools.notes -> lithos.knowledge._UnsetType`
-  - `lithos.tools.tasks -> lithos.server.LithosServer._apply_task_feedback`
-  - `lithos.tools.tasks -> lithos.server.LithosServer._validate_task_feedback`
 - Tests importing src privates: **87**
   - `tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)`
   - `tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)`
@@ -152,4 +150,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (44526 test lines / 23648 source lines)
+- Test-to-source line ratio: **1.88** (44522 test lines / 23663 source lines)

--- a/docs/generated/tool_catalog.md
+++ b/docs/generated/tool_catalog.md
@@ -99,7 +99,7 @@ lithos_tags(prefix: str | None = None)
 | `lithos_task_cancel` | Cancel a task, releasing all claims. | Coordination, Events |
 | `lithos_task_children` | Return the child tasks of a parent/epic (via ``parent_child`` edges). | Coordination |
 | `lithos_task_claim` | Claim an aspect of a task. | Coordination, Events |
-| `lithos_task_complete` | Mark a task as completed. | Coordination, Events |
+| `lithos_task_complete` | Mark a task as completed. | CognitiveMemory, Coordination, Events |
 | `lithos_task_create` | Create a new coordination task. | Coordination, Events |
 | `lithos_task_edge_list` | List edges touching a task. | Coordination |
 | `lithos_task_edge_upsert` | Create or update a typed relation between two tasks. | Coordination |

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from lithos.envelopes import error_envelope
 from lithos.errors import SearchBackendError
 from lithos.events import EVENT_ORIGIN_ENRICH, LithosEvent, make_edge_upserted_event
 from lithos.frontmatter_codec import normalize_datetime
@@ -267,6 +268,117 @@ class CognitiveMemory:
         """
         return await self._stats_store.get_latest_receipt(task_id, agent_id)
 
+    async def validate_task_feedback(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        cited_nodes: list[str] | None,
+        misleading_nodes: list[str] | None,
+        receipt_id: str | None,
+    ) -> tuple[dict[str, Any], None] | tuple[None, dict[str, Any]]:
+        """Validate receipt and compute filtered node sets without side effects.
+
+        Returns ``(error_envelope, None)`` on hard failure, or
+        ``(None, validated_data)`` on success.  ``validated_data`` contains the
+        keys ``cited``, ``misleading``, ``ignored`` (each a list[str] or None)
+        and ``skip`` (bool — True when feedback should be silently dropped).
+
+        The ``lithos_task_complete`` handler calls this *before* completing the
+        task so invalid feedback fails fast without completing it; the paired
+        :meth:`apply_task_feedback` runs *after* completion.
+        """
+        # -- Resolve receipt --
+        receipt: dict[str, object] | None
+        if receipt_id is not None:
+            receipt = await self.get_receipt(receipt_id, task_id)
+            if receipt is None:
+                return (
+                    error_envelope(
+                        "receipt_not_found",
+                        f"Receipt '{receipt_id}' not found or does not belong to task '{task_id}'.",
+                    ),
+                    None,
+                )
+        else:
+            receipt = await self.get_latest_receipt(task_id, agent)
+            if receipt is None:
+                logger.warning(
+                    "No receipt found for task=%s agent=%s — dropping all feedback",
+                    task_id,
+                    agent,
+                )
+                return (None, {"skip": True, "cited": None, "misleading": None, "ignored": []})
+
+        receipt_node_ids: set[str] = set()
+        raw_ids = receipt.get("final_node_ids")
+        if isinstance(raw_ids, list):
+            receipt_node_ids = {str(nid) for nid in raw_ids}
+
+        # -- Intersect with receipt node IDs --
+        cited = list(receipt_node_ids & set(cited_nodes)) if cited_nodes is not None else None
+        misleading = (
+            list(receipt_node_ids & set(misleading_nodes)) if misleading_nodes is not None else None
+        )
+
+        # Log dropped IDs
+        if cited_nodes is not None:
+            dropped = set(cited_nodes) - receipt_node_ids
+            for nid in dropped:
+                logger.debug("Dropped cited node %s — not in receipt", nid)
+        if misleading_nodes is not None:
+            dropped = set(misleading_nodes) - receipt_node_ids
+            for nid in dropped:
+                logger.debug("Dropped misleading node %s — not in receipt", nid)
+
+        # -- Intersect with existing knowledge (prevent writes for deleted notes) --
+        existing_ids: set[str] = set()
+        for nid in receipt_node_ids:
+            if self._knowledge.get_cached_meta(nid) is not None:
+                existing_ids.add(nid)
+
+        if cited is not None:
+            cited = [nid for nid in cited if nid in existing_ids]
+        if misleading is not None:
+            misleading = [nid for nid in misleading if nid in existing_ids]
+
+        # -- Compute ignored: receipt nodes not in cited or misleading --
+        cited_set = set(cited) if cited is not None else set()
+        misleading_set = set(misleading) if misleading is not None else set()
+        ignored = [
+            nid
+            for nid in receipt_node_ids
+            if nid not in cited_set and nid not in misleading_set and nid in existing_ids
+        ]
+
+        return (
+            None,
+            {"skip": False, "cited": cited, "misleading": misleading, "ignored": ignored},
+        )
+
+    async def apply_task_feedback(self, validated: dict[str, Any]) -> None:
+        """Apply reinforcement side-effects using pre-validated data.
+
+        *validated* is the second element of a :meth:`validate_task_feedback`
+        success tuple. Runs after the task is completed (see that method).
+        """
+        if validated.get("skip"):
+            return
+
+        cited = validated["cited"]
+        misleading = validated["misleading"]
+        ignored = validated["ignored"]
+
+        if cited:
+            await self.reinforce_cited(cited)
+            await self.reinforce_between(cited)
+
+        if misleading:
+            await self.reinforce_misleading(misleading)
+
+        if ignored:
+            await self.reinforce_ignored(ignored)
+
     async def refresh_cached_counts(self) -> None:
         """Refresh the cached LCMA gauge values from the database.
 
@@ -478,6 +590,15 @@ class CognitiveMemory:
             namespace=namespace,
         )
 
+    async def get_edge(self, edge_id: str) -> dict[str, object] | None:
+        """Return a single edge's current state (weight, conflict_state, …), or None.
+
+        Public single-edge read-back through the projection (ADR-0004), so
+        callers and tests read edge state through this interface instead of
+        reaching into ``_projection`` / the edge store.
+        """
+        return await self._projection.get_edge(edge_id)
+
     async def edge_delete(self, *, edge_ids: list[str]) -> int:
         """Delete edges by id. Returns the number of rows deleted.
 
@@ -641,7 +762,7 @@ class CognitiveMemory:
         """Penalise misleading nodes and weaken their adjacent edges.
 
         Folds the two helpers that always fired together against the same
-        node set in :meth:`LithosServer._apply_task_feedback`
+        node set in :meth:`apply_task_feedback`
         (``penalize_misleading`` + ``weaken_edges_for_bad_context``).
 
         For each *node_id*:
@@ -920,7 +1041,7 @@ class CognitiveMemory:
                     ),
                 }
 
-            edge = await self._projection.get_edge(edge_id)
+            edge = await self.get_edge(edge_id)
             if edge is None:
                 return {
                     "status": "error",

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -17,9 +17,6 @@ from lithos.cognitive_memory import CognitiveMemory
 from lithos.config import LithosConfig, get_config, set_config
 from lithos.coordination import CoordinationService
 from lithos.edge_store import EdgeStore
-from lithos.envelopes import (
-    error_envelope,
-)
 from lithos.events import (
     EventBus,
     LithosEvent,
@@ -237,109 +234,6 @@ class LithosServer:
             await self.event_bus.emit(event)
         except Exception:
             logger.exception("Failed to emit %s event", event.type)
-
-    async def _validate_task_feedback(
-        self,
-        *,
-        task_id: str,
-        agent: str,
-        cited_nodes: list[str] | None,
-        misleading_nodes: list[str] | None,
-        receipt_id: str | None,
-    ) -> tuple[dict[str, Any], None] | tuple[None, dict[str, Any]]:
-        """Validate receipt and compute filtered node sets without side effects.
-
-        Returns ``(error_envelope, None)`` on hard failure, or
-        ``(None, validated_data)`` on success.  ``validated_data`` contains the
-        keys ``cited``, ``misleading``, ``ignored`` (each a list[str] or None)
-        and ``skip`` (bool — True when feedback should be silently dropped).
-        """
-        # -- Resolve receipt --
-        receipt: dict[str, object] | None
-        if receipt_id is not None:
-            receipt = await self.memory.get_receipt(receipt_id, task_id)
-            if receipt is None:
-                return (
-                    error_envelope(
-                        "receipt_not_found",
-                        f"Receipt '{receipt_id}' not found or does not belong to task '{task_id}'.",
-                    ),
-                    None,
-                )
-        else:
-            receipt = await self.memory.get_latest_receipt(task_id, agent)
-            if receipt is None:
-                logger.warning(
-                    "No receipt found for task=%s agent=%s — dropping all feedback",
-                    task_id,
-                    agent,
-                )
-                return (None, {"skip": True, "cited": None, "misleading": None, "ignored": []})
-
-        receipt_node_ids: set[str] = set()
-        raw_ids = receipt.get("final_node_ids")
-        if isinstance(raw_ids, list):
-            receipt_node_ids = {str(nid) for nid in raw_ids}
-
-        # -- Intersect with receipt node IDs --
-        cited = list(receipt_node_ids & set(cited_nodes)) if cited_nodes is not None else None
-        misleading = (
-            list(receipt_node_ids & set(misleading_nodes)) if misleading_nodes is not None else None
-        )
-
-        # Log dropped IDs
-        if cited_nodes is not None:
-            dropped = set(cited_nodes) - receipt_node_ids
-            for nid in dropped:
-                logger.debug("Dropped cited node %s — not in receipt", nid)
-        if misleading_nodes is not None:
-            dropped = set(misleading_nodes) - receipt_node_ids
-            for nid in dropped:
-                logger.debug("Dropped misleading node %s — not in receipt", nid)
-
-        # -- Intersect with existing knowledge (prevent writes for deleted notes) --
-        existing_ids: set[str] = set()
-        for nid in receipt_node_ids:
-            if self.knowledge.get_cached_meta(nid) is not None:
-                existing_ids.add(nid)
-
-        if cited is not None:
-            cited = [nid for nid in cited if nid in existing_ids]
-        if misleading is not None:
-            misleading = [nid for nid in misleading if nid in existing_ids]
-
-        # -- Compute ignored: receipt nodes not in cited or misleading --
-        cited_set = set(cited) if cited is not None else set()
-        misleading_set = set(misleading) if misleading is not None else set()
-        ignored = [
-            nid
-            for nid in receipt_node_ids
-            if nid not in cited_set and nid not in misleading_set and nid in existing_ids
-        ]
-
-        return (
-            None,
-            {"skip": False, "cited": cited, "misleading": misleading, "ignored": ignored},
-        )
-
-    async def _apply_task_feedback(self, validated: dict[str, Any]) -> None:
-        """Apply reinforcement side-effects using pre-validated data."""
-        if validated.get("skip"):
-            return
-
-        cited = validated["cited"]
-        misleading = validated["misleading"]
-        ignored = validated["ignored"]
-
-        if cited:
-            await self.memory.reinforce_cited(cited)
-            await self.memory.reinforce_between(cited)
-
-        if misleading:
-            await self.memory.reinforce_misleading(misleading)
-
-        if ignored:
-            await self.memory.reinforce_ignored(ignored)
 
     async def _get_health(self) -> dict[str, Any]:
         """Run health checks and return a status dict (shared by HTTP and any callers)."""

--- a/src/lithos/tools/tasks.py
+++ b/src/lithos/tools/tasks.py
@@ -387,7 +387,7 @@ def register(mcp: FastMCP, server: LithosServer) -> None:
         feedback_supplied = cited_nodes is not None or misleading_nodes is not None
         validated: dict[str, Any] | None = None
         if feedback_supplied:
-            error, validated = await server._validate_task_feedback(
+            error, validated = await server.memory.validate_task_feedback(
                 task_id=task_id,
                 agent=agent,
                 cited_nodes=cited_nodes,
@@ -421,7 +421,7 @@ def register(mcp: FastMCP, server: LithosServer) -> None:
                     "ignored_count": len(validated.get("ignored") or []),
                 },
             )
-            await server._apply_task_feedback(validated)
+            await server.memory.apply_task_feedback(validated)
 
         await server._emit(
             LithosEvent(

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -841,9 +841,9 @@ class TestReinforceCited:
 
         await memory_with_knowledge.reinforce_cited([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["cited_count"] == 1
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.cited_count == 1
 
     async def test_bumps_salience_by_0_02(
         self,
@@ -854,10 +854,10 @@ class TestReinforceCited:
 
         await memory_with_knowledge.reinforce_cited([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
         # Default salience 0.5 + 0.02
-        assert stats["salience"] == pytest.approx(0.52)
+        assert stats.salience == pytest.approx(0.52)
 
     async def test_bumps_spaced_rep_strength_by_0_05(
         self,
@@ -868,9 +868,9 @@ class TestReinforceCited:
 
         await memory_with_knowledge.reinforce_cited([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["spaced_rep_strength"] == pytest.approx(0.05)
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.spaced_rep_strength == pytest.approx(0.05)
 
     async def test_accumulates_across_calls(
         self,
@@ -882,11 +882,11 @@ class TestReinforceCited:
         await memory_with_knowledge.reinforce_cited([nid])
         await memory_with_knowledge.reinforce_cited([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["cited_count"] == 2
-        assert stats["salience"] == pytest.approx(0.54)
-        assert stats["spaced_rep_strength"] == pytest.approx(0.10)
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.cited_count == 2
+        assert stats.salience == pytest.approx(0.54)
+        assert stats.spaced_rep_strength == pytest.approx(0.10)
 
 
 class TestReinforceIgnored:
@@ -901,9 +901,9 @@ class TestReinforceIgnored:
 
         await memory_with_knowledge.reinforce_ignored([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["ignored_count"] == 1
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.ignored_count == 1
 
     async def test_does_not_decay_salience_under_threshold(
         self,
@@ -916,10 +916,10 @@ class TestReinforceIgnored:
         for _ in range(5):
             await memory_with_knowledge.reinforce_ignored([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["ignored_count"] == 5
-        assert stats["salience"] == pytest.approx(0.5)
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.ignored_count == 5
+        assert stats.salience == pytest.approx(0.5)
 
     async def test_decays_salience_when_chronic(
         self,
@@ -932,10 +932,10 @@ class TestReinforceIgnored:
         for _ in range(6):
             await memory_with_knowledge.reinforce_ignored([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["ignored_count"] == 6
-        assert stats["salience"] == pytest.approx(0.5 - 0.02)
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.ignored_count == 6
+        assert stats.salience == pytest.approx(0.5 - 0.02)
 
 
 class TestReinforceBetween:
@@ -952,7 +952,7 @@ class TestReinforceBetween:
         await memory_with_knowledge.reinforce_between([n1, n2])
 
         from_id, to_id = sorted([n1, n2])
-        edges = await memory_with_knowledge._projection._edge_store.list_edges(
+        edges = await memory_with_knowledge.edge_list(
             from_id=from_id, to_id=to_id, edge_type="related_to"
         )
         assert len(edges) == 1
@@ -972,7 +972,7 @@ class TestReinforceBetween:
         await memory_with_knowledge.reinforce_between([n1, n2])
 
         from_id, to_id = sorted([n1, n2])
-        edges = await memory_with_knowledge._projection._edge_store.list_edges(
+        edges = await memory_with_knowledge.edge_list(
             from_id=from_id, to_id=to_id, edge_type="related_to"
         )
         assert len(edges) == 1
@@ -988,9 +988,7 @@ class TestReinforceBetween:
 
         await memory_with_knowledge.reinforce_between([n1, n2])
 
-        all_edges = await memory_with_knowledge._projection._edge_store.list_edges(
-            edge_type="related_to"
-        )
+        all_edges = await memory_with_knowledge.edge_list(edge_type="related_to")
         assert len(all_edges) == 0
 
     async def test_canonicalises_pair_order(
@@ -1004,9 +1002,7 @@ class TestReinforceBetween:
 
         await memory_with_knowledge.reinforce_between([n1, n2])
 
-        edges = await memory_with_knowledge._projection._edge_store.list_edges(
-            edge_type="related_to"
-        )
+        edges = await memory_with_knowledge.edge_list(edge_type="related_to")
         assert len(edges) == 1
         edge = edges[0]
         assert str(edge["from_id"]) <= str(edge["to_id"])
@@ -1024,10 +1020,10 @@ class TestReinforceMisleading:
 
         await memory_with_knowledge.reinforce_misleading([nid])
 
-        stats = await memory_with_knowledge._stats_store.get_node_stats(nid)
-        assert stats is not None
-        assert stats["misleading_count"] == 1
-        assert stats["salience"] == pytest.approx(0.5 - 0.05)
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.misleading_count == 1
+        assert stats.salience == pytest.approx(0.5 - 0.05)
 
     async def test_quarantines_after_three_hits(
         self,
@@ -1078,7 +1074,7 @@ class TestReinforceMisleading:
         await memory_with_knowledge.reinforce_misleading([n1, n2])
 
         from_id, to_id = sorted([n1, n2])
-        edges = await memory_with_knowledge._projection._edge_store.list_edges(
+        edges = await memory_with_knowledge.edge_list(
             from_id=from_id, to_id=to_id, edge_type="related_to"
         )
         assert len(edges) == 1
@@ -1284,7 +1280,7 @@ class TestConflictResolve:
             "conflict_state": "accepted_dual",
         }
 
-        roundtrip = await memory._projection.get_edge(edge_id)
+        roundtrip = await memory.get_edge(edge_id)
         assert roundtrip is not None
         assert roundtrip["conflict_state"] == "accepted_dual"
         assert roundtrip["provenance_actor"] == "agent-x"


### PR DESCRIPTION
## What

The reinforcement-adjacent logic for `lithos_task_complete` lived on the **transport class**: `LithosServer._validate_task_feedback` (joins receipts against live notes, filters the cited/misleading/ignored sets) and `LithosServer._apply_task_feedback` (drives the four `reinforce_*` primitives). The handler reached back into those server privates. ADR-0005 wanted the handler to be a thin *"sequence coordination + one memory call"* orchestrator; it had grown well past that.

This moves both helpers onto **`CognitiveMemory`** — the module that already owns receipts (`get_receipt`/`get_latest_receipt`), the knowledge handle, the stats store, the projection, and all four `reinforce_*` primitives. Nothing server-only moves (no event bus, `_emit`, caches).

## Changes

- **`CognitiveMemory.validate_task_feedback(...)`** — pure validation, returns `(error_envelope, None) | (None, validated)`.
- **`CognitiveMemory.apply_task_feedback(validated)`** — the four `reinforce_*` calls.
- **`CognitiveMemory.get_edge(edge_id)`** — the missing public single-edge-state read-back; `conflict_resolve` now reads through it instead of reaching `self._projection.get_edge`.
- The task-complete handler calls `server.memory.validate_task_feedback` / `apply_task_feedback`; the two server helpers are deleted.

### Two methods, not one — deliberately

The task says "one memory call," but the handler validates **before** `coordination.complete_task` (so bad feedback fails fast without completing the task) and applies **after**. Folding validate into a single post-completion `apply_task_feedback` would change that ordering — an invalid receipt would complete the task and *then* error. Keeping `validate` a separate pre-completion gate preserves the sequence (`validate → complete → apply`) exactly — the behaviour-neutral shape.

## Metrics

| metric | before | after |
|---|---|---|
| cross_module_private_refs | 31 | **29** |
| cross_component_edges | 71 | 71 |
| component_cycles / module_cycles | 0 / 1 | 0 / 1 |
| modules_over_800_lines | 11 | 11 |

The **−2 private refs** are the two `tools.tasks → server._validate/_apply` reaches the handler no longer makes — the whole point of the move. `error_envelope` moved into `cognitive_memory` (same Errors component, so no new cross-component edge). server.py 967→861; cognitive_memory.py 1000→1121.

## Tests

The **13 reinforcement-invariant reach-throughs** in `test_cognitive_memory.py` move onto the public surface — 8 `memory._stats_store.get_node_stats` → `node_stats()` (returning the `NodeStats` dataclass), 5 `memory._projection._edge_store.list_edges` → `edge_list()`, plus a conflict-resolve `get_edge` read → `memory.get_edge()`. **Assertion values unchanged** — the reinforcement invariants (salience +0.02/−0.05, quarantine `misleading>=3`, once-only edge weakening) are now assertable through the interface. Out-of-scope private reaches (wiring, edge-seeding setup) left as-is.

## Verification

- `make check` — typecheck + full unit suite + lint clean
- `make test-integration`
- `make diagrams` — **48 guardrails**
- Behaviour-neutral: `test_cognitive_memory` (57) + `test_task_complete_feedback` (14) + `test_server` pass.
