### PR TITLE
feat: EventBus replay-gap signal + search/graph conformance suites (PR8, task 87b45d1f)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1501,6 +1501,8 @@ For `task.completed`, the current implementation emits `cited_nodes`, `misleadin
 
 The event bus maintains an in-memory ring buffer of the last N events using `collections.deque(maxlen=N)`. SSE replay uses `get_buffered_since(event_id)` to replay buffered events after a known event ID. Buffer size is configurable via `events.event_buffer_size` (default: 500).
 
+When the reconnect id is not in the ring — evicted past the buffer horizon, carried over from a previous server run, or otherwise unknown — replay cannot be proven complete. Rather than silently under-deliver, `get_buffered_since` reports a gap and the SSE surface emits a `resync` control event (see §8.7) so the client re-fetches current state instead of trusting a truncated replay.
+
 ### 8.7 SSE Delivery Surface
 
 Lithos exposes a best-effort Server-Sent Events endpoint at `GET /events`.
@@ -1523,6 +1525,7 @@ Lithos exposes a best-effort Server-Sent Events endpoint at `GET /events`.
 
 - Returns `text/event-stream`.
 - Replays buffered events first when `since` or `Last-Event-ID` is supplied, then streams live events.
+- When the supplied id is not in the ring buffer (evicted, from a previous server run, or unknown), emits an `event: resync` control message (no `id:` line, so it never becomes the client's next `Last-Event-ID`) instructing the client to resync from current state, then continues streaming live events.
 - Emits periodic keepalive comments when idle.
 - Returns `503` when `events.sse_enabled=false`.
 - Returns `429` when `events.max_sse_clients` is exceeded.

--- a/docs/generated/components/Events.md
+++ b/docs/generated/components/Events.md
@@ -11,13 +11,14 @@ Internal event bus decoupling producers from consumers.
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `lithos.events` | M | 2 | 1 |
+| `lithos.events` | M | 3 | 1 |
 
 ## Public API
 
 ### `lithos.events`
 - class `LithosEvent` — A typed event emitted by the Lithos event bus.
 - def `make_edge_upserted_event` — Build the canonical :data:`EDGE_UPSERTED` event.
+- class `BufferedReplay` — Result of :meth:`EventBus.get_buffered_since`.
 - class `EventBus` — In-memory event bus with filtered subscriptions and ring buffer history.
 
 ## Dependencies

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -33,7 +33,7 @@
       },
       "Events": {
         "functions_over_10": 0,
-        "max_complexity": 7,
+        "max_complexity": 9,
         "max_function": "lithos.events.EventBus.emit"
       },
       "Graph": {
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 718
+    "total_functions": 719
   },
   "domain": {
     "associations": 26,
@@ -297,12 +297,12 @@
       "tests/test_entities.py -> lithos.lcma.entities._download_model",
       "tests/test_entities.py -> lithos.lcma.entities._get_nlp",
       "tests/test_entities.py -> lithos.lcma.entities._load_model",
+      "tests/test_event_delivery.py -> lithos.server._format_resync_sse",
       "tests/test_event_delivery.py -> lithos.server._format_sse",
       "tests/test_knowledge.py -> lithos.knowledge._atomic_write",
-      "tests/test_lcma_config.py -> lithos.config._DEFAULT_NOTE_TYPE_PRIORS",
-      "tests/test_lcma_config.py -> lithos.config._DEFAULT_RERANK_WEIGHTS"
+      "tests/test_lcma_config.py -> lithos.config._DEFAULT_NOTE_TYPE_PRIORS"
     ],
-    "tests_private_imports": 87
+    "tests_private_imports": 88
   },
   "size": {
     "components": {
@@ -348,13 +348,13 @@
       },
       "Entrypoints": {
         "classes": 4,
-        "functions": 135,
+        "functions": 136,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5813,
+        "lines": 5847,
         "modules": 13,
         "public_symbols": 30,
-        "sloc": 4668
+        "sloc": 4692
       },
       "Errors": {
         "classes": 9,
@@ -367,14 +367,14 @@
         "sloc": 152
       },
       "Events": {
-        "classes": 3,
+        "classes": 4,
         "functions": 12,
         "largest_module": "lithos.events",
-        "largest_module_lines": 323,
-        "lines": 323,
+        "largest_module_lines": 353,
+        "lines": 353,
         "modules": 1,
-        "public_symbols": 3,
-        "sloc": 259
+        "public_symbols": 4,
+        "sloc": 279
       },
       "Graph": {
         "classes": 8,
@@ -482,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23663,
+    "total_lines": 23727,
     "total_modules": 41,
-    "total_sloc": 19017
+    "total_sloc": 19061
   },
   "tests": {
-    "ratio": 1.88,
-    "src_lines": 23663,
-    "test_lines": 44522
+    "ratio": 1.89,
+    "src_lines": 23727,
+    "test_lines": 44830
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -33,7 +33,7 @@
       },
       "Events": {
         "functions_over_10": 0,
-        "max_complexity": 9,
+        "max_complexity": 7,
         "max_function": "lithos.events.EventBus.emit"
       },
       "Graph": {
@@ -351,10 +351,10 @@
         "functions": 136,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5847,
+        "lines": 5851,
         "modules": 13,
         "public_symbols": 30,
-        "sloc": 4692
+        "sloc": 4693
       },
       "Errors": {
         "classes": 9,
@@ -370,11 +370,11 @@
         "classes": 4,
         "functions": 12,
         "largest_module": "lithos.events",
-        "largest_module_lines": 353,
-        "lines": 353,
+        "largest_module_lines": 350,
+        "lines": 350,
         "modules": 1,
         "public_symbols": 4,
-        "sloc": 279
+        "sloc": 281
       },
       "Graph": {
         "classes": 8,
@@ -482,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23727,
+    "total_lines": 23728,
     "total_modules": 41,
-    "total_sloc": 19061
+    "total_sloc": 19064
   },
   "tests": {
     "ratio": 1.89,
-    "src_lines": 23727,
-    "test_lines": 44830
+    "src_lines": 23728,
+    "test_lines": 44880
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -38,9 +38,9 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | CognitiveMemory | 1 | 1121 | 920 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
 | Config | 1 | 371 | 281 | 11 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5847 | 4692 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
+| Entrypoints | 13 | 5851 | 4693 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 211 | 152 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
-| Events | 1 | 353 | 279 | 4 | 2 | 0.33 | 9 (`lithos.events.EventBus.emit`) | 0 |
+| Events | 1 | 350 | 281 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **41**, lines: **23727**, SLOC: **19061**
+- Modules: **41**, lines: **23728**, SLOC: **19064**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -150,4 +150,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.89** (44830 test lines / 23727 source lines)
+- Test-to-source line ratio: **1.89** (44880 test lines / 23728 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -17,7 +17,7 @@ lower a budget after improving the code to lock in the gain.
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
-| `tests_private_imports` | 87 | 88 | 1 |
+| `tests_private_imports` | 88 | 88 | 0 |
 
 ## Import graph
 
@@ -38,9 +38,9 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | CognitiveMemory | 1 | 1121 | 920 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
 | Config | 1 | 371 | 281 | 11 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5813 | 4668 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
+| Entrypoints | 13 | 5847 | 4692 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 211 | 152 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
-| Events | 1 | 323 | 259 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
+| Events | 1 | 353 | 279 | 4 | 2 | 0.33 | 9 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **41**, lines: **23663**, SLOC: **19017**
+- Modules: **41**, lines: **23727**, SLOC: **19061**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **718**, cyclomatic > 10: **60**
+- Functions: **719**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -113,7 +113,7 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._emit`
   - `lithos.tools.notes -> lithos.knowledge._UNSET`
   - `lithos.tools.notes -> lithos.knowledge._UnsetType`
-- Tests importing src privates: **87**
+- Tests importing src privates: **88**
   - `tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)`
   - `tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)`
   - `tests/test_telemetry.py -> lithos.telemetry._initialized (x7)`
@@ -140,14 +140,14 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `tests/test_entities.py -> lithos.lcma.entities._download_model`
   - `tests/test_entities.py -> lithos.lcma.entities._get_nlp`
   - `tests/test_entities.py -> lithos.lcma.entities._load_model`
+  - `tests/test_event_delivery.py -> lithos.server._format_resync_sse`
   - `tests/test_event_delivery.py -> lithos.server._format_sse`
   - `tests/test_knowledge.py -> lithos.knowledge._atomic_write`
   - `tests/test_lcma_config.py -> lithos.config._DEFAULT_NOTE_TYPE_PRIORS`
-  - `tests/test_lcma_config.py -> lithos.config._DEFAULT_RERANK_WEIGHTS`
   - … (list capped at 30 pairs)
 
 ## Domain, tools & tests
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (44522 test lines / 23663 source lines)
+- Test-to-source line ratio: **1.89** (44830 test lines / 23727 source lines)

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -139,12 +139,13 @@ class BufferedReplay(NamedTuple):
     """Result of :meth:`EventBus.get_buffered_since`.
 
     ``events`` are the buffered events after the reconnect id (in emission
-    order). ``gapped`` is True when the id was not found in the ring *and* the
-    ring has dropped events — i.e. the caller's position most likely fell off
-    it and the SSE stream should tell the client to resync. A never-seen id
-    cannot be distinguished from an evicted one here, but the only real
-    reconnect token is a previously-delivered id and a spurious resync is safe;
-    when nothing was ever evicted there is no lost data and ``gapped`` is False.
+    order). ``gapped`` is True when the id is not found in the ring, meaning the
+    bus cannot prove continuity from it — the id was evicted, belongs to a
+    previous server run (a fresh buffer after restart), or was never emitted —
+    so the SSE stream should tell the client to resync rather than silently
+    under-deliver. A previously-delivered id that is still buffered yields
+    ``gapped=False``; a spurious resync for a fabricated id is harmless (it just
+    re-fetches current state).
     """
 
     events: list[LithosEvent]
@@ -165,10 +166,6 @@ class EventBus:
             self._queue_size = 100
 
         self._buffer: deque[LithosEvent] = deque(maxlen=self._buffer_size)
-        # Set once the ring first drops an event on overflow, so a later
-        # get_buffered_since can tell "your position fell off the ring" (gap)
-        # from "you're caught up / never-seen id" (no gap).
-        self._has_evicted = False
         self._subscribers: list[_Subscriber] = []
         register_event_bus_metrics(self)
 
@@ -206,10 +203,6 @@ class EventBus:
             )
 
             try:
-                # A full ring evicts its oldest event on the next append; record
-                # that so replay can signal a gap instead of a silent under-delivery.
-                if self._buffer.maxlen is not None and len(self._buffer) == self._buffer.maxlen:
-                    self._has_evicted = True
                 self._buffer.append(event)
             except Exception:
                 logger.exception("EventBus.emit: buffer append failed")
@@ -319,14 +312,18 @@ class EventBus:
         """Return buffered events after *since_id*, with a replay-gap signal.
 
         Used for SSE replay on reconnect. Events are returned in emission order,
-        exclusive of *since_id*.
+        exclusive of *since_id*. Continuity is decided purely by whether
+        *since_id* is still in the ring:
 
-        When *since_id* is not found in the ring, the result's ``gapped`` flag
-        distinguishes the two cases the old ``[]`` conflated: if the ring has
-        dropped events (``_has_evicted``), the caller's position most likely fell
-        off it — ``gapped=True`` so the SSE layer can tell the client to resync;
-        otherwise nothing was lost and ``gapped=False``. A caught-up client (its
-        id is the newest buffered event) matches and gets ``([], gapped=False)``.
+        - **Found** — the caller's position is known; return the events after it.
+          A caught-up client (its id is the newest buffered event) gets
+          ``([], gapped=False)``.
+        - **Absent** — the bus cannot prove continuity: the id was evicted from
+          the ring, belongs to a previous server run (a fresh buffer after a
+          restart), or was never emitted. All three mean events may have been
+          missed, so ``gapped=True`` and the SSE layer tells the client to
+          resync. A spurious resync for a fabricated id is harmless (it just
+          re-fetches current state); a silent under-delivery is not.
 
         Args:
             since_id: The event ID to replay from (exclusive).
@@ -338,7 +335,7 @@ class EventBus:
         for i, event in enumerate(events):
             if event.id == since_id:
                 return BufferedReplay(events[i + 1 :], gapped=False)
-        return BufferedReplay([], gapped=self._has_evicted)
+        return BufferedReplay([], gapped=True)
 
     @property
     def active_subscriber_count(self) -> int:

--- a/src/lithos/events.py
+++ b/src/lithos/events.py
@@ -16,7 +16,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from lithos.config import EventsConfig
@@ -135,6 +135,22 @@ class _Subscriber:
     drops: int = 0
 
 
+class BufferedReplay(NamedTuple):
+    """Result of :meth:`EventBus.get_buffered_since`.
+
+    ``events`` are the buffered events after the reconnect id (in emission
+    order). ``gapped`` is True when the id was not found in the ring *and* the
+    ring has dropped events — i.e. the caller's position most likely fell off
+    it and the SSE stream should tell the client to resync. A never-seen id
+    cannot be distinguished from an evicted one here, but the only real
+    reconnect token is a previously-delivered id and a spurious resync is safe;
+    when nothing was ever evicted there is no lost data and ``gapped`` is False.
+    """
+
+    events: list[LithosEvent]
+    gapped: bool
+
+
 class EventBus:
     """In-memory event bus with filtered subscriptions and ring buffer history."""
 
@@ -149,6 +165,10 @@ class EventBus:
             self._queue_size = 100
 
         self._buffer: deque[LithosEvent] = deque(maxlen=self._buffer_size)
+        # Set once the ring first drops an event on overflow, so a later
+        # get_buffered_since can tell "your position fell off the ring" (gap)
+        # from "you're caught up / never-seen id" (no gap).
+        self._has_evicted = False
         self._subscribers: list[_Subscriber] = []
         register_event_bus_metrics(self)
 
@@ -186,6 +206,10 @@ class EventBus:
             )
 
             try:
+                # A full ring evicts its oldest event on the next append; record
+                # that so replay can signal a gap instead of a silent under-delivery.
+                if self._buffer.maxlen is not None and len(self._buffer) == self._buffer.maxlen:
+                    self._has_evicted = True
                 self._buffer.append(event)
             except Exception:
                 logger.exception("EventBus.emit: buffer append failed")
@@ -291,24 +315,30 @@ class EventBus:
                 result.append((sub.subscriber_id, sub.queue.qsize() / maxsize))
         return result
 
-    def get_buffered_since(self, since_id: str) -> list[LithosEvent]:
-        """Return buffered events that occurred after the event with the given ID.
+    def get_buffered_since(self, since_id: str) -> BufferedReplay:
+        """Return buffered events after *since_id*, with a replay-gap signal.
 
-        Used for SSE replay on reconnect. Events are returned in emission order.
-        If since_id is not found in the buffer, returns an empty list.
+        Used for SSE replay on reconnect. Events are returned in emission order,
+        exclusive of *since_id*.
+
+        When *since_id* is not found in the ring, the result's ``gapped`` flag
+        distinguishes the two cases the old ``[]`` conflated: if the ring has
+        dropped events (``_has_evicted``), the caller's position most likely fell
+        off it — ``gapped=True`` so the SSE layer can tell the client to resync;
+        otherwise nothing was lost and ``gapped=False``. A caught-up client (its
+        id is the newest buffered event) matches and gets ``([], gapped=False)``.
 
         Args:
-            since_id: The event ID to replay from (exclusive — the named event
-                      is NOT included; only events emitted after it are returned).
+            since_id: The event ID to replay from (exclusive).
 
         Returns:
-            Ordered list of LithosEvent items emitted after the given ID.
+            A :class:`BufferedReplay` — ``events`` after *since_id* and ``gapped``.
         """
         events = list(self._buffer)
         for i, event in enumerate(events):
             if event.id == since_id:
-                return events[i + 1 :]
-        return []
+                return BufferedReplay(events[i + 1 :], gapped=False)
+        return BufferedReplay([], gapped=self._has_evicted)
 
     @property
     def active_subscriber_count(self) -> int:

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -443,11 +443,13 @@ class LithosServer:
                             replay = self.event_bus.get_buffered_since(since_id)
                             replay_count = 0
                             if replay.gapped:
-                                # The client's position fell off the ring — tell it to
-                                # resync instead of silently under-delivering the replay.
+                                # since_id is not in the ring (evicted, from a previous
+                                # server run, or unknown) — the replay cannot be proven
+                                # complete, so tell the client to resync instead of
+                                # silently under-delivering.
                                 logger.warning(
-                                    "SSE replay gap: since_id=%s not in buffer and events "
-                                    "were evicted; signalling resync",
+                                    "SSE replay gap: since_id=%s not in the replay buffer; "
+                                    "signalling resync",
                                     since_id,
                                 )
                                 replay_span.set_attribute("lithos.sse.gapped", True)
@@ -852,8 +854,9 @@ def _format_sse(event: LithosEvent) -> str:
     return f"id: {event.id}\nevent: {event.type}\ndata: {data}\n\n"
 
 
-# SSE control event emitted when the replay buffer dropped events the reconnecting
-# client needs. The client should discard its assumed position and resync from
+# SSE control event emitted when the replay buffer cannot prove continuity from the
+# reconnecting client's Last-Event-ID (it was evicted, is from a previous server run,
+# or is unknown). The client should discard its assumed position and resync from
 # current state rather than trust a silently-truncated replay.
 SSE_RESYNC_EVENT = "resync"
 
@@ -866,10 +869,11 @@ def _format_resync_sse(since_id: str) -> str:
     """
     data = json.dumps(
         {
-            "reason": "buffer_evicted",
+            "reason": "replay_gap",
             "since_id": since_id,
             "message": (
-                "Replay buffer dropped events since the given id; resync from current state."
+                "Cannot replay from the given id (evicted, from a previous server run, "
+                "or unknown); resync from current state."
             ),
         }
     )

--- a/src/lithos/server.py
+++ b/src/lithos/server.py
@@ -440,9 +440,19 @@ class LithosServer:
                     # Replay buffered events if a since_id was provided
                     if since_id:
                         with tracer.start_as_current_span("lithos.sse.replay") as replay_span:
-                            replayed = self.event_bus.get_buffered_since(since_id)
+                            replay = self.event_bus.get_buffered_since(since_id)
                             replay_count = 0
-                            for evt in replayed:
+                            if replay.gapped:
+                                # The client's position fell off the ring — tell it to
+                                # resync instead of silently under-delivering the replay.
+                                logger.warning(
+                                    "SSE replay gap: since_id=%s not in buffer and events "
+                                    "were evicted; signalling resync",
+                                    since_id,
+                                )
+                                replay_span.set_attribute("lithos.sse.gapped", True)
+                                yield _format_resync_sse(since_id)
+                            for evt in replay.events:
                                 # Apply the same filters to replayed events
                                 if event_types and evt.type not in event_types:
                                     continue
@@ -840,6 +850,30 @@ def _format_sse(event: LithosEvent) -> str:
     }
     data = json.dumps(payload, default=str)
     return f"id: {event.id}\nevent: {event.type}\ndata: {data}\n\n"
+
+
+# SSE control event emitted when the replay buffer dropped events the reconnecting
+# client needs. The client should discard its assumed position and resync from
+# current state rather than trust a silently-truncated replay.
+SSE_RESYNC_EVENT = "resync"
+
+
+def _format_resync_sse(since_id: str) -> str:
+    """Format an SSE ``resync`` control message (a buffered-replay gap was detected).
+
+    No ``id:`` line — this is a control signal, not a replayable event, so it must
+    not become the client's next ``Last-Event-ID``.
+    """
+    data = json.dumps(
+        {
+            "reason": "buffer_evicted",
+            "since_id": since_id,
+            "message": (
+                "Replay buffer dropped events since the given id; resync from current state."
+            ),
+        }
+    )
+    return f"event: {SSE_RESYNC_EVENT}\ndata: {data}\n\n"
 
 
 # Global server instance

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -34,7 +34,7 @@ from lithos.events import (
     EventBus,
     LithosEvent,
 )
-from lithos.server import LithosServer, _format_sse
+from lithos.server import LithosServer, _format_resync_sse, _format_sse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -157,6 +157,17 @@ class TestFormatSSE:
         )
         result = _format_sse(evt)
         assert "origin" not in result
+
+    def test_resync_format_has_no_id_line(self) -> None:
+        """The resync control signal must carry no ``id:`` line (it must not become
+        the client's next Last-Event-ID) and names the gap reason."""
+        result = _format_resync_sse("evt-123")
+        assert "id: " not in result
+        assert "event: resync\n" in result
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["reason"] == "buffer_evicted"
+        assert data["since_id"] == "evt-123"
+        assert result.endswith("\n\n")
         assert EVENT_ORIGIN_ENRICH not in result
         data = json.loads(result.split("data: ")[1].strip())
         assert "origin" not in data
@@ -179,22 +190,40 @@ class TestGetBufferedSince:
         await bus.emit(e3)
 
         result = bus.get_buffered_since(e1.id)
-        assert [e.id for e in result] == [e2.id, e3.id]
+        assert [e.id for e in result.events] == [e2.id, e3.id]
+        assert result.gapped is False
 
     @pytest.mark.asyncio
-    async def test_unknown_id_returns_empty(self) -> None:
+    async def test_unknown_id_no_eviction_is_not_a_gap(self) -> None:
+        # An id that was never buffered, with no eviction, means nothing was lost.
         bus = EventBus()
         await bus.emit(LithosEvent(type=NOTE_CREATED))
         result = bus.get_buffered_since("nonexistent-id")
-        assert result == []
+        assert result.events == []
+        assert result.gapped is False
 
     @pytest.mark.asyncio
-    async def test_last_event_returns_empty(self) -> None:
+    async def test_last_event_is_caught_up_not_a_gap(self) -> None:
         bus = EventBus()
         e = LithosEvent(type=NOTE_CREATED)
         await bus.emit(e)
         result = bus.get_buffered_since(e.id)
-        assert result == []
+        assert result.events == []
+        assert result.gapped is False
+
+    @pytest.mark.asyncio
+    async def test_evicted_id_signals_gap(self) -> None:
+        # A reconnect id that fell off the ring must report a gap so the SSE
+        # client resyncs instead of silently under-delivering the replay.
+        bus = EventBus(EventsConfig(event_buffer_size=2))
+        e1 = LithosEvent(type=NOTE_CREATED)
+        await bus.emit(e1)
+        await bus.emit(LithosEvent(type=NOTE_UPDATED))
+        await bus.emit(LithosEvent(type=NOTE_DELETED))  # evicts e1 (maxlen=2)
+
+        result = bus.get_buffered_since(e1.id)
+        assert result.events == []
+        assert result.gapped is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_event_delivery.py
+++ b/tests/test_event_delivery.py
@@ -165,7 +165,7 @@ class TestFormatSSE:
         assert "id: " not in result
         assert "event: resync\n" in result
         data = json.loads(result.split("data: ")[1].strip())
-        assert data["reason"] == "buffer_evicted"
+        assert data["reason"] == "replay_gap"
         assert data["since_id"] == "evt-123"
         assert result.endswith("\n\n")
         assert EVENT_ORIGIN_ENRICH not in result
@@ -194,13 +194,26 @@ class TestGetBufferedSince:
         assert result.gapped is False
 
     @pytest.mark.asyncio
-    async def test_unknown_id_no_eviction_is_not_a_gap(self) -> None:
-        # An id that was never buffered, with no eviction, means nothing was lost.
+    async def test_unknown_id_signals_gap(self) -> None:
+        # An id the bus cannot locate — never emitted, or carried over from a
+        # previous server run — means continuity cannot be proven. Signal a gap
+        # so the SSE client resyncs instead of silently believing it is caught up.
         bus = EventBus()
         await bus.emit(LithosEvent(type=NOTE_CREATED))
-        result = bus.get_buffered_since("nonexistent-id")
+        result = bus.get_buffered_since("id-from-a-previous-run")
         assert result.events == []
-        assert result.gapped is False
+        assert result.gapped is True
+
+    @pytest.mark.asyncio
+    async def test_fresh_bus_with_prior_id_signals_gap(self) -> None:
+        # Restart case: a brand-new bus (empty ring, nothing evicted yet) asked
+        # to replay from a real pre-restart id cannot replay it. This must be a
+        # gap, not a silent "caught up" — the client missed everything before and
+        # during the downtime.
+        bus = EventBus()
+        result = bus.get_buffered_since("pre-restart-id")
+        assert result.events == []
+        assert result.gapped is True
 
     @pytest.mark.asyncio
     async def test_last_event_is_caught_up_not_a_gap(self) -> None:
@@ -407,16 +420,53 @@ class TestReplay:
         assert e1.id not in ids  # since= is exclusive
 
     @pytest.mark.asyncio
-    async def test_since_unknown_id_yields_no_replay(self, sse_server: LithosServer) -> None:
-        """Unknown since= ID yields no buffered replay (just live events)."""
+    async def test_unknown_since_id_emits_resync_and_streams(
+        self, sse_server: LithosServer
+    ) -> None:
+        """An unknown since= id (e.g. a Last-Event-ID from before a restart) makes
+        the endpoint emit a ``resync`` control event, then keep streaming live
+        events — fail-safe, not a silent no-replay.
+        """
         live = LithosEvent(type=NOTE_CREATED, agent="live")
         request = _make_mock_request(sse_server, since="no-such-id")
         lines = await _collect_sse_lines(sse_server, request, emit_events=[live])
-        events = _parse_sse_events(lines)
 
-        # Only the live event should appear
-        ids = [e["id"] for e in events]
-        assert live.id in ids
+        # The endpoint signalled a resync (control event, no id: line).
+        resync_chunks = [c for c in lines if "event: resync" in c]
+        assert len(resync_chunks) == 1
+        assert "id: " not in resync_chunks[0]
+
+        # And the stream still delivered the live event after the resync signal.
+        events = _parse_sse_events(lines)
+        assert any(e.get("id") == live.id for e in events)
+
+    @pytest.mark.asyncio
+    async def test_evicted_since_id_emits_resync(self, temp_dir: Path) -> None:
+        """End-to-end: an evicted reconnect id makes ``_sse_endpoint`` emit resync.
+
+        Covers the endpoint's gap branch, not just ``get_buffered_since``: with a
+        tiny ring, pre-populate past the reconnect id so it is evicted, connect
+        with ``since=<evicted-id>``, and assert the wire carries an ``event:
+        resync`` control message with no ``id:`` line.
+        """
+        config = _make_config(temp_dir)
+        config.events.event_buffer_size = 2
+        server = LithosServer(config)
+        await server.initialize()
+        try:
+            e1 = LithosEvent(type=NOTE_CREATED, agent="old")
+            await server.event_bus.emit(e1)
+            await server.event_bus.emit(LithosEvent(type=NOTE_UPDATED))
+            await server.event_bus.emit(LithosEvent(type=NOTE_DELETED))  # evicts e1
+
+            request = _make_mock_request(server, since=e1.id)
+            lines = await _collect_sse_lines(server, request, emit_events=[])
+
+            resync_chunks = [c for c in lines if "event: resync" in c]
+            assert len(resync_chunks) == 1
+            assert "id: " not in resync_chunks[0]  # must not become next Last-Event-ID
+        finally:
+            await server.shutdown()
 
     @pytest.mark.asyncio
     async def test_last_event_id_header_replay(self, sse_server: LithosServer) -> None:

--- a/tests/test_graph_conformance.py
+++ b/tests/test_graph_conformance.py
@@ -1,0 +1,130 @@
+"""Conformance test suite for the link Graph derived view.
+
+The Graph is one of Reconcile's three symmetric derived views (Search, Graph,
+Provenance). Provenance and freshness already have conformance suites; this
+fills the gap for the corpus-wiki-links->graph projection (task 87b45d1f,
+item 11e).
+
+Invariants proven here:
+
+- Node set == corpus: every written doc becomes a graph node and nothing else.
+- Links become edges with backlinks: a ``[[target]]`` in A's content produces
+  an outgoing A->B edge and a symmetric incoming B<-A backlink.
+- resolve_link matches the corpus: a resolvable target resolves to its doc id.
+- Unresolved links are not fabricated: a dangling ``[[...]]`` creates no
+  phantom node or edge and does not resolve.
+- Idempotent convergence: once the derived view is reconciled to the corpus,
+  re-planning finds no drift, and applying again leaves it converged.
+
+Note on wiki-link form: ``resolve_link`` resolves by path / filename-slug /
+uuid / alias, not by a title-with-spaces. Notes here use the slug form
+(``[[beta-note]]`` for the note titled "Beta Note", stored at ``beta-note.md``)
+so links resolve deterministically regardless of write order.
+"""
+
+import pytest
+
+from lithos.server import LithosServer
+from tests.helpers import call_tool
+
+pytestmark = pytest.mark.integration
+
+
+async def _write(server: LithosServer, title: str, content: str) -> str:
+    """Write a note through the MCP path and return its id."""
+    result = await call_tool(
+        server,
+        "lithos_write",
+        {"title": title, "content": content, "agent": "conf-agent"},
+    )
+    assert result["status"] == "created"
+    return result["id"]
+
+
+class TestGraphNodeSetConformance:
+    """The graph's node set mirrors the corpus exactly."""
+
+    async def test_node_set_equals_corpus(self, server: LithosServer):
+        """Every written doc is a node; no extra nodes exist."""
+        ids = {
+            await _write(server, "Node One", "First node."),
+            await _write(server, "Node Two", "Second node."),
+            await _write(server, "Node Three", "Third node."),
+        }
+        assert server.graph.get_doc_ids() == ids
+
+
+class TestGraphEdgeConformance:
+    """Wiki-links project to directed edges with symmetric backlinks."""
+
+    async def test_links_become_edges_with_backlinks(self, server: LithosServer):
+        """A ``[[beta-note]]`` in A yields A->B outgoing and B<-A incoming."""
+        b_id = await _write(server, "Beta Note", "Target note.")
+        a_id = await _write(server, "Alpha Note", "Alpha references [[beta-note]] inline.")
+
+        outgoing = server.graph.get_links(a_id, direction="outgoing")
+        assert b_id in {d.id for d in outgoing.outgoing}
+
+        incoming = server.graph.get_links(b_id, direction="incoming")
+        assert a_id in {d.id for d in incoming.incoming}
+
+    async def test_resolve_link_matches_corpus(self, server: LithosServer):
+        """A resolvable slug target resolves to the corresponding doc id."""
+        b_id = await _write(server, "Beta Note", "Target note.")
+        assert server.graph.resolve_link("beta-note") == b_id
+
+
+class TestGraphUnresolvedConformance:
+    """Dangling wiki-links are never fabricated into nodes or edges."""
+
+    async def test_unresolved_link_not_fabricated(self, server: LithosServer):
+        """A ``[[ghost-note]]`` with no matching doc creates no phantom.
+
+        resolve_link returns None, the graph's doc-id set stays limited to the
+        real corpus, and the source note has no resolved outgoing edge (the
+        placeholder is not a real node).
+        """
+        solo_id = await _write(server, "Solo Note", "Solo mentions [[ghost-note]] which is absent.")
+
+        assert server.graph.resolve_link("ghost-note") is None
+        # No phantom node leaked into the corpus node set.
+        assert server.graph.get_doc_ids() == {solo_id}
+        # The dangling link produced no resolved outgoing edge.
+        outgoing = server.graph.get_links(solo_id, direction="outgoing")
+        assert outgoing.outgoing == []
+
+
+class TestGraphReconcileConformance:
+    """Corpus-wiki-links->graph derived-view convergence over the seam."""
+
+    async def test_reconcile_converges_and_is_idempotent(self, server: LithosServer):
+        """Once reconciled to the corpus, the graph view stays converged.
+
+        Writes update the in-memory graph, but the on-disk graph cache the
+        planner reads is debounced (#203) and may lag, so the first plan after
+        writes reports drift. Applying it flushes a cache that agrees with the
+        corpus; re-planning is then a noop, and applying that noop again leaves
+        it converged. Plain notes (no wiki-links) keep the corpus free of
+        dangling targets, which would otherwise surface as report-only
+        ``stale_link`` actions.
+        """
+        await _write(server, "Converge One", "Plain body one.")
+        await _write(server, "Converge Two", "Plain body two.")
+        await _write(server, "Converge Three", "Plain body three.")
+
+        # Bring the derived view into agreement with the corpus.
+        plan = await server.knowledge.plan_reconcile(graph=server.graph)
+        assert plan.graph is not None
+        await server.knowledge.apply_reconcile(plan, graph=server.graph)
+
+        # Converged: re-planning finds no drift.
+        converged = await server.knowledge.plan_reconcile(graph=server.graph)
+        assert converged.graph is not None
+        assert converged.graph.is_noop
+        assert converged.graph.actions == ()
+
+        # Idempotent: applying the noop plan and re-planning stays converged.
+        await server.knowledge.apply_reconcile(converged, graph=server.graph)
+        again = await server.knowledge.plan_reconcile(graph=server.graph)
+        assert again.graph is not None
+        assert again.graph.is_noop

--- a/tests/test_search_conformance.py
+++ b/tests/test_search_conformance.py
@@ -1,0 +1,149 @@
+"""Conformance test suite for the Search engine derived view.
+
+Search is one of Reconcile's three symmetric derived views (Search, Graph,
+Provenance). Provenance and freshness already have conformance suites; this
+fills the gap for the corpus->index projection (task 87b45d1f, item 11e).
+
+Invariants proven here:
+
+- Convergence: a corpus written through the normal path leaves the search
+  index already in agreement — reconcile finds no doc-set drift.
+- Indexed-set == corpus: both search backends index exactly the written docs.
+- Idempotent apply: applying a reconcile repairs drift, and a repaired index
+  needs no further action; applying again leaves the same state.
+- Round-trip: written content is actually findable through ``lithos_search``.
+"""
+
+import pytest
+
+from lithos.server import LithosServer
+from tests.helpers import call_tool
+
+pytestmark = pytest.mark.integration
+
+
+# Distinctive bodies so full-text search can disambiguate the round-trip doc.
+_CORPUS = {
+    "Distributed Systems Primer": (
+        "Consensus, replication, and partition tolerance in distributed systems."
+    ),
+    "Vector Databases": ("Embeddings and approximate nearest neighbor search in vector databases."),
+    "Graph Theory Notes": "Nodes, edges, and traversal algorithms in graph theory.",
+}
+
+
+async def _seed_corpus(server: LithosServer) -> set[str]:
+    """Write ``_CORPUS`` through the MCP write path and return the doc ids.
+
+    ``lithos_write`` persists the note AND indexes it through the normal
+    corpus->index projection, so on return the search backends should already
+    agree with the corpus.
+    """
+    ids: set[str] = set()
+    for title, content in _CORPUS.items():
+        result = await call_tool(
+            server,
+            "lithos_write",
+            {"title": title, "content": content, "agent": "conf-agent"},
+        )
+        assert result["status"] == "created"
+        ids.add(result["id"])
+    return ids
+
+
+class TestSearchReconcileConformance:
+    """Corpus->index derived-view invariants over the reconcile seam."""
+
+    async def test_written_corpus_needs_no_search_rebuild(self, server: LithosServer):
+        """A freshly-written corpus is already converged — no doc-set drift.
+
+        The server's one-shot startup schema rebuild leaves Tantivy's
+        ``needs_rebuild`` flag set (it is not cleared by the rebuild path), so a
+        raw plan always carries a ``schema_mismatch`` action. That flag is a
+        startup concern orthogonal to the write-path convergence invariant; the
+        existing reconcile unit tests (``test_search_reconcile.py``) flatten it
+        the same way before asserting doc-set state.
+        """
+        await _seed_corpus(server)
+        server.search.mark_needs_rebuild(False)
+
+        plan = await server.knowledge.plan_reconcile(search=server.search)
+
+        assert plan.search is not None
+        assert plan.search.is_noop
+        assert plan.search.actions == ()
+
+    async def test_indexed_set_equals_corpus(self, server: LithosServer):
+        """Both search backends index exactly the set of written doc ids.
+
+        These are the same backend accessors ``plan_reconcile_to`` compares
+        against the corpus, so the equality here is what makes convergence hold.
+        """
+        ids = await _seed_corpus(server)
+
+        assert server.search._tantivy.get_indexed_doc_ids() == ids
+        assert server.search._chroma.get_indexed_doc_ids() == ids
+
+    async def test_apply_repairs_drift_and_is_idempotent(self, server: LithosServer):
+        """apply_reconcile repairs a drifted index; a repaired index converges.
+
+        Drift is made real (not just the schema flag) by clearing both
+        backends, so the plan reports ``doc_set_mismatch``. After applying, the
+        index matches the corpus and re-planning is a noop — applying again
+        leaves the same state.
+        """
+        ids = await _seed_corpus(server)
+        # Flatten the startup schema flag so drift is attributable to doc sets.
+        server.search.mark_needs_rebuild(False)
+        # Establish genuine drift: indices emptied, corpus still holds N docs.
+        server.search.clear_all()
+
+        drift_plan = await server.knowledge.plan_reconcile(search=server.search)
+        assert drift_plan.search is not None
+        assert not drift_plan.search.is_noop
+        reasons = {a.reason for a in drift_plan.search.actions}
+        assert reasons == {"doc_set_mismatch"}
+
+        result = await server.knowledge.apply_reconcile(drift_plan, search=server.search)
+        assert result.search is not None
+        assert result.search.failed == ()
+
+        # Repaired: index matches corpus and re-planning finds nothing to do.
+        converged = await server.knowledge.plan_reconcile(search=server.search)
+        assert converged.search is not None
+        assert converged.search.is_noop
+        assert server.search._tantivy.get_indexed_doc_ids() == ids
+        assert server.search._chroma.get_indexed_doc_ids() == ids
+
+        # Idempotent: applying the noop plan changes nothing.
+        await server.knowledge.apply_reconcile(converged, search=server.search)
+        again = await server.knowledge.plan_reconcile(search=server.search)
+        assert again.search is not None
+        assert again.search.is_noop
+        assert server.search._tantivy.get_indexed_doc_ids() == ids
+
+
+class TestSearchRoundTripConformance:
+    """The corpus->index projection actually makes content findable."""
+
+    async def test_written_note_is_findable(self, server: LithosServer):
+        """A written note is returned by ``lithos_search`` for its own content."""
+        write = await call_tool(
+            server,
+            "lithos_write",
+            {
+                "title": "Photosynthesis Overview",
+                "content": "Chloroplasts convert sunlight into chemical energy via photosynthesis.",
+                "agent": "conf-agent",
+            },
+        )
+        assert write["status"] == "created"
+        doc_id = write["id"]
+
+        result = await call_tool(
+            server,
+            "lithos_search",
+            {"query": "chloroplasts sunlight photosynthesis"},
+        )
+        hit_ids = {r["id"] for r in result["results"]}
+        assert doc_id in hit_ids


### PR DESCRIPTION
## What

The **final PR of the 2026-07 architecture-cleanup roadmap** — two independent items from task 11.

## 11a — EventBus SSE-replay gap signal (robustness bug)

On reconnect, the SSE endpoint calls `EventBus.get_buffered_since(since_id)` and streams the events after it. That method returned `[]` for **three indistinguishable cases**: *caught up* (id is the newest), *unknown* (never emitted, or carried over from a previous server run after a restart), and *evicted* (the client's position fell off the ring). The last two are data loss — but the endpoint streamed nothing for all three, so **a client that missed events silently believed it was in sync**.

**Fix (minimal, no id-scheme change):** `get_buffered_since` now returns a `BufferedReplay(events, gapped)` NamedTuple and decides continuity purely by **presence of the id in the ring**:

- **found** → replay the events after it, `gapped=False` (a caught-up client's id is the newest buffered event, so it matches → no spurious resync);
- **absent** → `gapped=True`, covering evicted / previous-run / never-emitted alike — the bus cannot prove continuity from the id.

When gapped, the SSE endpoint emits a new `event: resync` control message (no `id:` line, so it can't become the next `Last-Event-ID`) telling the client to resync from current state. **Fail-safe:** a fabricated id triggers a harmless resync rather than a silent under-delivery.

Presence-based detection (rather than an eviction flag or low-water mark) is what makes the **server-restart** reconnect correct: after a restart the ring is fresh and nothing has been evicted, yet a real pre-restart `Last-Event-ID` is absent → gap → resync. Chosen over a monotonic-sequence rework, which would have changed the SSE wire `id:` contract every consumer relies on.

## 11e — search + graph conformance suites (test gap)

Provenance and freshness had conformance suites; the **Search engine** and **link Graph** — the other two of Reconcile's three symmetric derived views — did not. New `tests/test_search_conformance.py` (4) and `tests/test_graph_conformance.py` (5), `pytest.mark.integration`, mirror the established pattern (seed a corpus via `lithos_write`, drive `KnowledgeManager.plan_reconcile` / `apply_reconcile`). They assert the derived-view invariants:

- **Search** — indexed set (both backends) == corpus; real drift (`clear_all`) is repaired and re-plan converges (idempotent apply); written content is findable via `lithos_search`.
- **Graph** — node set == corpus; wiki-links project to edges with **symmetric backlinks**; `resolve_link` matches the corpus; dangling `[[links]]` fabricate **no phantom** node/edge; reconcile converges idempotently.

## Metrics

| metric | before | after |
|---|---|---|
| cross_module_private_refs | 29 | 29 |
| cross_component_edges | 71 | 71 |
| component_cycles / module_cycles | 0 / 1 | 0 / 1 |
| modules_over_800_lines | 11 | 11 |
| tests_private_imports | 87 | 88 |

`tests_private_imports` +1 is the `_format_resync_sse` helper import in the SSE-format unit test (same pattern as the existing `_format_sse` import). `events.py` 323→350, `server.py` 861→899.

## Tests

New SSE unit + endpoint tests pin the fix: `get_buffered_since` reports `gapped=True` for any absent id (evicted / previous-run / unknown) and `gapped=False` only when the id is still buffered (including a caught-up client); `_sse_endpoint` emits `event: resync` with no `id:` line and keeps streaming live events afterwards. The 9 conformance tests run under `make test-integration`.

## Verification

- `make check` — **1614 passed**, typecheck + lint clean
- `make test-integration` — includes the 9 new conformance tests
- `make diagrams` — **48 guardrails**

This closes the 8-PR roadmap (tasks 2, 6, 9, 3, 4, 7, 5, 11).
