### PR TITLE
docs(lcma): promote revised MVP-3 plan into lcma-design + checklist

### DIFF
--- a/docs/plans/lcma-checklist.md
+++ b/docs/plans/lcma-checklist.md
@@ -140,23 +140,58 @@ Exit criteria (all MVPs):
 
 ---
 
-## MVP 3 — Advanced Cognition
+## MVP 3 — Advanced Cognition (revised 2026-07)
 
-- [ ] Analogy scout: frame extraction (`{problem, constraints, actions, outcome, lessons}`) + structural matching
-- [ ] Computed temperature in `lithos_retrieve` Terrace 1: `temperature = 1 - coherence` (coherence = mean edge strength among top candidates) — activated when edges exceed threshold; MVP 1 returns fixed default (0.5)
-- [ ] Temperature-guided exploration depth (high temp → deeper exploration, more `scout_exploration` weight)
-- [ ] `scout_exploration` with novelty/random/mixed modes
-- [ ] Concept nodes: regular notes with `note_type: "concept"` created via `lithos_write` — concepts are derived clusters first, with explicit promotion/materialization (not auto-materialized early)
-- [ ] Concept node formation from stable coactivation clusters (`maybe_update_concepts`) — runs inside `lithos-enrich`, not `lithos_retrieve` hot path
-- [ ] Concept node damping: salience ceiling + diversity penalty for repeated concept retrieval
-- [ ] Embedding space versioning via separate ChromaDB collections per space (`knowledge_<space_id>`)
-- [ ] Multi-space vector scout during embedding migration
-- [ ] `lithos_receipts` tool — query retrieval audit history from `receipts` table in `stats.db`
-- [ ] Background LLM synthesis in `lithos-enrich` (requires `LithosConfig.lcma.llm_provider` config) — produces persistent artifacts (summaries, concept notes, edge annotations), not query-time reranking
+> Revised plan grounded in the 2026-07 substrate measurement (see the MVP-3 section of
+> `lcma-design.md` and KB note `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`).
+> Embedding-space versioning dropped; analogy/concepts/temperature re-grounded; Lithos Lens added
+> as a consumer.
+
+**Gated prerequisites (separate tasks, not MVP-3 work):**
+
+- [ ] Salience recalibration — task `e7d8ef60` (HIGH; `blocks` this epic)
+- [ ] Feedback capture — task `fc4b0669`
+- [ ] (operational) Semantic-index coverage reconcile — task `97cd00bb`
+
+**WS1 — LLM-synthesis backbone**
+
+- [ ] Optional `LcmaConfig.llm_provider` (local or external) wired into `lithos-enrich`; background, budget-bounded, provenance-stamped, idempotent
+
+**WS2 — Typed-edge inference**
+
+- [ ] Infer `supports`/`contradicts`/`refines`/`is_example_of`/`depends_on`/`analogy_to` over semantic-neighbour pairs (LLM-adjudicated), written to `edges.db` with `provenance_type=inferred`
+- [ ] Governance: inferred ≠ asserted, confidence floor, `contradicts` surfaced not auto-applied
+
+**WS3 — Coherence / temperature / exploration**
+
+- [ ] `coherence = 1 − semantic dispersion` (embedding variance); `temperature = 1 − coherence`
+- [ ] `scout_exploration` (novelty + graph-frontier, temperature-weighted); no pure-random mode
+
+**WS4 — Concept nodes**
+
+- [ ] Density-cluster embeddings (HDBSCAN; tight eps ≈ 0.18–0.22 / min_size ≈ 4–8), validate by coactivation, promote stable clusters to `note_type: concept` (gateway model)
+- [ ] Damping (salience ceiling — needs `e7d8ef60` — + diversity + promotion threshold); provenance-stamped + reversible
+
+**WS5 — Analogy scout**
+
+- [ ] LLM frame extraction `{problem, constraints, actions, outcome, lessons}` from task outcomes/findings; `scout_analogy` structural match (incl. cross-namespace)
+
+**WS6 — Metamemory (implicit)**
+
+- [ ] Tune `rerank_weights` from receipts/coactivation/outcomes (no explicit labels); apply behind a flag; folds `ac6ddb9f`
+
+**WS7 — Lithos Lens surface**
+
+- [ ] `lithos_related`: resolve edge titles; normalised neighbour shape + `source`; opt-in `semantic`/`coactivation` includes; `relation_types`/`sources`/`min_weight`/`limit`/`order`; ranked `neighbours` list
+- [ ] `lithos_edge_list`: `source`/`min_weight` filters + endpoint titles
+- [ ] `provenance_type` controlled vocabulary (`asserted`·`inferred`·`consolidation`·`frontmatter`)
+- [ ] `lithos_receipts` — query retrieval audit history from `receipts`
+
+**Dropped:** embedding-space versioning + multi-space vector scout (→ separate infra task).
 
 **Exit criteria:**
 
 - Analogy scout returns structurally similar notes across domains
-- Temperature operationalized and controlling exploration depth
+- Temperature operationalized (embedding-based) and controlling exploration depth
 - Concept nodes emerge from usage patterns without manual curation
-- Embedding model can be upgraded without losing retrieval quality during transition
+- `lithos_related` renders a typed, provenanced neighbourhood for Lens

--- a/docs/plans/lcma-checklist.md
+++ b/docs/plans/lcma-checklist.md
@@ -184,7 +184,7 @@ Exit criteria (all MVPs):
 
 - [ ] `lithos_related`: resolve edge titles; normalised neighbour shape + `source`; opt-in `semantic`/`coactivation` includes; `relation_types`/`sources`/`min_weight`/`limit`/`order`; ranked `neighbours` list
 - [ ] `lithos_edge_list`: `source`/`min_weight` filters + endpoint titles
-- [ ] `provenance_type` controlled vocabulary (`asserted`·`inferred`·`consolidation`·`frontmatter`)
+- [ ] Read-time `source` mapping over existing free-form `provenance_type` (human/agent/rule/manual→asserted, reinforcement/consolidation→consolidation, frontmatter→provenance, inferred→inferred) — no persisted-vocab change/migration
 - [ ] `lithos_receipts` — query retrieval audit history from `receipts`
 
 **Dropped:** embedding-space versioning + multi-space vector scout (→ separate infra task).

--- a/docs/plans/lcma-checklist.md
+++ b/docs/plans/lcma-checklist.md
@@ -143,7 +143,9 @@ Exit criteria (all MVPs):
 ## MVP 3 — Advanced Cognition (revised 2026-07)
 
 > Revised plan grounded in the 2026-07 substrate measurement (see the MVP-3 section of
-> `lcma-design.md` and KB note `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`).
+> `lcma-design.md` and the Lithos knowledge-base note
+> `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`, under `$LITHOS_DATA_DIR/knowledge/`
+> — not committed to git).
 > Embedding-space versioning dropped; analogy/concepts/temperature re-grounded; Lithos Lens added
 > as a consumer.
 
@@ -155,7 +157,7 @@ Exit criteria (all MVPs):
 
 **WS1 — LLM-synthesis backbone**
 
-- [ ] Optional `LcmaConfig.llm_provider` (local or external) wired into `lithos-enrich`; background, budget-bounded, provenance-stamped, idempotent
+- [ ] Optional `LithosConfig.lcma.llm_provider` (local or external) wired into `lithos-enrich`; background, budget-bounded, provenance-stamped, idempotent
 
 **WS2 — Typed-edge inference**
 
@@ -169,7 +171,7 @@ Exit criteria (all MVPs):
 
 **WS4 — Concept nodes**
 
-- [ ] Density-cluster embeddings (HDBSCAN; tight eps ≈ 0.18–0.22 / min_size ≈ 4–8), validate by coactivation, promote stable clusters to `note_type: concept` (gateway model)
+- [ ] Density-cluster embeddings (HDBSCAN: `min_cluster_size` ≈ 4–8, small `min_samples`; measured via DBSCAN `eps` ≈ 0.18–0.22), validate by coactivation, promote stable clusters to `note_type: concept` (gateway model)
 - [ ] Damping (salience ceiling — needs `e7d8ef60` — + diversity + promotion threshold); provenance-stamped + reversible
 
 **WS5 — Analogy scout**

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -1501,15 +1501,136 @@ Write-contract note for LCMA params:
 - `lithos-enrich` pseudocode finalized (§5.12) before implementation begins
 - Differentiated `note_type_priors` tuning based on MVP 1 learning data
 
-## MVP 3 (Hofstadter-flavored)
+## MVP 3 — Advanced Cognition (revised 2026-07)
 
-> **Note**: Background LLM synthesis is part of `lithos-enrich`, not `lithos_retrieve`. It runs asynchronously and produces persistent artifacts. `lithos_retrieve` remains Terrace 0 + Terrace 1 only.
+> **Supersedes the earlier Hofstadter-framed MVP-3 sketch** and the MVP-3 mechanism notes woven
+> into §5.2 (analogy/exploration scouts), §5.3 (edge-based temperature) and §5.8
+> (coactivation-seeded concepts) **wherever they conflict**. Grounded in a read-only substrate
+> measurement of production (2026-07); full findings + numbers in the KB note
+> `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`.
 
-- Analogy scout (frame extraction — new, no existing equivalent)
-- Exploration scout (novelty/random/mixed modes, temperature-guided)
-- Temperature-based exploration depth
-- Concept nodes (regular notes with `note_type: "concept"`) + damping
-- Embedding space versioning via ChromaDB collections
+MVP-3 was conceived in 2026-03, before the KB had content or interaction, and framed around
+Hofstadter's Copycat (analogy / temperature / terraces as *query-time search*). Two things
+invalidate parts of that framing: (1) the measured substrate below, and (2) a new consumer —
+**Lithos Lens**, a knowledge-*browsing* UI that must render a document's linked + related
+neighbours, which turns MVP-3's graph enrichment into a **product surface**.
+
+**Reframed goal:** from "clever query-time search" to **"LLM-assisted background enrichment over a
+semantic substrate, surfaced as explainable typed relationships."** `lithos_retrieve` stays fast
+(Terrace-0 union + Terrace-1 rerank only); the intelligence accrues in the `lithos-enrich`
+background worker as persistent artifacts (typed edges, concept notes, analogy frames) read by
+*both* `lithos_retrieve` and Lens (via `lithos_related`).
+
+### Measured substrate (production, 2026-07)
+
+| signal | measurement | consequence |
+|---|---|---|
+| typed edges | 2,302 edges, but 2 genuine relation types (`contradicts`/`summarizes`); 88% weight-≤0.05 `related_to`; 17% node coverage | graph is *semantically empty* → WS2 typed-edge inference is the top lever |
+| coactivation | 8,175 pairs, 295 with count ≥5 | real but modest → *validates* clusters, doesn't seed them |
+| temperature | 0.5 on all 1,946 receipts | inert → WS3 recomputes on embeddings |
+| salience 🔴 | avg 0.076, 86% of nodes ≤0.30 | collapsed (live bug) → prereq `e7d8ef60` |
+| explicit feedback 🔴 | cited 8 / misleading 0 over 1,486 tasks | empty → WS6 uses implicit signals; prereq `fc4b0669` |
+| analogy material | 1,348 task outcomes (91% of completed) | abundant → WS5 is well-supported |
+| semantic coverage 🔴 | chroma holds 935 / 3,115 docs (reading-pile skewed) | operational drift → task `97cd00bb`; embedding-driven WS assume it is repaired |
+
+### Gated prerequisites (external tasks — not MVP-3 workstreams)
+
+- **Salience recalibration** — `e7d8ef60` (HIGH, live retrieval bug). Wired as a `blocks`
+  predecessor of this epic (`d921d168`); WS4 damping + WS6 depend on a meaningful salience spread.
+- **Feedback capture** — `fc4b0669`. Start early to bank labels for WS6.
+- **Semantic-index coverage (operational)** — `97cd00bb`. A `plan_reconcile(search=)` / re-embed
+  backfills the ~2,180 unindexed docs. Not a design workstream; the embedding-driven workstreams
+  below assume coverage is repaired.
+
+### Workstreams
+
+**WS1 — LLM-synthesis worker (backbone).** `lithos-enrich` gains an **optional** LLM provider
+(`LcmaConfig.llm_provider`, local or external — local keeps privacy-first deployments whole).
+Query-independent, background, budget-bounded; never on the retrieve hot path. Emits provenance-
+stamped, idempotent artifacts (the `enrich_queue` already sequences work). Enables WS2/WS4/WS5.
+
+**WS2 — Typed-edge inference (top lever + Lens enabler).** For each node, take its top semantic
+neighbours as candidate pairs, cheap-pre-filter (similarity + entity/tag overlap), then have WS1
+adjudicate **relation type + direction + confidence**: `supports`, `contradicts`, `refines`,
+`is_example_of`, `depends_on`, `analogy_to`. Write to `edges.db` **reusing the existing provenance
+columns** (no migration): `provenance_type="inferred"`, `provenance_actor="lithos-enrich"`,
+`weight=confidence`, `evidence={rationale, model, confidence}`. Lifts coverage from 17% with *real*
+semantic types and — because `lithos_related` already surfaces `edges.db` — feeds Lens for free.
+Governance: inferred ≠ asserted (marked + filterable); confidence floor; `contradicts` is surfaced,
+never auto-mutating.
+
+**WS3 — Embedding-based coherence + temperature + exploration.** Edge-based coherence is dead (17%
+coverage); redefine **coherence = 1 − normalised semantic dispersion** of the top candidates
+(embedding variance). `temperature = 1 − coherence` then varies and drives an **exploration scout**
+(novelty: semantically adjacent but low-salience / rarely-retrieved + graph-frontier). Drop
+pure-random.
+
+**WS4 — Concept nodes (semantic clusters + Memora gateway).** Cluster document embeddings and
+**validate** clusters with coactivation + entity/tag cohesion; promote stable clusters to
+`note_type: concept` notes (WS1 writes a summary + member links; gateway model — retrieval returns
+concept + specifics). Damping (needs `e7d8ef60`): salience ceiling + diversity penalty + promotion
+threshold. Governance: provenance-stamped, reviewable, reversible; never overwrite human notes.
+*Measured thresholds (2026-07, over the currently-embedded content — provisional until `97cd00bb`):*
+semantic separation is weak (silhouette ~0.05), so **use density clustering (HDBSCAN), not fixed-K
+KMeans**; tight params (cosine eps ≈ 0.18–0.22, min_cluster_size ≈ 4–8) yield **~15–30 concept
+candidates over ~20–30%** of docs, with noise treated as a feature (don't force a concept for
+everything); coactivation validation is load-bearing given the weak separation.
+
+**WS5 — Analogy scout (task-outcome frames).** WS1 extracts `{problem, constraints, actions,
+outcome, lessons}` frames from the 1,348 task outcomes + 117 findings; `scout_analogy` structurally
+matches a query/task against frame slots, surfacing structurally-similar prior work (incl.
+cross-namespace). Registers via `SCOUT_REGISTRY`.
+
+**WS6 — Metamemory (implicit signals).** Explicit feedback is empty, so tune from receipt
+`final_nodes` recurrence, coactivation strength, task-outcome success, and staleness; periodically
+fit `LcmaConfig.rerank_weights`, apply behind a flag, measure. Folds the open calibration
+observation `ac6ddb9f` (#179). Depends on `e7d8ef60`.
+
+**WS7 — Lithos Lens integration surface (read-shape enrichment; no migration, no write-tool
+change).** `lithos_related` already merges links + provenance + typed edges + `related_ids`, and
+`edges.db` / `lithos_edge_upsert` already carry provenance — so the work is:
+
+- **`lithos_related`:** resolve **titles** on edge entries (currently raw ids); normalise every
+  neighbour to `{id, title, note_type, namespace, relation, source, direction, weight, rationale?}`
+  where `source ∈ asserted | provenance | inferred | semantic | coactivation` (mapped from
+  `provenance_type`); add opt-in `include` values `semantic` (ChromaDB k-NN) + `coactivation`
+  (default stays the structural three — backward compatible); add `relation_types` / `sources` /
+  `min_weight` / `limit` / `order` params; upgrade `related_ids` → a ranked flat `neighbours` list.
+- **`lithos_edge_list`:** add `source` / `min_weight` filters + endpoint titles.
+- **`lithos_edge_upsert`:** no change (WS2 uses the existing provenance args).
+- **Data discipline:** give `provenance_type` a controlled vocabulary
+  (`asserted` · `inferred` · `consolidation` · `frontmatter`) so the read layer maps `→ source`.
+
+Freeze the neighbour shape + `source` vocabulary alongside WS2 so Lens builds against it while
+enrichment fills `edges.db`. Lens then becomes MVP-3's external validation.
+
+### Sequence & dependencies
+
+`WS0 prereqs (e7d8ef60, fc4b0669; + operational 97cd00bb)` → `WS1` → `WS2` (freeze the WS7 contract
+here) → { `WS3`, `WS4` (needs e7d8ef60), `WS5`, `WS7` } → `WS6` (needs e7d8ef60). Prerequisites are
+gated via task-edges, not folded into this epic.
+
+### Non-goals / dropped
+
+- **Embedding-space versioning + transition querying** — dropped from MVP-3; spin to a separate
+  low-priority infra task, revisited only if the embedding model changes.
+- Pure-random exploration; LLM synthesis on the retrieve hot path; auto-overwriting human notes.
+
+### Success criteria
+
+- Salience distribution recovers (no longer 86% floored).
+- Typed-edge coverage 17% → majority, with real semantic types.
+- `lithos_related` returns a typed, provenanced, explainable neighbourhood Lens can render.
+- `scout_analogy` surfaces a structurally-similar prior task on a held-out set.
+- Rerank weights improve on the implicit-relevance metric; `contradicts` edges exist and surface.
+
+### Decisions (Dave, 2026-07)
+
+LLM synthesis = backbone with a **local/optional** provider; coherence redefined on **embedding
+dispersion** + **typed-edge inference** to densify; **embedding-versioning dropped**; prerequisites
+kept as **separate gated tasks**, not folded; **Lens is a first-class consumer** (the
+`lithos_related` neighbourhood is the browse surface); coverage reconcile handled **operationally**,
+not as a design workstream.
 
 ---
 
@@ -1547,8 +1668,12 @@ Write-contract note for LCMA params:
 - `lithos_node_stats` — view/query salience and usage stats
 - `lithos_conflict_resolve` — contradiction resolution
 
-**MVP 3:**
+**MVP 3 (revised — see the MVP-3 section above):**
 
+- **Extended, not new (WS7 Lens surface):** `lithos_related` gains title resolution, a normalised
+  neighbour shape with `source`, opt-in `semantic`/`coactivation` includes, and rank/filter params;
+  `lithos_edge_list` gains `source`/`min_weight` filters + endpoint titles. `lithos_edge_upsert` is
+  unchanged.
 - `lithos_receipts` — query retrieval audit history
 
   ```python

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -1521,8 +1521,9 @@ Write-contract note for LCMA params:
 > temperature — now embedding-dispersion), §5.2 (analogy/exploration scouts — pure-random dropped)
 > and §5.8 (coactivation-seeded concepts — now semantic clusters) **wherever they conflict; those
 > sections carry inline `Superseded` markers**. Grounded in a read-only substrate
-> measurement of production (2026-07); full findings + numbers in the KB note
-> `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`.
+> measurement of production (2026-07); full findings + numbers in the Lithos **knowledge-base**
+> note `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md` (stored under
+> `$LITHOS_DATA_DIR/knowledge/`, not a git-tracked file).
 
 MVP-3 was conceived in 2026-03, before the KB had content or interaction, and framed around
 Hofstadter's Copycat (analogy / temperature / terraces as *query-time search*). Two things
@@ -1560,7 +1561,7 @@ background worker as persistent artifacts (typed edges, concept notes, analogy f
 ### Workstreams
 
 **WS1 — LLM-synthesis worker (backbone).** `lithos-enrich` gains an **optional** LLM provider
-(`LcmaConfig.llm_provider`, local or external — local keeps privacy-first deployments whole).
+(`LithosConfig.lcma.llm_provider`, local or external — local keeps privacy-first deployments whole).
 Query-independent, background, budget-bounded; never on the retrieve hot path. Emits provenance-
 stamped, idempotent artifacts (the `enrich_queue` already sequences work). Enables WS2/WS4/WS5.
 
@@ -1587,7 +1588,8 @@ concept + specifics). Damping (needs `e7d8ef60`): salience ceiling + diversity p
 threshold. Governance: provenance-stamped, reviewable, reversible; never overwrite human notes.
 *Measured thresholds (2026-07, over the currently-embedded content — provisional until `97cd00bb`):*
 semantic separation is weak (silhouette ~0.05), so **use density clustering (HDBSCAN), not fixed-K
-KMeans**; tight params (cosine eps ≈ 0.18–0.22, min_cluster_size ≈ 4–8) yield **~15–30 concept
+KMeans** — HDBSCAN core params `min_cluster_size` ≈ 4–8 (+ small `min_samples`; optional
+`cluster_selection_epsilon`). *Measured* with DBSCAN at cosine `eps` ≈ 0.18–0.22, which yields **~15–30 concept
 candidates over ~20–30%** of docs, with noise treated as a feature (don't force a concept for
 everything); coactivation validation is load-bearing given the weak separation.
 
@@ -1607,7 +1609,7 @@ change).** `lithos_related` already merges links + provenance + typed edges + `r
 
 - **`lithos_related`:** resolve **titles** on edge entries (currently raw ids); normalise every
   neighbour to `{id, title, note_type, namespace, relation, source, direction, weight, rationale?}`
-  where `source ∈ asserted | provenance | inferred | semantic | coactivation` (mapped from
+  where `source ∈ asserted | provenance | consolidation | inferred | semantic | coactivation | other` (mapped from
   `provenance_type`); add opt-in `include` values `semantic` (ChromaDB k-NN) + `coactivation`
   (default stays the structural three — backward compatible); add `relation_types` / `sources` /
   `min_weight` / `limit` / `order` params; upgrade `related_ids` → a ranked flat `neighbours` list.
@@ -1617,8 +1619,8 @@ change).** `lithos_related` already merges links + provenance + typed edges + `r
   existing `provenance_type` column is free-form (`human`/`agent`/`rule`/`manual`/`frontmatter`/
   `reinforcement`/`consolidation`, per SPECIFICATION.md); `lithos_related` maps it to `source` at
   read time: `human`/`agent`/`rule`/`manual` → `asserted`; `reinforcement`/`consolidation` →
-  `consolidation`; `frontmatter` → `provenance`; WS2's new `inferred` → `inferred`; unknown →
-  passthrough. WS2 writes `provenance_type="inferred"` (a new free-form value), so the write path
+  `consolidation`; `frontmatter` → `provenance`; WS2's new `inferred` → `inferred`; any unknown
+  value → `other`. WS2 writes `provenance_type="inferred"` (a new free-form value), so the write path
   and schema are unchanged — the normalisation lives only in the read layer, for Lens.
 
 Freeze the neighbour shape + the `source` mapping alongside WS2 so Lens builds against it while

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -650,7 +650,8 @@ Each scout wraps existing Lithos infrastructure where possible. Implementation n
 
 def scout_vector(q: QueryContext, k: int) -> list[Candidate]:
     # Wraps existing ChromaIndex.search(query, limit=k, threshold, tags)
-    # Queries active embedding spaces (multiple ChromaDB collections during migration)
+    # Queries the current `knowledge` collection; multi-space querying is deferred
+    # with embedding-space versioning (see the revised MVP-3 section)
     ...
 
 def scout_lexical(q: QueryContext, k: int) -> list[Candidate]:

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -246,6 +246,8 @@ When no weights/stats exist:
 
 ### G) Embedding model versioning
 
+> **Superseded (revised MVP-3, 2026-07): dropped.** Embedding-space versioning is no longer part of MVP-3 — spun out to a separate low-priority infra task, revisited only if the embedding model changes. See the "MVP 3 — Advanced Cognition (revised 2026-07)" section.
+
 Support multiple embedding spaces:
 
 - store `embedding_space_id` per embedding
@@ -266,6 +268,8 @@ MVP 1 boundary:
 - Existing direct-access tools remain unchanged until a separate caller-context contract is introduced.
 
 ### I) Temperature is operationalized
+
+> **Superseded (revised MVP-3, 2026-07):** coherence is computed from **embedding dispersion** of the top candidates, not edge strength (the typed-edge graph is too sparse). See the revised MVP-3 section (WS3).
 
 Per query:
 
@@ -536,6 +540,8 @@ Indexes: `(ts)`, `(task_id)`, `(agent_id)` for filtered queries via `lithos_rece
 
 Lithos already uses **ChromaDB** (`data/.chroma/`) with `all-MiniLM-L6-v2` (sentence-transformers) and cosine similarity. Documents are chunked (~500 char target, ~1000 max) and stored with metadata (`doc_id`, `chunk_index`, `title`, `path`, `author`, `tags`).
 
+> **Superseded (revised MVP-3, 2026-07): dropped.** Embedding-space versioning (multi-collection Chroma) is deferred to a separate infra task; MVP-3 uses the single `knowledge` collection. The description below is retained as deferred design.
+
 LCMA extends this with embedding space versioning via **separate ChromaDB collections** per space:
 
 - Current collection: `knowledge` (existing, preserved)
@@ -738,7 +744,8 @@ def scout_analogy(q: QueryContext, k: int) -> list[Candidate]:
     ...
 
 def scout_exploration(q: QueryContext, k: int, mode: str) -> list[Candidate]:
-    # NEW: mode in {"novelty","random","mixed"}, temperature-guided
+    # NEW: novelty + graph-frontier modes, temperature-guided
+    # (revised MVP-3, 2026-07: pure-"random" mode dropped — see WS3)
     ...
 
 def scout_contradictions(q: QueryContext, seed_nodes: list[str]) -> list[str]:
@@ -756,6 +763,8 @@ Notes:
 ---
 
 ## 5.3 Temperature (Coherence)
+
+> **Superseded (revised MVP-3, 2026-07):** coherence is computed from **embedding dispersion** of the top candidates, not edge strength. See the revised MVP-3 section (WS3). The edge-coherence design below is retained for history.
 
 Reviewer suggestion, implemented as coherence among top candidates (by edges).
 
@@ -1140,6 +1149,8 @@ def consolidate(task_id: str, agent_id: str):
 
 ## 5.8 Concept Formation + Damping
 
+> **Superseded (revised MVP-3, 2026-07):** concepts are seeded from **semantic (embedding) clusters validated by coactivation**, not coactivation clusters alone (coactivation is too sparse to seed); density clustering (HDBSCAN), not fixed-K. See the revised MVP-3 section (WS4). The damping/gateway mechanics below still apply.
+
 > **Note**: This function runs inside `lithos-enrich`, not in the `lithos_retrieve` hot path.
 
 Concepts emerge in two phases: derived clusters first, then explicit promotion to notes (see §1.1 Concept Node).
@@ -1210,6 +1221,8 @@ def resolve_conflict(edge_id: str, resolution: str, resolver: str):
 ---
 
 ## 5.10 Embedding Space Versioning / Migration
+
+> **Superseded (revised MVP-3, 2026-07): dropped from MVP-3.** Deferred to a separate low-priority infra task, revisited only if the embedding model changes. Retained below as deferred design.
 
 Lithos currently uses a single ChromaDB collection `"knowledge"` with `all-MiniLM-L6-v2`. LCMA adds versioning via separate ChromaDB collections per embedding space.
 
@@ -1504,8 +1517,10 @@ Write-contract note for LCMA params:
 ## MVP 3 — Advanced Cognition (revised 2026-07)
 
 > **Supersedes the earlier Hofstadter-framed MVP-3 sketch** and the MVP-3 mechanism notes woven
-> into §5.2 (analogy/exploration scouts), §5.3 (edge-based temperature) and §5.8
-> (coactivation-seeded concepts) **wherever they conflict**. Grounded in a read-only substrate
+> into §2.G / §4.5 / §5.10 (embedding-space versioning — **dropped**), §2.I / §5.3 (edge-based
+> temperature — now embedding-dispersion), §5.2 (analogy/exploration scouts — pure-random dropped)
+> and §5.8 (coactivation-seeded concepts — now semantic clusters) **wherever they conflict; those
+> sections carry inline `Superseded` markers**. Grounded in a read-only substrate
 > measurement of production (2026-07); full findings + numbers in the KB note
 > `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`.
 
@@ -1598,10 +1613,15 @@ change).** `lithos_related` already merges links + provenance + typed edges + `r
   `min_weight` / `limit` / `order` params; upgrade `related_ids` → a ranked flat `neighbours` list.
 - **`lithos_edge_list`:** add `source` / `min_weight` filters + endpoint titles.
 - **`lithos_edge_upsert`:** no change (WS2 uses the existing provenance args).
-- **Data discipline:** give `provenance_type` a controlled vocabulary
-  (`asserted` · `inferred` · `consolidation` · `frontmatter`) so the read layer maps `→ source`.
+- **`source` is a read-time normalised view — no persisted vocabulary change, no migration.** The
+  existing `provenance_type` column is free-form (`human`/`agent`/`rule`/`manual`/`frontmatter`/
+  `reinforcement`/`consolidation`, per SPECIFICATION.md); `lithos_related` maps it to `source` at
+  read time: `human`/`agent`/`rule`/`manual` → `asserted`; `reinforcement`/`consolidation` →
+  `consolidation`; `frontmatter` → `provenance`; WS2's new `inferred` → `inferred`; unknown →
+  passthrough. WS2 writes `provenance_type="inferred"` (a new free-form value), so the write path
+  and schema are unchanged — the normalisation lives only in the read layer, for Lens.
 
-Freeze the neighbour shape + `source` vocabulary alongside WS2 so Lens builds against it while
+Freeze the neighbour shape + the `source` mapping alongside WS2 so Lens builds against it while
 enrichment fills `edges.db`. Lens then becomes MVP-3's external validation.
 
 ### Sequence & dependencies


### PR DESCRIPTION
## What

Promotes the revised **LCMA MVP-3 ("Advanced Cognition")** plan into the canonical design doc (`lcma-design.md`) + checklist, grounded in a read-only 2026-07 substrate measurement of production.

## Why

MVP-3 was drafted 2026-03 (Hofstadter/Copycat framing) before the KB had content or interaction. The measured substrate reroutes it, and **Lithos Lens** — a knowledge-browsing UI that must render linked + related documents — is a new consumer that turns the graph enrichment into a product surface.

## Key changes

- **Reframe:** query-time search cleverness → *LLM-assisted background enrichment over a semantic substrate, surfaced as explainable typed relationships* (`lithos_retrieve` stays Terrace-0/1).
- **Workstreams WS1–WS7** replace the old sketch: LLM-synthesis backbone (local/optional provider), **typed-edge inference** (top lever — the typed-edge graph is semantically empty: 2 genuine relation edges in 3,115 docs), embedding-based coherence/temperature/exploration, concept nodes (density clusters + Memora gateway + **measured thresholds**), analogy scout from the **1,348 task outcomes**, implicit-signal metamemory, and the **Lens browse surface**.
- **Lens (WS7)** is read-shape enrichment only — extends `lithos_related` / `lithos_edge_list`; `edges.db` provenance columns already exist, so **no migration, no write-tool change**.
- **Prerequisites** kept as separate gated tasks (salience `e7d8ef60`, feedback `fc4b0669`) linked by task-edges; semantic-index coverage (`97cd00bb`) is an **operational** dependency, not a design workstream.
- **Dropped:** embedding-space versioning + transition querying; pure-random exploration.

Docs-only. Full substrate numbers + method in the KB note `analysis/lcma-substrate-measurement-phase-3-re-plan-2026-07.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSmaazv8JXyoHGYUGUwii
