### PR TITLE
feat(lcma): recalibrate salience — decay-to-floor + usage signal (e7d8ef60)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1134,7 +1134,8 @@ PTS-style retrieval orchestrating seven scouts in parallel and reranking via a f
       "derived_from_ids": [],
       "reasons": ["lexical match score 0.91"],
       "scouts": ["scout_lexical"],
-      "salience": 0.42
+      "salience": 0.42,
+      "usage_score": 0.18
     }
   ],
   "temperature": 0.5,
@@ -1145,7 +1146,7 @@ PTS-style retrieval orchestrating seven scouts in parallel and reranking via a f
 }
 ```
 
-The `id`/`title`/`snippet`/`score`/`path`/`source_url`/`updated_at`/`is_stale`/`derived_from_ids` keys mirror the `lithos_search` shape so clients that read only those fields work unchanged. `reasons`/`scouts`/`salience` are LCMA-only additive fields. `degraded`/`failed_scouts` are always present: `failed_scouts` lists the canonical names of any scouts whose backend raised (so one bad backend degrades rather than kills the retrieve), and `degraded` is `true` when that list is non-empty — letting a caller distinguish partial results from a genuinely empty corpus.
+The `id`/`title`/`snippet`/`score`/`path`/`source_url`/`updated_at`/`is_stale`/`derived_from_ids` keys mirror the `lithos_search` shape so clients that read only those fields work unchanged. `reasons`/`scouts`/`salience`/`usage_score` are LCMA-only additive fields — `salience` is the stored learned utility (`stats.db`), while `usage_score` is the live, non-decaying popularity signal (retrieval frequency + recency) that feeds reranking alongside it. `degraded`/`failed_scouts` are always present: `failed_scouts` lists the canonical names of any scouts whose backend raised (so one bad backend degrades rather than kills the retrieve), and `degraded` is `true` when that list is non-empty — letting a caller distinguish partial results from a genuinely empty corpus.
 
 **Receipt audit trail:** every call writes a row to `stats.db.receipts` with columns including `id`, `ts`, `query`, `namespace_filter`, `scouts_fired` (canonical names of every scout that ran cleanly — empty results still count as fired), `candidates_considered`, `final_nodes` (JSON array of `{id, reasons, scouts}` objects), `surface_conflicts`, `temperature`, and `terrace_reached`.
 

--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -115,7 +115,7 @@ module_cycles          = 1    # server<->tools; the knowledge<->graph<->search<-
 modules_over_800_lines = 11   # incl. tools.tasks (985) split from server in #374; knowledge.py 2444→1773 (codec out) but still over; direction: down
 max_module_lines       = 2800 # stop-loss; largest today is coordination.py at 2675
 cross_module_private_refs = 42  # measured 2026-07; server._emit/_config x12 etc. (normalize_datetime made public in task 4a3836a9); goal: 0
-tests_private_imports     = 88  # measured 2026-07; test_telemetry alone is 45; direction: down
+tests_private_imports     = 90  # measured 2026-07; test_telemetry alone is 45; direction: down. 88→90: two white-box config-wiring tests import _rerank_fast / _usage_from_stats to prove the newly-exposed LcmaConfig rerank/usage fields actually change behaviour (task e7d8ef60, review finding 5) — the private helpers are the precise units under test.
 
 # MCP tool surface: modules scanned for @…tool()-decorated handlers (counted in
 # the metrics snapshot; catalogued in docs/generated/tool_catalog.md). Omit the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,6 +113,27 @@ lithos reindex --clear
 
 Use this after manually editing or adding Markdown files outside of the MCP interface.
 
+### `recalibrate-salience` — One-time salience backfill
+
+```bash
+# Preview: show the distribution and how many rows would be lifted
+lithos recalibrate-salience --dry-run
+
+# Lift decay-collapsed rows up to the floor (config lcma.salience_floor)
+lithos recalibrate-salience
+
+# Override the floor explicitly
+lithos recalibrate-salience --floor 0.3
+```
+
+Corrects the historical salience collapse (task `e7d8ef60`) where a floor-less daily
+decay drove most nodes to ~0. Lifts every node below the floor up to it, **except** nodes
+carrying explicit negative feedback (misleading / chronically ignored), which stay below
+deliberately. Idempotent — safe to re-run. Run it **once on staging first, then prod**,
+with the server stopped is not required (it only touches `stats.db`), but the operator
+should confirm the reported before/after distribution. Going forward the daily enrich
+sweep holds the floor, so this should not need re-running.
+
 ### `validate` — Check knowledge base integrity
 
 ```bash

--- a/docs/generated/components/CognitiveMemory.md
+++ b/docs/generated/components/CognitiveMemory.md
@@ -11,13 +11,14 @@ Agent-facing facade of LCMA: retrieval, learning, and asserted state.
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `lithos.cognitive_memory` | L | 2 | 0 |
+| `lithos.cognitive_memory` | L | 2 | 1 |
 
 ## Public API
 
 ### `lithos.cognitive_memory`
 - class `NodeStats` — Per-node retrieval / salience stats returned by :meth:`CognitiveMemory.node_stats`.
 - class `CognitiveMemory` — Module facade over LCMA's agent-facing surface (ADR-0005).
+- def `recalibrate_salience` — Run the one-time salience floor backfill as a standalone maintenance op.
 
 ## Dependencies
 

--- a/docs/generated/components/Entrypoints.md
+++ b/docs/generated/components/Entrypoints.md
@@ -11,7 +11,7 @@ CLI, MCP server, tool handlers, filesystem watcher — the outward-facing surfac
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `lithos.cli` | L | 0 | 15 |
+| `lithos.cli` | L | 0 | 16 |
 | `lithos.cli_reconcile` | M | 0 | 1 |
 | `lithos.pipeline` | S | 1 | 1 |
 | `lithos.server` | L | 1 | 2 |
@@ -31,6 +31,7 @@ CLI, MCP server, tool handlers, filesystem watcher — the outward-facing surfac
 - def `cli` — Lithos - Local shared knowledge base for AI agents.
 - def `serve` — Start the Lithos MCP server.
 - def `reindex` — Rebuild search indices from knowledge files.
+- def `recalibrate_salience` — One-time backfill: lift decay-collapsed salience rows to the floor.
 - def `validate` — Validate knowledge base integrity.
 - def `stats` — Show knowledge base statistics.
 - def `search` — Search the knowledge base.

--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -17,7 +17,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.entities` | M | 0 | 1 |
 | `lithos.lcma.migrations` | S | 1 | 1 |
 | `lithos.lcma.retrieve` | L | 0 | 1 |
-| `lithos.lcma.salience` | XS | 0 | 2 |
+| `lithos.lcma.salience` | S | 0 | 3 |
 | `lithos.lcma.scouts` | L | 2 | 11 |
 | `lithos.lcma.stats` | L | 1 | 0 |
 | `lithos.lcma.utils` | S | 1 | 1 |
@@ -42,6 +42,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 
 ### `lithos.lcma.salience`
 - def `decay_amount` — Return the salience decay to subtract for a node idle *days_inactive* days.
+- def `recalibration_eligible` — Whether the one-time floor backfill should lift *salience* to *floor*.
 - def `usage_score` — Return a bounded ``[0, 1]`` popularity signal from live usage counters.
 
 ### `lithos.lcma.scouts`

--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -16,7 +16,8 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.enrich` | L | 1 | 0 |
 | `lithos.lcma.entities` | M | 0 | 1 |
 | `lithos.lcma.migrations` | S | 1 | 1 |
-| `lithos.lcma.retrieve` | M | 0 | 1 |
+| `lithos.lcma.retrieve` | L | 0 | 1 |
+| `lithos.lcma.salience` | XS | 0 | 2 |
 | `lithos.lcma.scouts` | L | 2 | 11 |
 | `lithos.lcma.stats` | L | 1 | 0 |
 | `lithos.lcma.utils` | S | 1 | 1 |
@@ -38,6 +39,10 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 
 ### `lithos.lcma.retrieve`
 - def `compute_temperature` — Return the MVP 1 retrieval temperature.
+
+### `lithos.lcma.salience`
+- def `decay_amount` — Return the salience decay to subtract for a node idle *days_inactive* days.
+- def `usage_score` — Return a bounded ``[0, 1]`` popularity signal from live usage counters.
 
 ### `lithos.lcma.scouts`
 - def `scout_vector` — ChromaDB semantic search via asyncio.to_thread.

--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -19,7 +19,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.retrieve` | L | 0 | 1 |
 | `lithos.lcma.salience` | S | 0 | 3 |
 | `lithos.lcma.scouts` | L | 2 | 11 |
-| `lithos.lcma.stats` | L | 1 | 0 |
+| `lithos.lcma.stats` | L | 1 | 1 |
 | `lithos.lcma.utils` | S | 1 | 1 |
 
 ## Public API
@@ -61,6 +61,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 - class `ScoutSpec` — One entry in the scout registry.
 
 ### `lithos.lcma.stats`
+- def `extract_final_node_ids` — Parse the ``final_nodes`` JSON column and collect ``id`` fields.
 - class `StatsStore` — Lazily-created SQLite store for LCMA retrieval statistics.
 
 ### `lithos.lcma.utils`

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -413,7 +413,7 @@
         "largest_module_lines": 1130,
         "lines": 4630,
         "modules": 10,
-        "public_symbols": 25,
+        "public_symbols": 26,
         "sloc": 3730
       },
       "Logging": {
@@ -487,8 +487,8 @@
     "total_sloc": 19470
   },
   "tests": {
-    "ratio": 1.88,
+    "ratio": 1.89,
     "src_lines": 24227,
-    "test_lines": 45652
+    "test_lines": 45693
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -411,7 +411,7 @@
         "functions": 130,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1130,
-        "lines": 4628,
+        "lines": 4630,
         "modules": 10,
         "public_symbols": 25,
         "sloc": 3730
@@ -482,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 24225,
+    "total_lines": 24227,
     "total_modules": 42,
     "total_sloc": 19470
   },
   "tests": {
     "ratio": 1.88,
-    "src_lines": 24225,
-    "test_lines": 45579
+    "src_lines": 24227,
+    "test_lines": 45652
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 736
+    "total_functions": 737
   },
   "domain": {
     "associations": 26,
@@ -281,6 +281,7 @@
       "tests/test_coordination.py -> lithos.coordination._parse_datetime (x2)",
       "tests/test_entities.py -> lithos.lcma.entities._clean_candidate (x2)",
       "tests/test_knowledge.py -> lithos.knowledge._UNSET (x2)",
+      "tests/test_retrieve.py -> lithos.lcma.retrieve._rerank_fast (x2)",
       "tests/test_telemetry.py -> lithos.telemetry._TraceContextFilter (x2)",
       "tests/test_telemetry.py -> lithos.telemetry._inject_trace_context_into_logs (x2)",
       "tests/test_telemetry.py -> lithos.telemetry._trace_context_filter (x2)",
@@ -299,10 +300,9 @@
       "tests/test_entities.py -> lithos.lcma.entities._load_model",
       "tests/test_event_delivery.py -> lithos.server._format_resync_sse",
       "tests/test_event_delivery.py -> lithos.server._format_sse",
-      "tests/test_knowledge.py -> lithos.knowledge._atomic_write",
-      "tests/test_lcma_config.py -> lithos.config._DEFAULT_NOTE_TYPE_PRIORS"
+      "tests/test_knowledge.py -> lithos.knowledge._atomic_write"
     ],
-    "tests_private_imports": 88
+    "tests_private_imports": 90
   },
   "size": {
     "components": {
@@ -408,13 +408,13 @@
       },
       "LCMA": {
         "classes": 7,
-        "functions": 129,
+        "functions": 130,
         "largest_module": "lithos.lcma.stats",
-        "largest_module_lines": 1110,
-        "lines": 4581,
+        "largest_module_lines": 1130,
+        "lines": 4628,
         "modules": 10,
-        "public_symbols": 24,
-        "sloc": 3691
+        "public_symbols": 25,
+        "sloc": 3730
       },
       "Logging": {
         "classes": 1,
@@ -460,11 +460,11 @@
         "classes": 9,
         "functions": 74,
         "largest_module": "lithos.telemetry",
-        "largest_module_lines": 1250,
-        "lines": 1250,
+        "largest_module_lines": 1256,
+        "lines": 1256,
         "modules": 1,
         "public_symbols": 13,
-        "sloc": 965
+        "sloc": 970
       }
     },
     "max_module": "lithos.coordination",
@@ -482,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 24172,
+    "total_lines": 24225,
     "total_modules": 42,
-    "total_sloc": 19426
+    "total_sloc": 19470
   },
   "tests": {
     "ratio": 1.88,
-    "src_lines": 24172,
-    "test_lines": 45349
+    "src_lines": 24225,
+    "test_lines": 45579
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 719
+    "total_functions": 736
   },
   "domain": {
     "associations": 26,
@@ -318,23 +318,23 @@
       },
       "CognitiveMemory": {
         "classes": 2,
-        "functions": 30,
+        "functions": 31,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 1121,
-        "lines": 1121,
+        "largest_module_lines": 1157,
+        "lines": 1157,
         "modules": 1,
-        "public_symbols": 2,
-        "sloc": 920
+        "public_symbols": 3,
+        "sloc": 952
       },
       "Config": {
         "classes": 9,
         "functions": 17,
         "largest_module": "lithos.config",
-        "largest_module_lines": 371,
-        "lines": 371,
+        "largest_module_lines": 401,
+        "lines": 401,
         "modules": 1,
         "public_symbols": 12,
-        "sloc": 281
+        "sloc": 295
       },
       "Coordination": {
         "classes": 8,
@@ -348,13 +348,13 @@
       },
       "Entrypoints": {
         "classes": 4,
-        "functions": 136,
+        "functions": 139,
         "largest_module": "lithos.tools.tasks",
         "largest_module_lines": 985,
-        "lines": 5851,
+        "lines": 5905,
         "modules": 13,
-        "public_symbols": 30,
-        "sloc": 4693
+        "public_symbols": 31,
+        "sloc": 4737
       },
       "Errors": {
         "classes": 9,
@@ -408,13 +408,13 @@
       },
       "LCMA": {
         "classes": 7,
-        "functions": 121,
+        "functions": 129,
         "largest_module": "lithos.lcma.stats",
-        "largest_module_lines": 1027,
-        "lines": 4305,
-        "modules": 9,
-        "public_symbols": 22,
-        "sloc": 3459
+        "largest_module_lines": 1110,
+        "lines": 4581,
+        "modules": 10,
+        "public_symbols": 24,
+        "sloc": 3691
       },
       "Logging": {
         "classes": 1,
@@ -457,14 +457,14 @@
         "sloc": 226
       },
       "Telemetry": {
-        "classes": 8,
-        "functions": 69,
+        "classes": 9,
+        "functions": 74,
         "largest_module": "lithos.telemetry",
-        "largest_module_lines": 1202,
-        "lines": 1202,
+        "largest_module_lines": 1250,
+        "lines": 1250,
         "modules": 1,
         "public_symbols": 13,
-        "sloc": 925
+        "sloc": 965
       }
     },
     "max_module": "lithos.coordination",
@@ -482,13 +482,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 23728,
-    "total_modules": 41,
-    "total_sloc": 19064
+    "total_lines": 24172,
+    "total_modules": 42,
+    "total_sloc": 19426
   },
   "tests": {
-    "ratio": 1.89,
-    "src_lines": 23728,
-    "test_lines": 44880
+    "ratio": 1.88,
+    "src_lines": 24172,
+    "test_lines": 45349
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -35,25 +35,25 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Codec | 1 | 777 | 583 | 7 | 0 | 0.00 | 14 (`lithos.frontmatter_codec.KnowledgeMetadata.from_dict`) | 3 |
-| CognitiveMemory | 1 | 1121 | 920 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
-| Config | 1 | 371 | 281 | 11 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
+| CognitiveMemory | 1 | 1157 | 952 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
+| Config | 1 | 401 | 295 | 11 | 0 | 0.00 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
-| Entrypoints | 13 | 5851 | 4693 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
+| Entrypoints | 13 | 5905 | 4737 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 211 | 152 | 7 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 350 | 281 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 9 | 4305 | 3459 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
+| LCMA | 10 | 4581 | 3691 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
 | SqliteStore | 1 | 279 | 226 | 2 | 1 | 0.33 | 10 (`lithos.async_sqlite_store.AsyncSqliteStore._session`) | 0 |
-| Telemetry | 1 | 1202 | 925 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
+| Telemetry | 1 | 1250 | 965 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
 
 ## Size
 
-- Modules: **41**, lines: **23728**, SLOC: **19064**
+- Modules: **42**, lines: **24172**, SLOC: **19426**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **719**, cyclomatic > 10: **60**
+- Functions: **736**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -150,4 +150,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.89** (44880 test lines / 23728 source lines)
+- Test-to-source line ratio: **1.88** (45349 test lines / 24172 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -17,7 +17,7 @@ lower a budget after improving the code to lock in the gain.
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
-| `tests_private_imports` | 88 | 88 | 0 |
+| `tests_private_imports` | 90 | 90 | 0 |
 
 ## Import graph
 
@@ -44,16 +44,16 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 10 | 4581 | 3691 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
+| LCMA | 10 | 4628 | 3730 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
 | SqliteStore | 1 | 279 | 226 | 2 | 1 | 0.33 | 10 (`lithos.async_sqlite_store.AsyncSqliteStore._session`) | 0 |
-| Telemetry | 1 | 1250 | 965 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
+| Telemetry | 1 | 1256 | 970 | 9 | 1 | 0.10 | 19 (`lithos.telemetry.setup_telemetry`) | 1 |
 
 ## Size
 
-- Modules: **42**, lines: **24172**, SLOC: **19426**
+- Modules: **42**, lines: **24225**, SLOC: **19470**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **736**, cyclomatic > 10: **60**
+- Functions: **737**, cyclomatic > 10: **60**
 
 Top 10 most complex functions:
 
@@ -113,7 +113,7 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._emit`
   - `lithos.tools.notes -> lithos.knowledge._UNSET`
   - `lithos.tools.notes -> lithos.knowledge._UnsetType`
-- Tests importing src privates: **88**
+- Tests importing src privates: **90**
   - `tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x18)`
   - `tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)`
   - `tests/test_telemetry.py -> lithos.telemetry._initialized (x7)`
@@ -124,6 +124,7 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `tests/test_coordination.py -> lithos.coordination._parse_datetime (x2)`
   - `tests/test_entities.py -> lithos.lcma.entities._clean_candidate (x2)`
   - `tests/test_knowledge.py -> lithos.knowledge._UNSET (x2)`
+  - `tests/test_retrieve.py -> lithos.lcma.retrieve._rerank_fast (x2)`
   - `tests/test_telemetry.py -> lithos.telemetry._TraceContextFilter (x2)`
   - `tests/test_telemetry.py -> lithos.telemetry._inject_trace_context_into_logs (x2)`
   - `tests/test_telemetry.py -> lithos.telemetry._trace_context_filter (x2)`
@@ -143,11 +144,10 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `tests/test_event_delivery.py -> lithos.server._format_resync_sse`
   - `tests/test_event_delivery.py -> lithos.server._format_sse`
   - `tests/test_knowledge.py -> lithos.knowledge._atomic_write`
-  - `tests/test_lcma_config.py -> lithos.config._DEFAULT_NOTE_TYPE_PRIORS`
   - … (list capped at 30 pairs)
 
 ## Domain, tools & tests
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (45349 test lines / 24172 source lines)
+- Test-to-source line ratio: **1.88** (45579 test lines / 24225 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -150,4 +150,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (45652 test lines / 24227 source lines)
+- Test-to-source line ratio: **1.89** (45693 test lines / 24227 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -44,7 +44,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
 | Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 10 | 4628 | 3730 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
+| LCMA | 10 | 4630 | 3730 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **42**, lines: **24225**, SLOC: **19470**
+- Modules: **42**, lines: **24227**, SLOC: **19470**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -150,4 +150,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (45579 test lines / 24225 source lines)
+- Test-to-source line ratio: **1.88** (45652 test lines / 24227 source lines)

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -620,18 +620,21 @@ class ResultItem:
     is_stale: bool
     derived_from_ids: list[str]
     # LCMA-only extras (additive):
-    reasons: list[str]   # why this node was retrieved
-    scouts: list[str]    # which scouts surfaced it
-    salience: float      # from stats.db
+    reasons: list[str]    # why this node was retrieved
+    scouts: list[str]     # which scouts surfaced it
+    salience: float       # stored learned utility (stats.db)
+    usage_score: float    # live popularity: retrieval frequency + recency (e7d8ef60)
 
 class RetrievalResult:
     """Response shape is structurally compatible with lithos_search.
 
     The top-level `results` key mirrors lithos_search so clients can
     switch between tools without rewriting result-handling code.
-    LCMA-specific fields (reasons, scouts, salience, temperature,
-    terrace_reached, receipt_id) are additive — clients that only
-    read id/title/score/snippet will work unchanged.
+    LCMA-specific fields (reasons, scouts, salience, usage_score,
+    temperature, terrace_reached, receipt_id) are additive — clients
+    that only read id/title/score/snippet will work unchanged.
+    `salience` is the stored learned-quality signal; `usage_score` is a
+    non-decaying popularity signal derived live from usage counters.
     """
     results: list[ResultItem]   # compatible with lithos_search results
     temperature: float
@@ -1735,7 +1738,7 @@ LCMA is also compatible with cross-plan metadata additions: `source_url`, `deriv
 
 ### Key design decisions
 
-- **`confidence` vs `salience`**: `confidence` (frontmatter) = author's belief about accuracy. `salience` (stats.db) = retrieval utility learned from usage. Both are 0–1 floats but serve different purposes.
+- **`confidence` vs `salience` vs `usage_score`**: `confidence` (frontmatter) = author's belief about accuracy. `salience` (stats.db) = retrieval utility *learned/reinforced* from feedback, decayed toward a non-zero floor (see `lcma.salience_floor`). `usage_score` (derived live at retrieve time from `stats.db` usage counters, not stored) = raw *popularity* — retrieval frequency + recency — a non-decaying signal that complements salience in reranking so ranking stays discriminating even on a cold, unreinforced corpus (task `e7d8ef60`). All are 0–1 floats serving different purposes.
 - **NetworkX vs edges.db**: NetworkX handles structural `[[wiki-link]]` navigation and powers the `links` section of `lithos_related`. edges.db handles semantic/learned relationships with weights and types. Both are queried by the graph scout.
 - **Declared provenance vs learned edges**: `derived_from_ids` is the source of truth for declared lineage. `edges.db` can carry mirrored `derived_from` edges as an accelerator only.
 - **Frontmatter vs stats.db**: Static metadata in frontmatter (author, tags, note_type). Dynamic signals in stats.db (salience, retrieval_count, decay). This avoids constant file rewrites from learning updates.
@@ -1766,9 +1769,30 @@ class LcmaConfig(BaseModel):
     temperature_edge_threshold: int = 50            # min edges for computed temp
     wm_eviction_days: int = 7
     llm_provider: str | None = None                # MVP 3+, background LLM synthesis
+
+    # Salience recalibration (task e7d8ef60) — decay floor, formerly-hardcoded
+    # decay/reinforcement constants, composite rerank weights, and the usage signal.
+    salience_floor: float = 0.3                     # time decay stops here, not at 0
+    salience_decay_per_day: float = 0.005
+    salience_decay_daily_cap: float = 0.1
+    salience_cited_boost: float = 0.02
+    salience_consolidation_boost: float = 0.01
+    salience_misleading_penalty: float = 0.05
+    salience_ignored_penalty: float = 0.02
+    rerank_salience_weight: float = 0.1             # additive composite terms
+    rerank_note_type_weight: float = 0.1
+    rerank_usage_weight: float = 0.1
+    usage_freq_weight: float = 0.6                  # usage_score = freq + recency
+    usage_recency_weight: float = 0.4
+    usage_recency_halflife_days: float = 14.0
+    usage_freq_norm_k: float = 20.0
 ```
 
-Ship with hardcoded defaults in MVP 1. Config override via `LithosConfig.lcma` available from first release but only becomes load-bearing when `lithos-enrich` ships in MVP 2.
+This block is a **draft**; the authoritative shape is `LcmaConfig` in `src/lithos/config.py`
+(e.g. `enabled` defaults to `True`, and `rerank_weights` is scout-name-keyed and sums to 1.0).
+Ship with defaults; config override via `LithosConfig.lcma` is load-bearing now that
+`lithos-enrich` has shipped. The salience/usage constants above were previously hardcoded and
+are exposed so the calibration harness and WS6 metamemory can tune them without a code change.
 
 ### 7.x Two-Component Design Rationale
 
@@ -1777,7 +1801,7 @@ Ship with hardcoded defaults in MVP 1. Config override via `LithosConfig.lcma` a
 - Clients who only need content can use `lithos_search` and benefit from enrichment passively — concept nodes created by `lithos-enrich` are regular `.md` files indexed by the standard search pipeline.
 - Clients who need salience-weighted, graph-aware, multi-scout ranked results use `lithos_retrieve`.
 - **Background LLM synthesis belongs to `lithos-enrich`** (not the retrieval pipeline) because: (a) it is expensive, (b) it is query-independent — it synthesizes knowledge proactively, producing persistent artifacts (summaries, concept notes, edge annotations), (c) clients should not block waiting for LLM synthesis. It is deliberately **not** numbered as "Terrace 2" to avoid implying it is a step in the retrieval pipeline.
-- **Response compatibility**: `lithos_retrieve` returns a `results` list with the same fields as `lithos_search` (`id`, `title`, `snippet`, `score`, `path`, `source_url`, `updated_at`, `is_stale`, `derived_from_ids`). LCMA-specific fields (`reasons`, `scouts`, `salience`) are additive. The envelope adds `temperature`, `terrace_reached`, and `receipt_id`. Clients that only read `results[].id` or `results[].score` work identically with both tools.
+- **Response compatibility**: `lithos_retrieve` returns a `results` list with the same fields as `lithos_search` (`id`, `title`, `snippet`, `score`, `path`, `source_url`, `updated_at`, `is_stale`, `derived_from_ids`). LCMA-specific fields (`reasons`, `scouts`, `salience`, `usage_score`) are additive. The envelope adds `temperature`, `terrace_reached`, and `receipt_id`. Clients that only read `results[].id` or `results[].score` work identically with both tools.
 - **Enrichment queue pattern**: Rather than triggering `lithos-enrich` directly on each action, triggering actions emit events via the existing Lithos event bus. The in-process `lithos-enrich` worker subscribes to these events and writes to an `enrich_queue` table in `stats.db`. A periodic drain processes pending work, deduplicating multiple events for the same node. A daily full sweep catches anything missed and recomputes global signals (decay, concept clusters). This avoids redundant enrichment runs (e.g., 10 task completions → 1 enrichment run), enables incremental targeted processing, and leverages existing event infrastructure with no new event system required.
 
 ### 7.y When to Use Which Tool

--- a/scripts/calibrate_salience.py
+++ b/scripts/calibrate_salience.py
@@ -9,24 +9,32 @@ signal. It imports the same pure helpers the server uses
 It answers two questions:
 
 1. **Floor** — for each candidate floor, what does the salience distribution look like
-   after the one-time ``max(salience, floor)`` backfill (mean, % ≤ 0.30, spread)?
-2. **Usage signal** — for each candidate ``usage_score`` parameter set, what is the
-   resulting distribution, and how well does it *separate* nodes that were genuinely
-   used (cited, or frequently retrieved) from cold ones? Configs are ranked by a
-   rank-based AUC so a good spread that also tracks real usage floats to the top.
+   after the one-time backfill? The projection uses the *same* eligibility predicate as
+   the operator run (:func:`lithos.lcma.salience.recalibration_eligible`), so
+   misleading / chronically-ignored nodes are excluded exactly as production excludes
+   them.
+2. **Usage signal** — for each candidate ``usage_score`` parameter set, how well does it
+   *separate* nodes that were genuinely used from cold ones? Separation is scored with a
+   rank-based AUC against an **independent** label:
 
-Ground truth is thin while explicit feedback is near-empty, so the ranking falls back
-from citation-AUC to retrieval-activity-AUC (with a warning) when there are too few
-cited nodes — exactly the regime the recalibration was written for.
+   - **citation-AUC** — cited (``cited_count > 0``) vs not; independent of retrieval.
+   - **future-retrieval-AUC** — a time split of the ``receipts`` log: score each node
+     from its *past* retrievals only, label it by whether it is retrieved again in the
+     held-out *future* window. This is non-circular (the label is not the score's own
+     input) and is what actually calibrates frequency vs recency vs half-life.
+
+   When neither label has enough support (the sparse-feedback regime), the harness
+   reports distribution diagnostics only and does **not** claim a best config.
 
 Usage:
     python scripts/calibrate_salience.py /path/to/stats-copy.db
-    python scripts/calibrate_salience.py stats.db --floors 0.25,0.3,0.35 --top 8
+    python scripts/calibrate_salience.py stats.db --floors 0.25,0.3,0.35 --split 0.7 --top 8
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sqlite3
 import statistics
 import sys
@@ -34,7 +42,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from lithos.lcma.salience import usage_score
+from lithos.lcma.salience import recalibration_eligible, usage_score
 
 # Candidate usage-signal parameter sets, expanded from these axes by default.
 _FREQ_RECENCY_SPLITS: tuple[tuple[float, float], ...] = (
@@ -46,15 +54,19 @@ _FREQ_RECENCY_SPLITS: tuple[tuple[float, float], ...] = (
 _HALFLIVES: tuple[float, ...] = (7.0, 14.0, 30.0)
 _NORM_KS: tuple[float, ...] = (10.0, 20.0, 50.0)
 _DEFAULT_FLOORS: tuple[float, ...] = (0.2, 0.25, 0.3, 0.35, 0.4)
+_MIN_LABEL_SUPPORT = 10  # need this many positives AND negatives to trust an AUC
 
 
 @dataclass(frozen=True)
 class NodeRow:
     """The node_stats fields the calibration needs."""
 
+    node_id: str
     salience: float
     retrieval_count: int
     cited_count: int
+    misleading_count: int
+    ignored_count: int
     days_since_use: float | None
 
 
@@ -70,6 +82,26 @@ class UsageConfig:
             f"f={self.freq_weight:.1f} r={self.recency_weight:.1f} "
             f"hl={self.recency_halflife_days:g} k={self.freq_norm_k:g}"
         )
+
+    def score(self, retrieval_count: int, days_since_use: float | None) -> float:
+        return usage_score(
+            retrieval_count,
+            days_since_use,
+            freq_weight=self.freq_weight,
+            recency_weight=self.recency_weight,
+            recency_halflife_days=self.recency_halflife_days,
+            freq_norm_k=self.freq_norm_k,
+        )
+
+
+@dataclass(frozen=True)
+class TimeSplit:
+    """A past/future partition of the receipts log for held-out evaluation."""
+
+    split_time: datetime
+    past_count: dict[str, int]
+    past_last: dict[str, datetime]
+    future_nodes: frozenset[str]
 
 
 def _parse_ts(value: object) -> datetime | None:
@@ -93,8 +125,8 @@ def load_nodes(db_path: str) -> list[NodeRow]:
     try:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
-            "SELECT salience, retrieval_count, cited_count, "
-            "last_used_at, last_retrieved_at FROM node_stats"
+            "SELECT node_id, salience, retrieval_count, cited_count, misleading_count, "
+            "ignored_count, last_used_at, last_retrieved_at FROM node_stats"
         ).fetchall()
     finally:
         conn.close()
@@ -113,13 +145,62 @@ def load_nodes(db_path: str) -> list[NodeRow]:
         days = None if ts is None else max(0.0, (reference - ts).total_seconds() / 86400.0)
         nodes.append(
             NodeRow(
+                node_id=str(row["node_id"]),
                 salience=float(row["salience"]),
                 retrieval_count=int(row["retrieval_count"]),
                 cited_count=int(row["cited_count"]),
+                misleading_count=int(row["misleading_count"]),
+                ignored_count=int(row["ignored_count"]),
                 days_since_use=days,
             )
         )
     return nodes
+
+
+def load_receipts(db_path: str) -> list[tuple[datetime, list[str]]]:
+    """Read (ts, returned node_ids) from the receipts log of a stats.db copy."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = conn.execute("SELECT ts, final_nodes FROM receipts").fetchall()
+    finally:
+        conn.close()
+
+    out: list[tuple[datetime, list[str]]] = []
+    for ts_raw, nodes_raw in rows:
+        ts = _parse_ts(ts_raw)
+        if ts is None:
+            continue
+        try:
+            node_ids = json.loads(nodes_raw) if nodes_raw else []
+        except (TypeError, ValueError):
+            continue
+        if isinstance(node_ids, list):
+            out.append((ts, [str(n) for n in node_ids]))
+    return out
+
+
+def build_time_split(
+    receipts: Sequence[tuple[datetime, list[str]]], split_quantile: float
+) -> TimeSplit | None:
+    """Partition receipts by time: earlier fraction = past (scored), rest = future (label)."""
+    if not receipts:
+        return None
+    ordered = sorted(receipts, key=lambda r: r[0])
+    idx = min(len(ordered) - 1, max(0, int(split_quantile * len(ordered))))
+    split_time = ordered[idx][0]
+    past_count: dict[str, int] = {}
+    past_last: dict[str, datetime] = {}
+    future_nodes: set[str] = set()
+    for ts, node_ids in ordered:
+        if ts <= split_time:
+            for nid in node_ids:
+                past_count[nid] = past_count.get(nid, 0) + 1
+                prev = past_last.get(nid)
+                if prev is None or ts > prev:
+                    past_last[nid] = ts
+        else:
+            future_nodes.update(node_ids)
+    return TimeSplit(split_time, past_count, past_last, frozenset(future_nodes))
 
 
 def auc(positives: Sequence[float], negatives: Sequence[float]) -> float:
@@ -132,7 +213,6 @@ def auc(positives: Sequence[float], negatives: Sequence[float]) -> float:
         return 0.5
     labelled = [(v, 1) for v in positives] + [(v, 0) for v in negatives]
     labelled.sort(key=lambda t: t[0])
-    # Average ranks over ties.
     ranks = [0.0] * len(labelled)
     i = 0
     while i < len(labelled):
@@ -160,22 +240,43 @@ def _fraction(values: Sequence[float], predicate: object) -> float:
 def _percentile(sorted_values: Sequence[float], q: float) -> float:
     if not sorted_values:
         return 0.0
-    idx = min(len(sorted_values) - 1, max(0, int(q * len(sorted_values))))
+    idx = min(len(sorted_values), max(1, int(-(-q * len(sorted_values)) // 1))) - 1
     return sorted_values[idx]
 
 
 def floor_report(nodes: Sequence[NodeRow], floors: Sequence[float]) -> list[str]:
-    """One row per candidate floor: the salience distribution after backfill."""
-    out = ["Floor backfill — salience distribution after max(salience, floor):"]
-    out.append(f"  {'floor':>6}  {'mean':>6}  {'<=0.30':>7}  {'std':>6}  {'p50':>6}  {'p90':>6}")
+    """One row per candidate floor: the salience distribution after the *real* backfill.
+
+    Projection uses :func:`recalibration_eligible`, so it excludes misleading /
+    chronically-ignored nodes exactly as the operator ``recalibrate-salience`` run does.
+    """
+    out = ["Floor backfill projection (matches the operator eligibility predicate):"]
+    out.append(
+        f"  {'floor':>6}  {'lift%':>6}  {'mean':>6}  {'<floor':>7}  "
+        f"{'std':>6}  {'p50':>6}  {'p90':>6}"
+    )
     for floor in floors:
-        lifted = [max(n.salience, floor) for n in nodes]
-        s = sorted(lifted)
-        mean = statistics.fmean(lifted) if lifted else 0.0
-        std = statistics.pstdev(lifted) if len(lifted) > 1 else 0.0
-        frac = _fraction(lifted, lambda v: v <= 0.30)
+        projected: list[float] = []
+        lifted = 0
+        for n in nodes:
+            if recalibration_eligible(
+                n.salience,
+                floor,
+                misleading_count=n.misleading_count,
+                ignored_count=n.ignored_count,
+                cited_count=n.cited_count,
+            ):
+                projected.append(floor)
+                lifted += 1
+            else:
+                projected.append(n.salience)
+        s = sorted(projected)
+        mean = statistics.fmean(projected) if projected else 0.0
+        std = statistics.pstdev(projected) if len(projected) > 1 else 0.0
+        below = (sum(1 for v in projected if v < floor) / len(projected)) if projected else 0.0
+        lift_pct = (lifted / len(nodes) * 100) if nodes else 0.0
         out.append(
-            f"  {floor:>6.2f}  {mean:>6.3f}  {frac * 100:>6.1f}%  "
+            f"  {floor:>6.2f}  {lift_pct:>5.1f}%  {mean:>6.3f}  {below * 100:>6.1f}%  "
             f"{std:>6.3f}  {_percentile(s, 0.5):>6.3f}  {_percentile(s, 0.9):>6.3f}"
         )
     return out
@@ -188,52 +289,65 @@ class UsageResult:
     std: float
     frac_zero: float
     frac_saturated: float
-    cited_auc: float
-    activity_auc: float
-    ranking_auc: float
+    cited_auc: float | None
+    future_auc: float | None
+    ranking_auc: float | None
     ranked_by: str
 
 
-def _score_all(nodes: Sequence[NodeRow], cfg: UsageConfig) -> list[float]:
-    return [
-        usage_score(
-            n.retrieval_count,
-            n.days_since_use,
-            freq_weight=cfg.freq_weight,
-            recency_weight=cfg.recency_weight,
-            recency_halflife_days=cfg.recency_halflife_days,
-            freq_norm_k=cfg.freq_norm_k,
-        )
-        for n in nodes
-    ]
+def _current_scores(nodes: Sequence[NodeRow], cfg: UsageConfig) -> list[float]:
+    return [cfg.score(n.retrieval_count, n.days_since_use) for n in nodes]
 
 
-def evaluate_usage(nodes: Sequence[NodeRow], configs: Sequence[UsageConfig]) -> list[UsageResult]:
-    """Score every node under each config and rank configs by separation.
+def _cited_auc(nodes: Sequence[NodeRow], scores: Sequence[float]) -> tuple[float | None, bool]:
+    pos = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count > 0]
+    neg = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count == 0]
+    ok = len(pos) >= _MIN_LABEL_SUPPORT and len(neg) >= _MIN_LABEL_SUPPORT
+    return (auc(pos, neg) if (pos and neg) else None), ok
 
-    Primary signal is citation-AUC (independent of retrieval); when there are too few
-    cited nodes to be meaningful it falls back to retrieval-activity AUC.
+
+def _future_auc(split: TimeSplit | None, cfg: UsageConfig) -> tuple[float | None, bool]:
+    """Score each past-seen node from its PAST usage; label = retrieved in the future."""
+    if split is None or not split.past_count:
+        return None, False
+    pos: list[float] = []
+    neg: list[float] = []
+    for nid, count in split.past_count.items():
+        last = split.past_last.get(nid)
+        days = None if last is None else max(0.0, (split.split_time - last).total_seconds() / 86400)
+        s = cfg.score(count, days)
+        (pos if nid in split.future_nodes else neg).append(s)
+    ok = len(pos) >= _MIN_LABEL_SUPPORT and len(neg) >= _MIN_LABEL_SUPPORT
+    return (auc(pos, neg) if (pos and neg) else None), ok
+
+
+def evaluate_usage(
+    nodes: Sequence[NodeRow],
+    configs: Sequence[UsageConfig],
+    split: TimeSplit | None = None,
+) -> list[UsageResult]:
+    """Score every node under each config and rank configs by an *independent* signal.
+
+    Ranking uses citation-AUC when citations are dense enough, else the non-circular
+    future-retrieval-AUC from the receipts time split, else neither — in which case
+    ``ranked_by == "none"`` and the ordering is descriptive (by spread), not a
+    recommendation.
     """
-    retrievals = [n.retrieval_count for n in nodes]
-    active_ret = [r for r in retrievals if r > 0]
-    ret_threshold = statistics.median(active_ret) if active_ret else 1
-    cited_pos = sum(1 for n in nodes if n.cited_count > 0)
-    use_cited = cited_pos >= 10 and (len(nodes) - cited_pos) >= 10
+    # Decide the ranking label once, from the first config's support (support is a
+    # property of the data + label, not the config).
+    probe = configs[0] if configs else UsageConfig(0.6, 0.4, 14.0, 20.0)
+    _, cited_ok = _cited_auc(nodes, _current_scores(nodes, probe))
+    _, future_ok = _future_auc(split, probe)
+    ranked_by = "cited" if cited_ok else "future" if future_ok else "none"
 
     results: list[UsageResult] = []
     for cfg in configs:
-        scores = _score_all(nodes, cfg)
-        cited_p = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count > 0]
-        cited_n = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count == 0]
-        act_p = [
-            s
-            for s, n in zip(scores, nodes, strict=True)
-            if n.retrieval_count >= ret_threshold and n.retrieval_count > 0
-        ]
-        act_n = [s for s, n in zip(scores, nodes, strict=True) if n.retrieval_count == 0]
-        cited_auc = auc(cited_p, cited_n)
-        activity_auc = auc(act_p, act_n)
-        ranking_auc = cited_auc if use_cited else activity_auc
+        scores = _current_scores(nodes, cfg)
+        cited_auc, _ = _cited_auc(nodes, scores)
+        future_auc, _ = _future_auc(split, cfg)
+        ranking = (
+            cited_auc if ranked_by == "cited" else future_auc if ranked_by == "future" else None
+        )
         results.append(
             UsageResult(
                 config=cfg,
@@ -242,36 +356,45 @@ def evaluate_usage(nodes: Sequence[NodeRow], configs: Sequence[UsageConfig]) -> 
                 frac_zero=_fraction(scores, lambda v: v <= 1e-9),
                 frac_saturated=_fraction(scores, lambda v: v >= 0.999),
                 cited_auc=cited_auc,
-                activity_auc=activity_auc,
-                ranking_auc=ranking_auc,
-                ranked_by="cited" if use_cited else "activity",
+                future_auc=future_auc,
+                ranking_auc=ranking,
+                ranked_by=ranked_by,
             )
         )
-    # Highest separation first; a lower saturated fraction breaks ties (avoid runaway).
-    results.sort(key=lambda r: (r.ranking_auc, -r.frac_saturated), reverse=True)
+    # When we have an independent signal, rank by it (a lower saturated fraction breaks
+    # ties, to avoid runaway). Otherwise fall back to descriptive spread, largest first.
+    if ranked_by == "none":
+        results.sort(key=lambda r: (r.std, -r.frac_saturated), reverse=True)
+    else:
+        results.sort(key=lambda r: ((r.ranking_auc or 0.0), -r.frac_saturated), reverse=True)
     return results
+
+
+def _fmt_auc(v: float | None) -> str:
+    return f"{v:.3f}" if v is not None else "  n/a"
 
 
 def usage_report(results: Sequence[UsageResult], top: int) -> list[str]:
     if not results:
         return ["Usage signal — no configs evaluated."]
     ranked_by = results[0].ranked_by
+    header = {
+        "cited": "ranked by citation-AUC (independent of retrieval)",
+        "future": "ranked by future-retrieval-AUC (held-out receipts time split)",
+        "none": "NO independent label with enough support — ordering is descriptive "
+        "(by spread) only, NOT a recommendation; set defaults by judgment or gather "
+        "feedback (fc4b0669)",
+    }[ranked_by]
     out = [
-        f"Usage signal — top {min(top, len(results))} configs ranked by {ranked_by}-AUC "
-        "(higher = better separation of used vs cold nodes):",
+        f"Usage signal — top {min(top, len(results))} of {len(results)} configs; {header}:",
         f"  {'config':<28}  {'mean':>5}  {'std':>5}  {'zero%':>6}  "
-        f"{'sat%':>5}  {'citedAUC':>8}  {'actAUC':>7}",
+        f"{'sat%':>5}  {'citedAUC':>8}  {'futAUC':>7}",
     ]
     for r in results[:top]:
         out.append(
             f"  {r.config.label():<28}  {r.mean:>5.3f}  {r.std:>5.3f}  "
             f"{r.frac_zero * 100:>5.1f}%  {r.frac_saturated * 100:>4.1f}%  "
-            f"{r.cited_auc:>8.3f}  {r.activity_auc:>7.3f}"
-        )
-    if ranked_by == "activity":
-        out.append(
-            "  NOTE: too few cited nodes for citation-AUC — ranked by retrieval-activity "
-            "AUC instead (revisit once fc4b0669 lands explicit feedback)."
+            f"{_fmt_auc(r.cited_auc):>8}  {_fmt_auc(r.future_auc):>7}"
         )
     return out
 
@@ -298,6 +421,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=list(_DEFAULT_FLOORS),
         help="Comma-separated candidate floors (default: 0.2,0.25,0.3,0.35,0.4)",
     )
+    parser.add_argument(
+        "--split",
+        type=float,
+        default=0.7,
+        help="Past/future receipts split quantile for future-retrieval-AUC (default: 0.7)",
+    )
     parser.add_argument("--top", type=int, default=10, help="How many usage configs to print")
     args = parser.parse_args(argv)
 
@@ -306,13 +435,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("No node_stats rows found.", file=sys.stderr)
         return 1
 
+    receipts = load_receipts(args.stats_db)
+    split = build_time_split(receipts, args.split)
     cited = sum(1 for n in nodes if n.cited_count > 0)
-    print(f"Loaded {len(nodes)} nodes ({cited} with citations).\n")
+    print(
+        f"Loaded {len(nodes)} nodes ({cited} cited), {len(receipts)} receipts"
+        + (f", time split at {split.split_time.isoformat()}." if split else ".")
+        + "\n"
+    )
     for line in floor_report(nodes, args.floors):
         print(line)
     print()
-    results = evaluate_usage(nodes, build_configs())
-    for line in usage_report(results, args.top):
+    for line in usage_report(evaluate_usage(nodes, build_configs(), split), args.top):
         print(line)
     return 0
 

--- a/scripts/calibrate_salience.py
+++ b/scripts/calibrate_salience.py
@@ -34,7 +34,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import sqlite3
 import statistics
 import sys
@@ -43,6 +42,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from lithos.lcma.salience import recalibration_eligible, usage_score
+
+# Reuse the store's own receipt parser so the harness reads `final_nodes` exactly as
+# production does (objects with an `id` field, per retrieve.py / design §4.6) and can
+# never drift from it.
+from lithos.lcma.stats import _extract_final_node_ids
 
 # Candidate usage-signal parameter sets, expanded from these axes by default.
 _FREQ_RECENCY_SPLITS: tuple[tuple[float, float], ...] = (
@@ -108,7 +112,7 @@ def _parse_ts(value: object) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        dt = datetime.fromisoformat(value)
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
@@ -158,10 +162,16 @@ def load_nodes(db_path: str) -> list[NodeRow]:
 
 
 def load_receipts(db_path: str) -> list[tuple[datetime, list[str]]]:
-    """Read (ts, returned node_ids) from the receipts log of a stats.db copy."""
+    """Read (ts, returned node_ids) from the receipts log of a stats.db copy.
+
+    ``final_nodes`` is a JSON list of *objects* (``{"id", "reasons", "scouts"}``); the
+    node ids are pulled via the store's own :func:`_extract_final_node_ids` so a node is
+    never fragmented by its explainability payload. Ordered by ``(ts, rowid)`` for a
+    deterministic split boundary when receipts share a second-resolution timestamp.
+    """
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     try:
-        rows = conn.execute("SELECT ts, final_nodes FROM receipts").fetchall()
+        rows = conn.execute("SELECT ts, final_nodes FROM receipts ORDER BY ts, rowid").fetchall()
     finally:
         conn.close()
 
@@ -170,36 +180,43 @@ def load_receipts(db_path: str) -> list[tuple[datetime, list[str]]]:
         ts = _parse_ts(ts_raw)
         if ts is None:
             continue
-        try:
-            node_ids = json.loads(nodes_raw) if nodes_raw else []
-        except (TypeError, ValueError):
-            continue
-        if isinstance(node_ids, list):
-            out.append((ts, [str(n) for n in node_ids]))
+        node_ids = _extract_final_node_ids(nodes_raw)
+        if node_ids:
+            out.append((ts, node_ids))
     return out
 
 
 def build_time_split(
     receipts: Sequence[tuple[datetime, list[str]]], split_quantile: float
 ) -> TimeSplit | None:
-    """Partition receipts by time: earlier fraction = past (scored), rest = future (label)."""
-    if not receipts:
+    """Partition receipts by position into past (scored) and future (label).
+
+    The earlier ``split_quantile`` fraction of receipts (by ``(ts, rowid)`` order) is the
+    past window, the remainder the held-out future. Slicing by *position* — not by a
+    ``ts <= boundary`` comparison — means a 70% split puts exactly 70% in the past and
+    keeps ties from leaking a whole timestamp group across the boundary. Returns ``None``
+    when the split is degenerate (fewer than two receipts, or ``split_quantile`` outside
+    ``(0, 1)``), so the caller falls back to descriptive-only output.
+    """
+    if len(receipts) < 2 or not (0.0 < split_quantile < 1.0):
         return None
     ordered = sorted(receipts, key=lambda r: r[0])
-    idx = min(len(ordered) - 1, max(0, int(split_quantile * len(ordered))))
-    split_time = ordered[idx][0]
+    past_count_n = min(len(ordered) - 1, max(1, int(split_quantile * len(ordered))))
+    past = ordered[:past_count_n]
+    future = ordered[past_count_n:]
+    split_time = past[-1][0]
+
     past_count: dict[str, int] = {}
     past_last: dict[str, datetime] = {}
+    for ts, node_ids in past:
+        for nid in node_ids:
+            past_count[nid] = past_count.get(nid, 0) + 1
+            prev = past_last.get(nid)
+            if prev is None or ts > prev:
+                past_last[nid] = ts
     future_nodes: set[str] = set()
-    for ts, node_ids in ordered:
-        if ts <= split_time:
-            for nid in node_ids:
-                past_count[nid] = past_count.get(nid, 0) + 1
-                prev = past_last.get(nid)
-                if prev is None or ts > prev:
-                    past_last[nid] = ts
-        else:
-            future_nodes.update(node_ids)
+    for _ts, node_ids in future:
+        future_nodes.update(node_ids)
     return TimeSplit(split_time, past_count, past_last, frozenset(future_nodes))
 
 

--- a/scripts/calibrate_salience.py
+++ b/scripts/calibrate_salience.py
@@ -46,7 +46,7 @@ from lithos.lcma.salience import recalibration_eligible, usage_score
 # Reuse the store's own receipt parser so the harness reads `final_nodes` exactly as
 # production does (objects with an `id` field, per retrieve.py / design §4.6) and can
 # never drift from it.
-from lithos.lcma.stats import _extract_final_node_ids
+from lithos.lcma.stats import extract_final_node_ids
 
 # Candidate usage-signal parameter sets, expanded from these axes by default.
 _FREQ_RECENCY_SPLITS: tuple[tuple[float, float], ...] = (
@@ -165,7 +165,7 @@ def load_receipts(db_path: str) -> list[tuple[datetime, list[str]]]:
     """Read (ts, returned node_ids) from the receipts log of a stats.db copy.
 
     ``final_nodes`` is a JSON list of *objects* (``{"id", "reasons", "scouts"}``); the
-    node ids are pulled via the store's own :func:`_extract_final_node_ids` so a node is
+    node ids are pulled via the store's own :func:`extract_final_node_ids` so a node is
     never fragmented by its explainability payload. Ordered by ``(ts, rowid)`` for a
     deterministic split boundary when receipts share a second-resolution timestamp.
     """
@@ -180,7 +180,7 @@ def load_receipts(db_path: str) -> list[tuple[datetime, list[str]]]:
         ts = _parse_ts(ts_raw)
         if ts is None:
             continue
-        node_ids = _extract_final_node_ids(nodes_raw)
+        node_ids = extract_final_node_ids(nodes_raw)
         if node_ids:
             out.append((ts, node_ids))
     return out

--- a/scripts/calibrate_salience.py
+++ b/scripts/calibrate_salience.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Offline calibration harness for LCMA salience recalibration (task e7d8ef60).
+
+Runs **read-only against a copy of a prod/staging ``stats.db``** — never the live
+instance — and helps pick the shipped defaults for the salience floor and the usage
+signal. It imports the same pure helpers the server uses
+(:mod:`lithos.lcma.salience`), so the numbers reflect exactly what runs in production.
+
+It answers two questions:
+
+1. **Floor** — for each candidate floor, what does the salience distribution look like
+   after the one-time ``max(salience, floor)`` backfill (mean, % ≤ 0.30, spread)?
+2. **Usage signal** — for each candidate ``usage_score`` parameter set, what is the
+   resulting distribution, and how well does it *separate* nodes that were genuinely
+   used (cited, or frequently retrieved) from cold ones? Configs are ranked by a
+   rank-based AUC so a good spread that also tracks real usage floats to the top.
+
+Ground truth is thin while explicit feedback is near-empty, so the ranking falls back
+from citation-AUC to retrieval-activity-AUC (with a warning) when there are too few
+cited nodes — exactly the regime the recalibration was written for.
+
+Usage:
+    python scripts/calibrate_salience.py /path/to/stats-copy.db
+    python scripts/calibrate_salience.py stats.db --floors 0.25,0.3,0.35 --top 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import statistics
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from lithos.lcma.salience import usage_score
+
+# Candidate usage-signal parameter sets, expanded from these axes by default.
+_FREQ_RECENCY_SPLITS: tuple[tuple[float, float], ...] = (
+    (0.6, 0.4),
+    (0.5, 0.5),
+    (0.7, 0.3),
+    (0.4, 0.6),
+)
+_HALFLIVES: tuple[float, ...] = (7.0, 14.0, 30.0)
+_NORM_KS: tuple[float, ...] = (10.0, 20.0, 50.0)
+_DEFAULT_FLOORS: tuple[float, ...] = (0.2, 0.25, 0.3, 0.35, 0.4)
+
+
+@dataclass(frozen=True)
+class NodeRow:
+    """The node_stats fields the calibration needs."""
+
+    salience: float
+    retrieval_count: int
+    cited_count: int
+    days_since_use: float | None
+
+
+@dataclass(frozen=True)
+class UsageConfig:
+    freq_weight: float
+    recency_weight: float
+    recency_halflife_days: float
+    freq_norm_k: float
+
+    def label(self) -> str:
+        return (
+            f"f={self.freq_weight:.1f} r={self.recency_weight:.1f} "
+            f"hl={self.recency_halflife_days:g} k={self.freq_norm_k:g}"
+        )
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def load_nodes(db_path: str) -> list[NodeRow]:
+    """Read node_stats from a stats.db copy (read-only).
+
+    Recency is measured relative to the newest activity in the snapshot rather than
+    wall-clock now, so the result is deterministic and independent of when the harness
+    runs.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT salience, retrieval_count, cited_count, "
+            "last_used_at, last_retrieved_at FROM node_stats"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    times: list[datetime] = []
+    parsed: list[tuple[sqlite3.Row, datetime | None]] = []
+    for row in rows:
+        ts = _parse_ts(row["last_used_at"]) or _parse_ts(row["last_retrieved_at"])
+        if ts is not None:
+            times.append(ts)
+        parsed.append((row, ts))
+
+    reference = max(times) if times else datetime.now(UTC)
+    nodes: list[NodeRow] = []
+    for row, ts in parsed:
+        days = None if ts is None else max(0.0, (reference - ts).total_seconds() / 86400.0)
+        nodes.append(
+            NodeRow(
+                salience=float(row["salience"]),
+                retrieval_count=int(row["retrieval_count"]),
+                cited_count=int(row["cited_count"]),
+                days_since_use=days,
+            )
+        )
+    return nodes
+
+
+def auc(positives: Sequence[float], negatives: Sequence[float]) -> float:
+    """Probability a random positive outranks a random negative (ties count 0.5).
+
+    Returns 0.5 (uninformative) when either group is empty. O(n log n) via rank sums
+    (Mann-Whitney U), so it scales to the whole corpus.
+    """
+    if not positives or not negatives:
+        return 0.5
+    labelled = [(v, 1) for v in positives] + [(v, 0) for v in negatives]
+    labelled.sort(key=lambda t: t[0])
+    # Average ranks over ties.
+    ranks = [0.0] * len(labelled)
+    i = 0
+    while i < len(labelled):
+        j = i
+        while j + 1 < len(labelled) and labelled[j + 1][0] == labelled[i][0]:
+            j += 1
+        avg_rank = (i + j) / 2 + 1  # 1-based average rank across the tie block
+        for k in range(i, j + 1):
+            ranks[k] = avg_rank
+        i = j + 1
+    rank_sum_pos = sum(r for r, (_, lbl) in zip(ranks, labelled, strict=True) if lbl == 1)
+    n_pos = len(positives)
+    n_neg = len(negatives)
+    u = rank_sum_pos - n_pos * (n_pos + 1) / 2
+    return u / (n_pos * n_neg)
+
+
+def _fraction(values: Sequence[float], predicate: object) -> float:
+    if not values:
+        return 0.0
+    assert callable(predicate)
+    return sum(1 for v in values if predicate(v)) / len(values)
+
+
+def _percentile(sorted_values: Sequence[float], q: float) -> float:
+    if not sorted_values:
+        return 0.0
+    idx = min(len(sorted_values) - 1, max(0, int(q * len(sorted_values))))
+    return sorted_values[idx]
+
+
+def floor_report(nodes: Sequence[NodeRow], floors: Sequence[float]) -> list[str]:
+    """One row per candidate floor: the salience distribution after backfill."""
+    out = ["Floor backfill — salience distribution after max(salience, floor):"]
+    out.append(f"  {'floor':>6}  {'mean':>6}  {'<=0.30':>7}  {'std':>6}  {'p50':>6}  {'p90':>6}")
+    for floor in floors:
+        lifted = [max(n.salience, floor) for n in nodes]
+        s = sorted(lifted)
+        mean = statistics.fmean(lifted) if lifted else 0.0
+        std = statistics.pstdev(lifted) if len(lifted) > 1 else 0.0
+        frac = _fraction(lifted, lambda v: v <= 0.30)
+        out.append(
+            f"  {floor:>6.2f}  {mean:>6.3f}  {frac * 100:>6.1f}%  "
+            f"{std:>6.3f}  {_percentile(s, 0.5):>6.3f}  {_percentile(s, 0.9):>6.3f}"
+        )
+    return out
+
+
+@dataclass(frozen=True)
+class UsageResult:
+    config: UsageConfig
+    mean: float
+    std: float
+    frac_zero: float
+    frac_saturated: float
+    cited_auc: float
+    activity_auc: float
+    ranking_auc: float
+    ranked_by: str
+
+
+def _score_all(nodes: Sequence[NodeRow], cfg: UsageConfig) -> list[float]:
+    return [
+        usage_score(
+            n.retrieval_count,
+            n.days_since_use,
+            freq_weight=cfg.freq_weight,
+            recency_weight=cfg.recency_weight,
+            recency_halflife_days=cfg.recency_halflife_days,
+            freq_norm_k=cfg.freq_norm_k,
+        )
+        for n in nodes
+    ]
+
+
+def evaluate_usage(nodes: Sequence[NodeRow], configs: Sequence[UsageConfig]) -> list[UsageResult]:
+    """Score every node under each config and rank configs by separation.
+
+    Primary signal is citation-AUC (independent of retrieval); when there are too few
+    cited nodes to be meaningful it falls back to retrieval-activity AUC.
+    """
+    retrievals = [n.retrieval_count for n in nodes]
+    active_ret = [r for r in retrievals if r > 0]
+    ret_threshold = statistics.median(active_ret) if active_ret else 1
+    cited_pos = sum(1 for n in nodes if n.cited_count > 0)
+    use_cited = cited_pos >= 10 and (len(nodes) - cited_pos) >= 10
+
+    results: list[UsageResult] = []
+    for cfg in configs:
+        scores = _score_all(nodes, cfg)
+        cited_p = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count > 0]
+        cited_n = [s for s, n in zip(scores, nodes, strict=True) if n.cited_count == 0]
+        act_p = [
+            s
+            for s, n in zip(scores, nodes, strict=True)
+            if n.retrieval_count >= ret_threshold and n.retrieval_count > 0
+        ]
+        act_n = [s for s, n in zip(scores, nodes, strict=True) if n.retrieval_count == 0]
+        cited_auc = auc(cited_p, cited_n)
+        activity_auc = auc(act_p, act_n)
+        ranking_auc = cited_auc if use_cited else activity_auc
+        results.append(
+            UsageResult(
+                config=cfg,
+                mean=statistics.fmean(scores) if scores else 0.0,
+                std=statistics.pstdev(scores) if len(scores) > 1 else 0.0,
+                frac_zero=_fraction(scores, lambda v: v <= 1e-9),
+                frac_saturated=_fraction(scores, lambda v: v >= 0.999),
+                cited_auc=cited_auc,
+                activity_auc=activity_auc,
+                ranking_auc=ranking_auc,
+                ranked_by="cited" if use_cited else "activity",
+            )
+        )
+    # Highest separation first; a lower saturated fraction breaks ties (avoid runaway).
+    results.sort(key=lambda r: (r.ranking_auc, -r.frac_saturated), reverse=True)
+    return results
+
+
+def usage_report(results: Sequence[UsageResult], top: int) -> list[str]:
+    if not results:
+        return ["Usage signal — no configs evaluated."]
+    ranked_by = results[0].ranked_by
+    out = [
+        f"Usage signal — top {min(top, len(results))} configs ranked by {ranked_by}-AUC "
+        "(higher = better separation of used vs cold nodes):",
+        f"  {'config':<28}  {'mean':>5}  {'std':>5}  {'zero%':>6}  "
+        f"{'sat%':>5}  {'citedAUC':>8}  {'actAUC':>7}",
+    ]
+    for r in results[:top]:
+        out.append(
+            f"  {r.config.label():<28}  {r.mean:>5.3f}  {r.std:>5.3f}  "
+            f"{r.frac_zero * 100:>5.1f}%  {r.frac_saturated * 100:>4.1f}%  "
+            f"{r.cited_auc:>8.3f}  {r.activity_auc:>7.3f}"
+        )
+    if ranked_by == "activity":
+        out.append(
+            "  NOTE: too few cited nodes for citation-AUC — ranked by retrieval-activity "
+            "AUC instead (revisit once fc4b0669 lands explicit feedback)."
+        )
+    return out
+
+
+def build_configs() -> list[UsageConfig]:
+    configs: list[UsageConfig] = []
+    for fw, rw in _FREQ_RECENCY_SPLITS:
+        for hl in _HALFLIVES:
+            for k in _NORM_KS:
+                configs.append(UsageConfig(fw, rw, hl, k))
+    return configs
+
+
+def _parse_floors(raw: str) -> list[float]:
+    return [float(x) for x in raw.split(",") if x.strip()]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("stats_db", help="Path to a COPY of stats.db (read-only)")
+    parser.add_argument(
+        "--floors",
+        type=_parse_floors,
+        default=list(_DEFAULT_FLOORS),
+        help="Comma-separated candidate floors (default: 0.2,0.25,0.3,0.35,0.4)",
+    )
+    parser.add_argument("--top", type=int, default=10, help="How many usage configs to print")
+    args = parser.parse_args(argv)
+
+    nodes = load_nodes(args.stats_db)
+    if not nodes:
+        print("No node_stats rows found.", file=sys.stderr)
+        return 1
+
+    cited = sum(1 for n in nodes if n.cited_count > 0)
+    print(f"Loaded {len(nodes)} nodes ({cited} with citations).\n")
+    for line in floor_report(nodes, args.floors):
+        print(line)
+    print()
+    results = evaluate_usage(nodes, build_configs())
+    for line in usage_report(results, args.top):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -246,6 +246,60 @@ def reindex(ctx: click.Context, clear: bool) -> None:
     asyncio.run(do_reindex())
 
 
+def _echo_salience_distribution(label: str, dist: dict[str, float], floor: float) -> None:
+    click.echo(
+        f"{label:>6}: n={int(dist['count'])} mean={dist['mean']:.3f} "
+        f"<=0.30={dist['fraction_le_030'] * 100:.1f}% "
+        f"p50={dist['p50']:.3f} p90={dist['p90']:.3f} (floor={floor:.3f})"
+    )
+
+
+@cli.command(name="recalibrate-salience")
+@click.option(
+    "--floor",
+    type=float,
+    default=None,
+    help="Floor to lift collapsed rows to (default: config lcma.salience_floor).",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="Report the distribution and how many rows would be lifted, without writing.",
+)
+@click.pass_context
+def recalibrate_salience(ctx: click.Context, floor: float | None, dry_run: bool) -> None:
+    """One-time backfill: lift decay-collapsed salience rows to the floor.
+
+    Corrects the historical salience collapse (task e7d8ef60) where a floor-less daily
+    decay drove most nodes to ~0. Run once — on staging first, then prod. Idempotent, so
+    re-running is safe. Nodes carrying explicit negative feedback (misleading /
+    chronically ignored) are deliberately left below the floor.
+    """
+    # Routed through the cognitive_memory facade so the CLI stays off the
+    # lithos.lcma import seam (ADR-0005 / test_module_boundaries).
+    from lithos.cognitive_memory import recalibrate_salience as run_recalibrate
+
+    config: LithosConfig = ctx.obj["config"]
+    resolved_floor = config.lcma.salience_floor if floor is None else floor
+
+    async def do_recalibrate() -> None:
+        before, after, count = await run_recalibrate(config, resolved_floor, dry_run=dry_run)
+        _echo_salience_distribution("Before", before, resolved_floor)
+        if dry_run:
+            click.echo(f"\n[dry-run] would lift {count} rows; no writes performed.")
+            return
+        assert after is not None
+        _echo_salience_distribution("After", after, resolved_floor)
+        click.echo(f"\nLifted {count} rows to floor {resolved_floor:.3f}.")
+        logger.info(
+            "recalibrate-salience complete: floor=%.3f lifted=%d",
+            resolved_floor,
+            count,
+        )
+
+    asyncio.run(do_recalibrate())
+
+
 @cli.command()
 @click.option(
     "--fix/--no-fix",

--- a/src/lithos/cli.py
+++ b/src/lithos/cli.py
@@ -249,7 +249,7 @@ def reindex(ctx: click.Context, clear: bool) -> None:
 def _echo_salience_distribution(label: str, dist: dict[str, float], floor: float) -> None:
     click.echo(
         f"{label:>6}: n={int(dist['count'])} mean={dist['mean']:.3f} "
-        f"<=0.30={dist['fraction_le_030'] * 100:.1f}% "
+        f"below_floor={dist['fraction_below_floor'] * 100:.1f}% "
         f"p50={dist['p50']:.3f} p90={dist['p90']:.3f} (floor={floor:.3f})"
     )
 
@@ -257,9 +257,9 @@ def _echo_salience_distribution(label: str, dist: dict[str, float], floor: float
 @cli.command(name="recalibrate-salience")
 @click.option(
     "--floor",
-    type=float,
+    type=click.FloatRange(0.0, 1.0),
     default=None,
-    help="Floor to lift collapsed rows to (default: config lcma.salience_floor).",
+    help="Floor to lift collapsed rows to, in [0, 1] (default: config lcma.salience_floor).",
 )
 @click.option(
     "--dry-run/--no-dry-run",

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -1146,12 +1146,12 @@ async def recalibrate_salience(
     store = StatsStore(config)
     await store.open()
     try:
-        before = await store.salience_distribution()
+        before = await store.salience_distribution(floor)
         if dry_run:
             would = await store.recalibrate_salience_floor(floor, dry_run=True)
             return before, None, would
         lifted = await store.recalibrate_salience_floor(floor)
-        after = await store.salience_distribution()
+        after = await store.salience_distribution(floor)
         return before, after, lifted
     finally:
         await store.close()

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -57,6 +57,7 @@ __all__ = [
     "CognitiveMemory",
     "NodeStats",
     "extract_entities",
+    "recalibrate_salience",
 ]
 
 
@@ -636,14 +637,15 @@ class CognitiveMemory:
             "CognitiveMemory.reinforce_cited: reinforcing",
             extra={"node_count": len(cited_ids)},
         )
+        cited_boost = self._config.lcma.salience_cited_boost
         for node_id in cited_ids:
             await self._stats_store.increment_cited(node_id)
-            await self._stats_store.update_salience(node_id, 0.02)
+            await self._stats_store.update_salience(node_id, cited_boost)
             await self._stats_store.update_spaced_rep_strength(node_id, 0.05)
             await self._stats_store.update_last_used_at(node_id)
             logger.debug(
                 "CognitiveMemory.reinforce_cited: node reinforced",
-                extra={"node_id": node_id, "salience_delta": 0.02, "spaced_rep_delta": 0.05},
+                extra={"node_id": node_id, "salience_delta": cited_boost, "spaced_rep_delta": 0.05},
             )
 
     async def reinforce_ignored(self, ignored_ids: list[str]) -> None:
@@ -668,14 +670,15 @@ class CognitiveMemory:
                 assert isinstance(ignored, int)
                 assert isinstance(cited, int)
                 if ignored > 5 and ignored > cited:
-                    await self._stats_store.update_salience(node_id, -0.02)
+                    ignored_penalty = self._config.lcma.salience_ignored_penalty
+                    await self._stats_store.update_salience(node_id, -ignored_penalty)
                     logger.debug(
                         "CognitiveMemory.reinforce_ignored: decayed salience",
                         extra={
                             "node_id": node_id,
                             "ignored_count": ignored,
                             "cited_count": cited,
-                            "salience_delta": -0.02,
+                            "salience_delta": -ignored_penalty,
                         },
                     )
             logger.debug(
@@ -781,9 +784,10 @@ class CognitiveMemory:
             "CognitiveMemory.reinforce_misleading: applying misleading penalties",
             extra={"node_count": len(misleading_ids)},
         )
+        misleading_penalty = self._config.lcma.salience_misleading_penalty
         for node_id in misleading_ids:
             await self._stats_store.increment_misleading(node_id)
-            await self._stats_store.update_salience(node_id, -0.05)
+            await self._stats_store.update_salience(node_id, -misleading_penalty)
             stats = await self._stats_store.get_node_stats(node_id)
             if stats is not None:
                 misleading = stats["misleading_count"]
@@ -805,7 +809,7 @@ class CognitiveMemory:
                     )
             logger.debug(
                 "CognitiveMemory.reinforce_misleading: node penalized",
-                extra={"node_id": node_id, "salience_delta": -0.05},
+                extra={"node_id": node_id, "salience_delta": -misleading_penalty},
             )
 
         edge_store = self._projection.edge_store
@@ -1119,3 +1123,35 @@ class CognitiveMemory:
                 "edge_id": edge_id,
                 "conflict_state": resolution,
             }
+
+
+async def recalibrate_salience(
+    config: LithosConfig,
+    floor: float,
+    *,
+    dry_run: bool = False,
+) -> tuple[dict[str, float], dict[str, float] | None, int]:
+    """Run the one-time salience floor backfill as a standalone maintenance op.
+
+    Opens a :class:`StatsStore` for *config*, captures the before distribution, lifts
+    decay-collapsed rows to *floor* (skipping explicit-negative-feedback nodes; unless
+    *dry_run*), captures the after distribution, and closes — without starting the
+    ``EnrichWorker``. Exposed here rather than in the CLI so entrypoints need not import
+    ``lithos.lcma`` (ADR-0005 seam). Corrects the historical salience collapse
+    (task ``e7d8ef60``).
+
+    Returns ``(before, after_or_None, lifted_count)``; ``after`` is ``None`` for a dry
+    run, where ``lifted_count`` is instead how many rows *would* be lifted.
+    """
+    store = StatsStore(config)
+    await store.open()
+    try:
+        before = await store.salience_distribution()
+        if dry_run:
+            would = await store.recalibrate_salience_floor(floor, dry_run=True)
+            return before, None, would
+        lifted = await store.recalibrate_salience_floor(floor)
+        after = await store.salience_distribution()
+        return before, after, lifted
+    finally:
+        await store.close()

--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -179,6 +179,36 @@ class LcmaConfig(BaseModel):
     # citation/glossary explosions (#320). 0 disables the cap.
     entity_max_per_doc: int = Field(default=50, ge=0)
 
+    # --- Salience recalibration (task e7d8ef60) -------------------------------
+    # Time-based decay erodes salience toward this non-zero floor, not to zero, so an
+    # idle-but-harmless note keeps a meaningful baseline instead of collapsing to a
+    # uniform ~0 rerank penalty. Explicit negative feedback may still push below it.
+    # The decay slope/cap and the reinforcement deltas were previously hardcoded
+    # literals in enrich.py / cognitive_memory.py; they are exposed here so the
+    # calibration harness (and WS6 metamemory) can tune them without a code change.
+    salience_floor: float = Field(default=0.3, ge=0.0, le=1.0)
+    salience_decay_per_day: float = Field(default=0.005, ge=0.0)
+    salience_decay_daily_cap: float = Field(default=0.1, ge=0.0)
+    salience_cited_boost: float = Field(default=0.02, ge=0.0)
+    salience_consolidation_boost: float = Field(default=0.01, ge=0.0)
+    salience_misleading_penalty: float = Field(default=0.05, ge=0.0)
+    salience_ignored_penalty: float = Field(default=0.02, ge=0.0)
+
+    # --- Rerank composite weights (previously hardcoded 0.1 coefficients) ------
+    # Added to the scout-weighted base score; these are outside the rerank_weights
+    # bucket (which must sum to 1.0) and need not normalise.
+    rerank_salience_weight: float = Field(default=0.1, ge=0.0)
+    rerank_note_type_weight: float = Field(default=0.1, ge=0.0)
+    rerank_usage_weight: float = Field(default=0.1, ge=0.0)
+
+    # --- Usage signal (non-decaying popularity term, retrieve.py rerank) -------
+    # log-scaled retrieval frequency + exponential recency, from live node_stats
+    # counters already fetched during rerank. See lithos.lcma.salience.usage_score.
+    usage_freq_weight: float = Field(default=0.6, ge=0.0)
+    usage_recency_weight: float = Field(default=0.4, ge=0.0)
+    usage_recency_halflife_days: float = Field(default=14.0, gt=0.0)
+    usage_freq_norm_k: float = Field(default=20.0, gt=0.0)
+
     @model_validator(mode="before")
     @classmethod
     def _fill_and_renormalize_rerank_weights(cls, data: Any) -> Any:

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -27,6 +27,8 @@ from lithos.events import (
 )
 from lithos.lcma.edge_reinforce import reinforce_related_edge
 from lithos.lcma.entities import ENTITY_EXTRACTOR_VERSION, extract_entities
+from lithos.lcma.salience import DEFAULT_SALIENCE
+from lithos.lcma.salience import decay_amount as compute_decay_amount
 
 if TYPE_CHECKING:
     from lithos.config import LcmaConfig
@@ -487,18 +489,49 @@ class EnrichWorker:
         if days_since_last_use <= self._config.decay_inactive_days:
             return False
 
-        decay_amount = min(0.1, days_since_last_use * 0.005)
-        await self._stats_store.update_salience(node_id, -decay_amount)
+        raw_salience = stats.get("salience")
+        current_salience = (
+            float(raw_salience) if isinstance(raw_salience, (int, float)) else DEFAULT_SALIENCE
+        )
+        amount = compute_decay_amount(
+            current_salience,
+            days_since_last_use,
+            per_day=self._config.salience_decay_per_day,
+            daily_cap=self._config.salience_decay_daily_cap,
+            floor=self._config.salience_floor,
+        )
+        if amount <= 0.0:
+            # Already at or below the floor (or below it via explicit feedback):
+            # time decay adds nothing. Nothing to write, nothing to converge.
+            return False
+
+        await self._stats_store.update_salience(node_id, -amount)
         await self._stats_store.update_last_decay_applied_at(node_id)
         logger.debug(
             "EnrichWorker: applied salience decay",
             extra={
                 "node_id": node_id,
                 "days_inactive": days_since_last_use,
-                "decay_amount": round(decay_amount, 3),
+                "decay_amount": round(amount, 3),
             },
         )
         return True
+
+    async def _emit_salience_distribution(self) -> None:
+        """Record the current salience distribution as gauges (no-op without telemetry).
+
+        One aggregate query on the daily sweep; cheap relative to the corpus decay pass.
+        """
+        if not _HAS_TELEMETRY or _lithos_metrics is None:
+            return
+        try:
+            dist = await self._stats_store.salience_distribution()
+        except Exception:
+            logger.exception("EnrichWorker: salience distribution snapshot failed")
+            return
+        _lithos_metrics.lcma_salience_mean.set(dist["mean"])
+        _lithos_metrics.lcma_salience_fraction_floored.set(dist["fraction_le_030"])
+        _lithos_metrics.lcma_salience_node_count.set(dist["count"])
 
     async def _extract_entities(self, node_id: str, doc: KnowledgeDocument | None = None) -> None:
         """Extract entities from note content and write to frontmatter.
@@ -594,6 +627,11 @@ class EnrichWorker:
             stats = all_stats.get(node_id)
             if stats is not None and await self._apply_decay(node_id, stats):
                 decayed += 1
+
+        # --- Snapshot the salience distribution for telemetry ---
+        # Makes "salience collapsed / recovered" (task e7d8ef60) observable so a
+        # re-collapse can be alerted on rather than re-found by a manual audit.
+        await self._emit_salience_distribution()
 
         # --- Evict stale working memory ---
         completed_tasks = await self._coordination.list_tasks(status="completed")
@@ -704,13 +742,14 @@ class EnrichWorker:
                 )
 
         # --- Salience boost for each frequent node ---
+        consolidation_boost = self._config.salience_consolidation_boost
         for entry in frequent:
             nid = str(entry["node_id"])
             if await self._stats_store.has_consolidation_salience_op(task_id, nid):
                 continue
             # Atomic: salience update + op record in one stats.db transaction
             await self._stats_store.update_salience_and_record_consolidation(
-                node_id=nid, delta=0.01, task_id=task_id
+                node_id=nid, delta=consolidation_boost, task_id=task_id
             )
 
         await self._stats_store.mark_task_consolidated(task_id)

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -525,13 +525,14 @@ class EnrichWorker:
         if not _HAS_TELEMETRY or _lithos_metrics is None:
             return
         try:
-            dist = await self._stats_store.salience_distribution()
+            dist = await self._stats_store.salience_distribution(self._config.salience_floor)
+            _lithos_metrics.lcma_salience_mean.set(dist["mean"])
+            _lithos_metrics.lcma_salience_fraction_below_floor.set(dist["fraction_below_floor"])
+            _lithos_metrics.lcma_salience_node_count.set(dist["count"])
         except Exception:
+            # Telemetry is best-effort — a metrics hiccup must never abort the sweep's
+            # decay / working-memory / provenance work that runs after this.
             logger.exception("EnrichWorker: salience distribution snapshot failed")
-            return
-        _lithos_metrics.lcma_salience_mean.set(dist["mean"])
-        _lithos_metrics.lcma_salience_fraction_floored.set(dist["fraction_le_030"])
-        _lithos_metrics.lcma_salience_node_count.set(dist["count"])
 
     async def _extract_entities(self, node_id: str, doc: KnowledgeDocument | None = None) -> None:
         """Extract entities from note content and write to frontmatter.

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -135,11 +135,15 @@ def _mmr_diversify(
 def _days_since(ts: object, now: datetime) -> float | None:
     """Fractional days between an ISO timestamp and *now* (tz-naive treated as UTC).
 
-    Returns ``None`` when *ts* is missing/blank so the usage recency term drops out.
+    Returns ``None`` when *ts* is missing/blank/unparseable so a single malformed
+    timestamp drops the recency term rather than failing the whole retrieval.
     """
     if not isinstance(ts, str) or not ts:
         return None
-    dt = datetime.fromisoformat(ts)
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return max(0.0, (now - dt).total_seconds() / 86400.0)

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -23,9 +23,11 @@ import itertools
 import logging
 import re
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from lithos.errors import ScoutFailure
+from lithos.lcma.salience import DEFAULT_SALIENCE, usage_score
 from lithos.lcma.scouts import (
     ALL_SCOUT_NAMES,
     SCOUT_CONTRADICTIONS,
@@ -130,18 +132,66 @@ def _mmr_diversify(
     return selected + tail
 
 
+def _days_since(ts: object, now: datetime) -> float | None:
+    """Fractional days between an ISO timestamp and *now* (tz-naive treated as UTC).
+
+    Returns ``None`` when *ts* is missing/blank so the usage recency term drops out.
+    """
+    if not isinstance(ts, str) or not ts:
+        return None
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return max(0.0, (now - dt).total_seconds() / 86400.0)
+
+
+def _usage_from_stats(
+    stats: dict[str, object] | None,
+    now: datetime,
+    lcma_config: LcmaConfig,
+) -> float:
+    """Compute the non-decaying usage signal for a node from its stats row.
+
+    Reads ``retrieval_count`` and last-use recency (``last_used_at`` falling back to
+    ``last_retrieved_at``) — both already present in the pre-fetched row — and defers
+    to :func:`lithos.lcma.salience.usage_score`. Unseen nodes score 0.0.
+    """
+    if stats is None:
+        return 0.0
+    raw_count = stats.get("retrieval_count")
+    retrieval_count = raw_count if isinstance(raw_count, int) else 0
+    days_since_use = _days_since(stats.get("last_used_at") or stats.get("last_retrieved_at"), now)
+    return usage_score(
+        retrieval_count,
+        days_since_use,
+        freq_weight=lcma_config.usage_freq_weight,
+        recency_weight=lcma_config.usage_recency_weight,
+        recency_halflife_days=lcma_config.usage_recency_halflife_days,
+        freq_norm_k=lcma_config.usage_freq_norm_k,
+    )
+
+
 def _rerank_fast(
     candidates: list[Candidate],
     lcma_config: LcmaConfig,
     knowledge: KnowledgeManager,
     salience_map: dict[str, float] | None = None,
+    usage_map: dict[str, float] | None = None,
 ) -> list[Candidate]:
-    """Terrace 1 reranking: weighted scout scores, note_type priors, salience.
+    """Terrace 1 reranking: weighted scout scores, note_type priors, salience, usage.
 
     When *salience_map* is provided, actual salience values from StatsStore are
     used instead of the normalised scout score.  ``salience_map`` maps
-    ``node_id → salience``; nodes absent from the map fall back to 0.5
-    (the StatsStore default).
+    ``node_id → salience``; nodes absent from the map fall back to
+    ``DEFAULT_SALIENCE`` (the StatsStore default).
+
+    *usage_map* carries the non-decaying popularity signal (retrieval frequency +
+    recency) per node; nodes absent from it — or the whole map being ``None`` — score
+    0.0 (neutral). Unlike salience this cannot collapse, so it restores a real spread
+    to the composite even on a cold, unreinforced corpus (task ``e7d8ef60``).
+
+    The additive term weights (salience, note_type, usage) come from
+    :class:`LcmaConfig` rather than hardcoded coefficients.
 
     After the linear combination sort, applies a greedy MMR pass over the top
     candidates to penalise near-duplicates (see checklist MVP 1 requirement for
@@ -151,6 +201,9 @@ def _rerank_fast(
     """
     rerank_weights = lcma_config.rerank_weights
     note_type_priors = lcma_config.note_type_priors
+    w_salience = lcma_config.rerank_salience_weight
+    w_note_type = lcma_config.rerank_note_type_weight
+    w_usage = lcma_config.rerank_usage_weight
 
     debug_rows: list[dict[str, object]] = []
     scored: list[tuple[float, Candidate]] = []
@@ -174,10 +227,20 @@ def _rerank_fast(
 
         # Salience: read from StatsStore via pre-fetched map when available,
         # otherwise fall back to normalised score (pre-reinforcement path).
-        salience = salience_map.get(c.node_id, 0.5) if salience_map is not None else c.score
+        salience = (
+            salience_map.get(c.node_id, DEFAULT_SALIENCE) if salience_map is not None else c.score
+        )
+
+        # Usage: non-decaying popularity signal; neutral (0.0) when absent.
+        usage = usage_map.get(c.node_id, 0.0) if usage_map is not None else 0.0
 
         # Final composite: weighted combination
-        final = c.score * scout_weight + note_type_prior * 0.1 + salience * 0.1
+        final = (
+            c.score * scout_weight
+            + note_type_prior * w_note_type
+            + salience * w_salience
+            + usage * w_usage
+        )
         scored.append(
             (
                 final,
@@ -201,6 +264,7 @@ def _rerank_fast(
                     "note_type": resolved_note_type,
                     "note_type_prior": round(note_type_prior, 4),
                     "salience": round(salience, 4),
+                    "usage_score": round(usage, 4),
                     "final": round(final, 4),
                 }
             )
@@ -525,16 +589,24 @@ async def _run_retrieve_impl(
         candidates_considered = len(merged)
 
         # ── Terrace 1: rerank_fast ────────────────────────────────
-        # ── Pre-fetch salience map for reranking ─────��────────────
+        # ── Pre-fetch salience + usage maps for reranking ──
+        # get_node_stats_batch returns full rows (SELECT *), so the usage counters
+        # (retrieval_count, last_used_at/last_retrieved_at) ride along for free — the
+        # usage signal costs no extra query.
         all_node_ids = [c.node_id for c in merged]
         stats_batch = await stats_store.get_node_stats_batch(all_node_ids)
+        now = datetime.now(UTC)
         salience_map: dict[str, float] = {}
+        usage_map: dict[str, float] = {}
         for nid in all_node_ids:
             stats = stats_batch.get(nid)
-            raw = stats["salience"] if stats else 0.5
-            salience_map[nid] = raw if isinstance(raw, float) else 0.5
+            raw = stats["salience"] if stats else DEFAULT_SALIENCE
+            salience_map[nid] = raw if isinstance(raw, float) else DEFAULT_SALIENCE
+            usage_map[nid] = _usage_from_stats(stats, now, lcma_config)
 
-        reranked = _rerank_fast(merged, lcma_config, knowledge, salience_map=salience_map)
+        reranked = _rerank_fast(
+            merged, lcma_config, knowledge, salience_map=salience_map, usage_map=usage_map
+        )
         terrace_reached = 1
 
         logger.info(
@@ -588,7 +660,8 @@ async def _run_retrieve_impl(
                         # LCMA extras
                         "reasons": c.reasons,
                         "scouts": c.scouts,
-                        "salience": salience_map.get(c.node_id, 0.5),
+                        "salience": salience_map.get(c.node_id, DEFAULT_SALIENCE),
+                        "usage_score": usage_map.get(c.node_id, 0.0),
                     }
                 )
             except FileNotFoundError:

--- a/src/lithos/lcma/retrieve.py
+++ b/src/lithos/lcma/retrieve.py
@@ -141,7 +141,9 @@ def _days_since(ts: object, now: datetime) -> float | None:
     if not isinstance(ts, str) or not ts:
         return None
     try:
-        dt = datetime.fromisoformat(ts)
+        # Normalise a trailing 'Z' to +00:00 (as server.py / coordination.py do) so
+        # older/alternate stored formats parse rather than silently dropping recency.
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
     except ValueError:
         return None
     if dt.tzinfo is None:

--- a/src/lithos/lcma/salience.py
+++ b/src/lithos/lcma/salience.py
@@ -1,0 +1,81 @@
+"""Pure salience math: decay toward a non-zero floor + a non-decaying usage signal.
+
+This module is the single source of truth for how salience erodes over time and how
+a node's live usage counters translate into a rerank signal. Both the live worker
+(:mod:`lithos.lcma.enrich`) / reranker (:mod:`lithos.lcma.retrieve`) **and** the offline
+calibration harness import these functions, so calibration reflects exactly what runs in
+production.
+
+Everything here is a pure function — plain numbers in, a number out, no I/O and no config
+object — so the helpers stay trivially unit-testable and parameter-sweepable. Callers pull
+the tunable constants from :class:`lithos.config.LcmaConfig` and pass them explicitly.
+
+Background (task ``e7d8ef60``): the original model decayed untouched nodes linearly to
+*zero* with no floor, while the only forces that raised salience fired solely on actively
+used nodes. On a large, mostly-cold corpus that drove ~86% of nodes to ~0, turning the
+rerank salience term into a near-uniform penalty. The floor stops the collapse; the usage
+signal restores a real spread from counters that cannot collapse.
+"""
+
+from __future__ import annotations
+
+import math
+
+#: Neutral salience assigned to a node on first touch and used as the rerank fallback
+#: when a node has no stats row yet.
+DEFAULT_SALIENCE = 0.5
+
+
+def decay_amount(
+    current_salience: float,
+    days_inactive: int,
+    *,
+    per_day: float,
+    daily_cap: float,
+    floor: float,
+) -> float:
+    """Return the salience decay to subtract for a node idle *days_inactive* days.
+
+    Linear in idle days (``per_day`` per day), capped at ``daily_cap`` per application,
+    and never enough to push salience below ``floor`` — time decay erodes toward a
+    non-zero resting baseline, not to zero. The returned amount is always non-negative
+    (``0.0`` once the node is already at or below the floor).
+
+    The floor applies to *time decay only*. Explicit negative feedback
+    (misleading/ignored) is a separate path that may still drive salience below the
+    floor, because those are deliberate quality signals rather than mere inactivity.
+    """
+    raw = min(daily_cap, max(0, days_inactive) * per_day)
+    headroom = max(0.0, current_salience - floor)
+    return min(raw, headroom)
+
+
+def usage_score(
+    retrieval_count: int,
+    days_since_use: float | None,
+    *,
+    freq_weight: float,
+    recency_weight: float,
+    recency_halflife_days: float,
+    freq_norm_k: float,
+) -> float:
+    """Return a bounded ``[0, 1]`` popularity signal from live usage counters.
+
+    Combines log-scaled retrieval frequency (diminishing returns, normalised so
+    ``freq_norm_k`` retrievals map to ~1.0) with exponential recency (value halves every
+    ``recency_halflife_days``). The result is monotonic increasing in ``retrieval_count``
+    and decreasing in ``days_since_use``, and is clamped to ``[0, 1]``.
+
+    Unlike stored salience this cannot collapse: ``retrieval_count`` is monotonic and the
+    recency term is recomputed live at read time, so the signal is always meaningful even
+    on a cold corpus with no reinforcement. ``days_since_use`` of ``None`` (a node never
+    used) contributes no recency.
+    """
+    freq = math.log1p(max(0, retrieval_count)) / math.log1p(max(freq_norm_k, 1.0))
+    freq = min(1.0, freq)
+    if days_since_use is None:
+        recency = 0.0
+    else:
+        recency = 0.5 ** (max(0.0, days_since_use) / recency_halflife_days)
+    score = freq_weight * freq + recency_weight * recency
+    return max(0.0, min(1.0, score))

--- a/src/lithos/lcma/salience.py
+++ b/src/lithos/lcma/salience.py
@@ -50,6 +50,28 @@ def decay_amount(
     return min(raw, headroom)
 
 
+def recalibration_eligible(
+    salience: float,
+    floor: float,
+    *,
+    misleading_count: int,
+    ignored_count: int,
+    cited_count: int,
+) -> bool:
+    """Whether the one-time floor backfill should lift *salience* to *floor*.
+
+    True iff the node is **strictly below** the floor and carries no explicit
+    negative-feedback signal: a node penalised as misleading, or chronically ignored
+    (ignored more than five times and more than it was cited), keeps its deliberate
+    sub-floor value. This is the single source of truth for backfill eligibility —
+    mirrored by the SQL ``WHERE`` clause in
+    :meth:`lithos.lcma.stats.StatsStore.recalibrate_salience_floor` and reused by the
+    offline calibration harness so its projected distribution matches the operator run.
+    """
+    chronically_ignored = ignored_count > 5 and ignored_count > cited_count
+    return not (salience >= floor or misleading_count > 0 or chronically_ignored)
+
+
 def usage_score(
     retrieval_count: int,
     days_since_use: float | None,

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -799,7 +800,9 @@ class StatsStore(AsyncSqliteStore):
         Sets ``salience = floor`` for every node currently below it, **except** nodes
         carrying an explicit negative-feedback signal (``misleading_count > 0`` or the
         chronic-ignored condition) — their sub-floor salience is a deliberate penalty,
-        not decay damage, so the backfill must not erase it.
+        not decay damage, so the backfill must not erase it. Eligibility mirrors
+        :func:`lithos.lcma.salience.recalibration_eligible` (shared with the offline
+        calibration harness).
 
         Idempotent (a second run matches nothing) and conservative (rows already at or
         above the floor, and the meaningful-high tail, are untouched). Returns the count
@@ -807,7 +810,13 @@ class StatsStore(AsyncSqliteStore):
         *would* be lifted. This is a deliberate operator-run maintenance pass over the
         whole table (exposed as the ``recalibrate-salience`` CLI command), not a
         hot-path query.
+
+        Raises ``ValueError`` if *floor* is not a finite value in ``[0.0, 1.0]`` — a
+        write outside that range would break the salience invariant every other path
+        upholds.
         """
+        if not math.isfinite(floor) or not (0.0 <= floor <= 1.0):
+            raise ValueError(f"salience floor must be a finite value in [0.0, 1.0], got {floor!r}")
         async with self._session() as db:
             if dry_run:
                 row = await (
@@ -830,28 +839,34 @@ class StatsStore(AsyncSqliteStore):
             )
             return cursor.rowcount
 
-    async def salience_distribution(self) -> dict[str, float]:
+    async def salience_distribution(self, floor: float) -> dict[str, float]:
         """Return summary statistics of the salience distribution across all nodes.
 
         A single aggregate scan used by the daily sweep to emit distribution telemetry
         (so "the distribution recovered / has re-collapsed" is observable) and by the
         recalibration CLI to report before/after. Keys: ``count``, ``mean``,
-        ``fraction_le_030`` (share ≤ 0.30 — the collapse marker), ``p50``, ``p90``.
-        Returns zeros for an empty table.
+        ``fraction_below_floor`` (share **strictly** below *floor*), ``p50``, ``p90``.
+
+        ``fraction_below_floor`` is the collapse marker: it is high while decay has
+        driven nodes toward zero and **clears to ~0 after the backfill lifts them to
+        the floor** (nodes resting *at* the floor are healthy, not collapsed). Using the
+        configured floor rather than a fixed 0.30 threshold keeps the signal meaningful
+        under a custom floor. Returns zeros for an empty table.
         """
         async with self._session() as db:
             row = await (
                 await db.execute(
                     """SELECT COUNT(*) AS n,
                               COALESCE(AVG(salience), 0.0) AS mean,
-                              COALESCE(AVG(CASE WHEN salience <= 0.30 THEN 1.0 ELSE 0.0 END), 0.0)
-                                  AS frac_le_030
-                         FROM node_stats"""
+                              COALESCE(AVG(CASE WHEN salience < ? THEN 1.0 ELSE 0.0 END), 0.0)
+                                  AS frac_below
+                         FROM node_stats""",
+                    (floor,),
                 )
             ).fetchone()
             n = int(row[0]) if row else 0
             mean = float(row[1]) if row else 0.0
-            frac_le_030 = float(row[2]) if row else 0.0
+            frac_below = float(row[2]) if row else 0.0
             p50 = p90 = 0.0
             if n > 0:
                 p50 = await self._salience_percentile(db, n, 0.50)
@@ -859,15 +874,20 @@ class StatsStore(AsyncSqliteStore):
         return {
             "count": float(n),
             "mean": mean,
-            "fraction_le_030": frac_le_030,
+            "fraction_below_floor": frac_below,
             "p50": p50,
             "p90": p90,
         }
 
     @staticmethod
     async def _salience_percentile(db: aiosqlite.Connection, n: int, q: float) -> float:
-        """Return the *q* quantile of salience via an OFFSET scan (n already known)."""
-        offset = min(n - 1, max(0, int(q * n)))
+        """Return the *q* quantile of salience via an OFFSET scan (n already known).
+
+        Nearest-rank definition: the value at 1-based rank ``ceil(q*n)`` (clamped to
+        ``[1, n]``), so ``q=0.5`` on ``n=2`` picks the lower of the two and ``q=0.9`` on
+        ``n=100`` picks the 90th value, not the 91st.
+        """
+        offset = min(n, max(1, math.ceil(q * n))) - 1
         row = await (
             await db.execute(
                 "SELECT salience FROM node_stats ORDER BY salience LIMIT 1 OFFSET ?",

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -133,7 +133,7 @@ def _generate_receipt_id() -> str:
     return f"rcpt_{uuid.uuid4().hex[:12]}"
 
 
-def _extract_final_node_ids(final_nodes_json: object) -> list[str]:
+def extract_final_node_ids(final_nodes_json: object) -> list[str]:
     """Parse the ``final_nodes`` JSON column and collect ``id`` fields."""
     if not isinstance(final_nodes_json, str):
         return []
@@ -1071,7 +1071,7 @@ class StatsStore(AsyncSqliteStore):
         result = dict(row)
         if result.get("task_id") != task_id:
             return None
-        result["final_node_ids"] = _extract_final_node_ids(result.get("final_nodes", "[]"))
+        result["final_node_ids"] = extract_final_node_ids(result.get("final_nodes", "[]"))
         return result
 
     async def get_latest_receipt(self, task_id: str, agent_id: str) -> dict[str, object] | None:
@@ -1091,7 +1091,7 @@ class StatsStore(AsyncSqliteStore):
         if row is None:
             return None
         result = dict(row)
-        result["final_node_ids"] = _extract_final_node_ids(result.get("final_nodes", "[]"))
+        result["final_node_ids"] = extract_final_node_ids(result.get("final_nodes", "[]"))
         return result
 
     # ------------------------------------------------------------------

--- a/src/lithos/lcma/stats.py
+++ b/src/lithos/lcma/stats.py
@@ -793,6 +793,89 @@ class StatsStore(AsyncSqliteStore):
             extra={"node_id": node_id, "delta": delta},
         )
 
+    async def recalibrate_salience_floor(self, floor: float, *, dry_run: bool = False) -> int:
+        """One-time backfill: lift decay-collapsed rows up to *floor*.
+
+        Sets ``salience = floor`` for every node currently below it, **except** nodes
+        carrying an explicit negative-feedback signal (``misleading_count > 0`` or the
+        chronic-ignored condition) — their sub-floor salience is a deliberate penalty,
+        not decay damage, so the backfill must not erase it.
+
+        Idempotent (a second run matches nothing) and conservative (rows already at or
+        above the floor, and the meaningful-high tail, are untouched). Returns the count
+        of rows lifted. With ``dry_run`` it writes nothing and returns how many rows
+        *would* be lifted. This is a deliberate operator-run maintenance pass over the
+        whole table (exposed as the ``recalibrate-salience`` CLI command), not a
+        hot-path query.
+        """
+        async with self._session() as db:
+            if dry_run:
+                row = await (
+                    await db.execute(
+                        """SELECT COUNT(*) FROM node_stats
+                            WHERE salience < ?
+                              AND misleading_count = 0
+                              AND NOT (ignored_count > 5 AND ignored_count > cited_count)""",
+                        (floor,),
+                    )
+                ).fetchone()
+                return int(row[0]) if row else 0
+            cursor = await db.execute(
+                """UPDATE node_stats
+                      SET salience = ?
+                    WHERE salience < ?
+                      AND misleading_count = 0
+                      AND NOT (ignored_count > 5 AND ignored_count > cited_count)""",
+                (floor, floor),
+            )
+            return cursor.rowcount
+
+    async def salience_distribution(self) -> dict[str, float]:
+        """Return summary statistics of the salience distribution across all nodes.
+
+        A single aggregate scan used by the daily sweep to emit distribution telemetry
+        (so "the distribution recovered / has re-collapsed" is observable) and by the
+        recalibration CLI to report before/after. Keys: ``count``, ``mean``,
+        ``fraction_le_030`` (share ≤ 0.30 — the collapse marker), ``p50``, ``p90``.
+        Returns zeros for an empty table.
+        """
+        async with self._session() as db:
+            row = await (
+                await db.execute(
+                    """SELECT COUNT(*) AS n,
+                              COALESCE(AVG(salience), 0.0) AS mean,
+                              COALESCE(AVG(CASE WHEN salience <= 0.30 THEN 1.0 ELSE 0.0 END), 0.0)
+                                  AS frac_le_030
+                         FROM node_stats"""
+                )
+            ).fetchone()
+            n = int(row[0]) if row else 0
+            mean = float(row[1]) if row else 0.0
+            frac_le_030 = float(row[2]) if row else 0.0
+            p50 = p90 = 0.0
+            if n > 0:
+                p50 = await self._salience_percentile(db, n, 0.50)
+                p90 = await self._salience_percentile(db, n, 0.90)
+        return {
+            "count": float(n),
+            "mean": mean,
+            "fraction_le_030": frac_le_030,
+            "p50": p50,
+            "p90": p90,
+        }
+
+    @staticmethod
+    async def _salience_percentile(db: aiosqlite.Connection, n: int, q: float) -> float:
+        """Return the *q* quantile of salience via an OFFSET scan (n already known)."""
+        offset = min(n - 1, max(0, int(q * n)))
+        row = await (
+            await db.execute(
+                "SELECT salience FROM node_stats ORDER BY salience LIMIT 1 OFFSET ?",
+                (offset,),
+            )
+        ).fetchone()
+        return float(row[0]) if row else 0.0
+
     async def increment_ignored(self, node_id: str) -> None:
         """Atomically increment ignored_count; creates row if absent."""
         async with self._session() as db:

--- a/src/lithos/telemetry.py
+++ b/src/lithos/telemetry.py
@@ -652,7 +652,7 @@ class _LithosMetrics:
         self._lcma_scout_failures: Any = None
         self._lcma_salience_updates: Any = None
         self._lcma_salience_mean: Any = None
-        self._lcma_salience_fraction_floored: Any = None
+        self._lcma_salience_fraction_below_floor: Any = None
         self._lcma_salience_node_count: Any = None
 
     @property
@@ -985,7 +985,7 @@ class _LithosMetrics:
     def lcma_salience_mean(self) -> Any:
         """Gauge: mean node salience, snapshotted by the daily enrich sweep.
 
-        Together with :attr:`lcma_salience_fraction_floored` this makes salience
+        Together with :attr:`lcma_salience_fraction_below_floor` this makes salience
         health observable so a re-collapse (the bug behind task e7d8ef60) can be
         alerted on rather than re-discovered by a manual audit.
         """
@@ -997,14 +997,20 @@ class _LithosMetrics:
         return self._lcma_salience_mean
 
     @property
-    def lcma_salience_fraction_floored(self) -> Any:
-        """Gauge: share of nodes with salience ≤ 0.30 (the collapse marker)."""
-        if self._lcma_salience_fraction_floored is None:
-            self._lcma_salience_fraction_floored = get_meter().create_gauge(
-                "lithos.lcma.salience.fraction_floored",
-                description="Fraction of nodes with salience <= 0.30 (daily snapshot)",
+    def lcma_salience_fraction_below_floor(self) -> Any:
+        """Gauge: share of nodes **strictly below** the configured salience floor.
+
+        This is the collapse marker: high while decay drives nodes toward zero, and it
+        clears to ~0 once the backfill lifts them to the floor — nodes resting *at* the
+        floor are healthy. (A fixed ≤ 0.30 threshold could not tell recovery from
+        collapse, since the backfill parks values at the floor.)
+        """
+        if self._lcma_salience_fraction_below_floor is None:
+            self._lcma_salience_fraction_below_floor = get_meter().create_gauge(
+                "lithos.lcma.salience.fraction_below_floor",
+                description="Fraction of nodes with salience below the configured floor",
             )
-        return self._lcma_salience_fraction_floored
+        return self._lcma_salience_fraction_below_floor
 
     @property
     def lcma_salience_node_count(self) -> Any:

--- a/src/lithos/telemetry.py
+++ b/src/lithos/telemetry.py
@@ -104,6 +104,13 @@ class _NoOpHistogram:
         pass
 
 
+class _NoOpGauge:
+    """No-op synchronous gauge instrument."""
+
+    def set(self, amount: int | float, attributes: dict[str, Any] | None = None) -> None:
+        pass
+
+
 class _NoOpMeter:
     """No-op meter that returns no-op instruments."""
 
@@ -112,6 +119,9 @@ class _NoOpMeter:
 
     def create_histogram(self, name: str, **kwargs: Any) -> _NoOpHistogram:
         return _NoOpHistogram()
+
+    def create_gauge(self, name: str, **kwargs: Any) -> _NoOpGauge:
+        return _NoOpGauge()
 
     def create_up_down_counter(self, name: str, **kwargs: Any) -> _NoOpCounter:
         return _NoOpCounter()
@@ -641,6 +651,9 @@ class _LithosMetrics:
         self._lcma_scout_candidates: Any = None
         self._lcma_scout_failures: Any = None
         self._lcma_salience_updates: Any = None
+        self._lcma_salience_mean: Any = None
+        self._lcma_salience_fraction_floored: Any = None
+        self._lcma_salience_node_count: Any = None
 
     @property
     def knowledge_ops(self) -> Any:
@@ -967,6 +980,41 @@ class _LithosMetrics:
                 description="Total update_salience calls",
             )
         return self._lcma_salience_updates
+
+    @property
+    def lcma_salience_mean(self) -> Any:
+        """Gauge: mean node salience, snapshotted by the daily enrich sweep.
+
+        Together with :attr:`lcma_salience_fraction_floored` this makes salience
+        health observable so a re-collapse (the bug behind task e7d8ef60) can be
+        alerted on rather than re-discovered by a manual audit.
+        """
+        if self._lcma_salience_mean is None:
+            self._lcma_salience_mean = get_meter().create_gauge(
+                "lithos.lcma.salience.mean",
+                description="Mean node_stats salience across the corpus (daily snapshot)",
+            )
+        return self._lcma_salience_mean
+
+    @property
+    def lcma_salience_fraction_floored(self) -> Any:
+        """Gauge: share of nodes with salience ≤ 0.30 (the collapse marker)."""
+        if self._lcma_salience_fraction_floored is None:
+            self._lcma_salience_fraction_floored = get_meter().create_gauge(
+                "lithos.lcma.salience.fraction_floored",
+                description="Fraction of nodes with salience <= 0.30 (daily snapshot)",
+            )
+        return self._lcma_salience_fraction_floored
+
+    @property
+    def lcma_salience_node_count(self) -> Any:
+        """Gauge: number of nodes with a stats row (daily snapshot)."""
+        if self._lcma_salience_node_count is None:
+            self._lcma_salience_node_count = get_meter().create_gauge(
+                "lithos.lcma.salience.node_count",
+                description="Number of node_stats rows (daily snapshot)",
+            )
+        return self._lcma_salience_node_count
 
 
 def register_active_claims_observer(get_active_claim_count: Callable[[], int]) -> None:

--- a/tests/test_calibrate_salience.py
+++ b/tests/test_calibrate_salience.py
@@ -1,15 +1,19 @@
-"""Smoke tests for the offline salience calibration harness (scripts/calibrate_salience.py).
+"""Smoke + validity tests for the offline salience calibration harness.
 
-Seeds a small stats.db and exercises the harness end-to-end on it, so the reusable
-tooling stays correct even though its real runs are against prod/staging copies.
+Seeds a small stats.db and exercises the harness on it, and — because the harness's
+whole job is to project the operator backfill and rank usage configs — proves that its
+floor projection matches the real store predicate and that its ranking metric can
+actually tell differently-tuned configs apart.
 """
 
 from __future__ import annotations
 
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from lithos.config import LithosConfig
+from lithos.lcma.salience import recalibration_eligible
 from lithos.lcma.stats import StatsStore
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
@@ -25,12 +29,10 @@ def test_auc_separates_cleanly() -> None:
 
 
 def test_auc_handles_ties() -> None:
-    # All equal -> every pair is a tie -> 0.5.
     assert cs.auc([0.5, 0.5], [0.5, 0.5]) == 0.5
 
 
 async def _seed(store: StatsStore) -> None:
-    # A "hot" node: many retrievals + a citation. A "cold" node: nothing.
     for _ in range(15):
         await store.increment_node_stats(node_id="hot")
     await store.increment_cited("hot")
@@ -52,22 +54,92 @@ async def test_load_and_evaluate(test_config: LithosConfig) -> None:
     assert hot.cited_count == 1
     assert hot.days_since_use is not None
 
-    # Floor backfill report lifts the collapsed mass.
     floor_lines = cs.floor_report(nodes, [0.3])
     assert any("0.30" in line for line in floor_lines)
 
-    # Usage evaluation ranks configs and produces bounded scores.
-    results = cs.evaluate_usage(nodes, cs.build_configs())
+    results = cs.evaluate_usage(nodes, cs.build_configs(), None)
     assert results
+    # Sparse feedback + no receipts -> honest "none" (descriptive-only) ranking.
+    assert results[0].ranked_by == "none"
     for r in results:
         assert 0.0 <= r.mean <= 1.0
-        assert 0.0 <= r.ranking_auc <= 1.0
-    # The hot node (retrievals + citation) should out-score the cold node under
-    # the top-ranked config — the whole point of the usage signal.
-    top = results[0].config
-    scored = cs._score_all(nodes, top)
-    by_count = {n.retrieval_count: s for n, s in zip(nodes, scored, strict=True)}
-    assert by_count[15] > by_count[0]
+        assert r.ranking_auc is None
+
+
+async def test_floor_projection_matches_store_backfill(test_config: LithosConfig) -> None:
+    """The harness's floor projection must lift exactly the rows the store lifts."""
+    floor = 0.3
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        await store.update_salience("collapsed", -0.45)  # 0.05 -> eligible
+        await store.update_salience("misleading", -0.45)
+        await store.increment_misleading("misleading")  # protected
+        await store.update_salience("chronic", -0.45)
+        for _ in range(6):
+            await store.increment_ignored("chronic")  # ignored 6 > 5, > cited 0 -> protected
+        await store.update_salience("light", -0.45)
+        for _ in range(2):
+            await store.increment_ignored("light")  # not chronic -> eligible
+        await store.update_salience("high", 0.4)  # 0.9 -> above floor, untouched
+
+        pre = {n.node_id: n for n in cs.load_nodes(str(store.db_path))}
+        expected_lift = {
+            nid
+            for nid, n in pre.items()
+            if recalibration_eligible(
+                n.salience,
+                floor,
+                misleading_count=n.misleading_count,
+                ignored_count=n.ignored_count,
+                cited_count=n.cited_count,
+            )
+        }
+        assert expected_lift == {"collapsed", "light"}
+
+        lifted = await store.recalibrate_salience_floor(floor)
+        assert lifted == len(expected_lift)
+
+        actually_lifted = {
+            nid
+            for nid in pre
+            if (row := await store.get_node_stats(nid)) is not None
+            and abs(float(row["salience"]) - floor) < 1e-9
+            and pre[nid].salience < floor
+        }
+        assert actually_lifted == expected_lift
+    finally:
+        await store.close()
+
+
+def test_future_auc_distinguishes_recency_configs() -> None:
+    """The ranking metric must reward a better-tuned config, not treat all as equal.
+
+    Future retrievals here are exactly the recently-used nodes; frequency is identical
+    across nodes, so only a recency-aware config can separate them.
+    """
+    split_time = datetime(2026, 1, 20, tzinfo=UTC)
+    recent = {f"r{i}": 3 for i in range(20)}
+    stale = {f"s{i}": 3 for i in range(20)}
+    past_count = {**recent, **stale}
+    past_last = {
+        **{k: split_time for k in recent},
+        **{k: split_time - timedelta(days=90) for k in stale},
+    }
+    split = cs.TimeSplit(split_time, past_count, past_last, frozenset(recent))
+    nodes = [cs.NodeRow("x", 0.5, 0, 0, 0, 0, None)]  # no citations -> future label used
+
+    recency_heavy = cs.UsageConfig(0.0, 1.0, 7.0, 20.0)
+    freq_only = cs.UsageConfig(1.0, 0.0, 7.0, 20.0)
+    results = cs.evaluate_usage(nodes, [recency_heavy, freq_only], split)
+
+    assert results[0].ranked_by == "future"
+    by_cfg = {r.config: r for r in results}
+    # Recency-aware config perfectly separates; the frequency-only config cannot.
+    assert by_cfg[recency_heavy].future_auc == 1.0
+    assert by_cfg[freq_only].future_auc == 0.5
+    # And the informative one ranks first.
+    assert results[0].config == recency_heavy
 
 
 async def test_main_runs(test_config: LithosConfig, capsys) -> None:

--- a/tests/test_calibrate_salience.py
+++ b/tests/test_calibrate_salience.py
@@ -1,0 +1,86 @@
+"""Smoke tests for the offline salience calibration harness (scripts/calibrate_salience.py).
+
+Seeds a small stats.db and exercises the harness end-to-end on it, so the reusable
+tooling stays correct even though its real runs are against prod/staging copies.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from lithos.config import LithosConfig
+from lithos.lcma.stats import StatsStore
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import calibrate_salience as cs
+
+
+def test_auc_separates_cleanly() -> None:
+    assert cs.auc([1.0, 1.0, 1.0], [0.0, 0.0, 0.0]) == 1.0
+    assert cs.auc([0.0], [1.0]) == 0.0
+    assert cs.auc([1.0, 0.0], [0.0, 1.0]) == 0.5  # interleaved -> uninformative
+    assert cs.auc([], [1.0]) == 0.5  # empty group -> uninformative
+
+
+def test_auc_handles_ties() -> None:
+    # All equal -> every pair is a tie -> 0.5.
+    assert cs.auc([0.5, 0.5], [0.5, 0.5]) == 0.5
+
+
+async def _seed(store: StatsStore) -> None:
+    # A "hot" node: many retrievals + a citation. A "cold" node: nothing.
+    for _ in range(15):
+        await store.increment_node_stats(node_id="hot")
+    await store.increment_cited("hot")
+    await store.update_salience("cold", -0.45)  # 0.05, collapsed
+    await store.increment_node_stats(node_id="warm")  # one retrieval
+
+
+async def test_load_and_evaluate(test_config: LithosConfig) -> None:
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        await _seed(store)
+    finally:
+        await store.close()
+
+    nodes = cs.load_nodes(str(store.db_path))
+    assert len(nodes) == 3
+    hot = next(n for n in nodes if n.retrieval_count == 15)
+    assert hot.cited_count == 1
+    assert hot.days_since_use is not None
+
+    # Floor backfill report lifts the collapsed mass.
+    floor_lines = cs.floor_report(nodes, [0.3])
+    assert any("0.30" in line for line in floor_lines)
+
+    # Usage evaluation ranks configs and produces bounded scores.
+    results = cs.evaluate_usage(nodes, cs.build_configs())
+    assert results
+    for r in results:
+        assert 0.0 <= r.mean <= 1.0
+        assert 0.0 <= r.ranking_auc <= 1.0
+    # The hot node (retrievals + citation) should out-score the cold node under
+    # the top-ranked config — the whole point of the usage signal.
+    top = results[0].config
+    scored = cs._score_all(nodes, top)
+    by_count = {n.retrieval_count: s for n, s in zip(nodes, scored, strict=True)}
+    assert by_count[15] > by_count[0]
+
+
+async def test_main_runs(test_config: LithosConfig, capsys) -> None:
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        await _seed(store)
+    finally:
+        await store.close()
+
+    rc = cs.main([str(store.db_path), "--top", "3"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Loaded 3 nodes" in out
+    assert "Floor backfill" in out
+    assert "Usage signal" in out

--- a/tests/test_calibrate_salience.py
+++ b/tests/test_calibrate_salience.py
@@ -172,6 +172,47 @@ def test_build_time_split_is_position_based() -> None:
     assert cs.build_time_split(receipts[:1], 0.5) is None
 
 
+async def test_time_split_deterministic_for_equal_timestamps(test_config: LithosConfig) -> None:
+    """Receipts sharing a second-resolution ts must split by rowid (insertion) order.
+
+    Guards the (ts, rowid) ordering contract: without the rowid tie-break the past/future
+    partition of same-timestamp receipts would be nondeterministic.
+    """
+    import aiosqlite
+
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        for rid, node in (("r_a", "a"), ("r_b", "b")):  # 'a' inserted before 'b'
+            await store.insert_receipt(
+                receipt_id=rid,
+                query="q",
+                limit=10,
+                namespace_filter=None,
+                scouts_fired=["scout_vector"],
+                candidates_considered=1,
+                final_nodes=[{"id": node, "reasons": [], "scouts": ["scout_vector"]}],
+                conflicts_surfaced=[],
+                surface_conflicts=False,
+                temperature=0.5,
+                terrace_reached=1,
+            )
+        # Force identical timestamps so only rowid order can disambiguate the split.
+        async with aiosqlite.connect(store.db_path) as db:
+            await db.execute("UPDATE receipts SET ts = ?", ("2026-01-01T00:00:00+00:00",))
+            await db.commit()
+    finally:
+        await store.close()
+
+    receipts = cs.load_receipts(str(store.db_path))
+    assert len(receipts) == 2
+    split = cs.build_time_split(receipts, 0.5)
+    assert split is not None
+    # Earlier rowid ('a') -> past; later rowid ('b') -> held-out future. Deterministic.
+    assert set(split.past_count) == {"a"}
+    assert split.future_nodes == frozenset({"b"})
+
+
 def test_future_auc_distinguishes_recency_configs() -> None:
     """The ranking metric must reward a better-tuned config, not treat all as equal.
 

--- a/tests/test_calibrate_salience.py
+++ b/tests/test_calibrate_salience.py
@@ -32,6 +32,15 @@ def test_auc_handles_ties() -> None:
     assert cs.auc([0.5, 0.5], [0.5, 0.5]) == 0.5
 
 
+def test_parse_ts_handles_z_and_garbage() -> None:
+    parsed = cs._parse_ts("2026-01-01T00:00:00Z")
+    assert parsed is not None
+    assert parsed.tzinfo is not None  # Z normalised to +00:00
+    assert cs._parse_ts("2026-01-01 00:00:00") is not None  # sqlite CURRENT_TIMESTAMP shape
+    assert cs._parse_ts("not-a-timestamp") is None  # unparseable -> dropped, not raised
+    assert cs._parse_ts(None) is None
+
+
 async def _seed(store: StatsStore) -> None:
     for _ in range(15):
         await store.increment_node_stats(node_id="hot")
@@ -110,6 +119,57 @@ async def test_floor_projection_matches_store_backfill(test_config: LithosConfig
         assert actually_lifted == expected_lift
     finally:
         await store.close()
+
+
+async def test_load_receipts_parses_production_shape(test_config: LithosConfig) -> None:
+    """final_nodes is a list of objects; the harness must key on `id`, not the whole dict.
+
+    Two receipts for the same node with different reasons/scouts must aggregate under one
+    node id rather than fragmenting into two pseudo-identifiers.
+    """
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        for i, reason in enumerate(("q1", "q2")):
+            await store.insert_receipt(
+                receipt_id=f"rcpt_{i}",
+                query=reason,
+                limit=10,
+                namespace_filter=None,
+                scouts_fired=["scout_vector"],
+                candidates_considered=1,
+                final_nodes=[{"id": "node-1", "reasons": [reason], "scouts": ["scout_vector"]}],
+                conflicts_surfaced=[],
+                surface_conflicts=False,
+                temperature=0.5,
+                terrace_reached=1,
+            )
+    finally:
+        await store.close()
+
+    receipts = cs.load_receipts(str(store.db_path))
+    assert len(receipts) == 2
+    for _ts, node_ids in receipts:
+        assert node_ids == ["node-1"]  # id extracted, not str(dict)
+
+    split = cs.build_time_split(receipts, 0.5)
+    assert split is not None
+    # Both objects collapse to the single node id across the past/future boundary.
+    assert set(split.past_count) | set(split.future_nodes) == {"node-1"}
+
+
+def test_build_time_split_is_position_based() -> None:
+    """A 0.7 split of 10 receipts puts exactly 7 in the past, not 8 (no boundary leak)."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    receipts = [(base + timedelta(days=i), [f"n{i}"]) for i in range(10)]
+    split = cs.build_time_split(receipts, 0.7)
+    assert split is not None
+    assert len(split.past_count) == 7  # n0..n6
+    assert split.future_nodes == frozenset(f"n{i}" for i in range(7, 10))
+    # Degenerate splits fall back to None (descriptive-only).
+    assert cs.build_time_split(receipts, 0.0) is None
+    assert cs.build_time_split(receipts, 1.0) is None
+    assert cs.build_time_split(receipts[:1], 0.5) is None
 
 
 def test_future_auc_distinguishes_recency_configs() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,12 @@
 
 import asyncio
 
+import pytest
 from click.testing import CliRunner
 
 from lithos.cli import cli
 from lithos.knowledge import KnowledgeManager
+from lithos.lcma.stats import StatsStore
 
 
 def test_inspect_doc_shows_created_and_updated_timestamps(test_config):
@@ -164,3 +166,67 @@ class TestExtractEntitiesCommand:
         assert meta.entities == []
         assert meta.entities_extractor is None
         assert meta.version == version_before
+
+
+class TestRecalibrateSalienceCommand:
+    """`lithos recalibrate-salience` — one-time backfill of collapsed salience (e7d8ef60)."""
+
+    def _seed(self, test_config):
+        async def _s():
+            store = StatsStore(test_config)
+            await store.open()
+            try:
+                await store.update_salience("cold", -0.45)  # 0.05, below floor
+                await store.update_salience("hot", 0.4)  # 0.9, untouched
+            finally:
+                await store.close()
+
+        asyncio.run(_s())
+
+    def _salience(self, test_config, node_id):
+        async def _r():
+            store = StatsStore(test_config)
+            await store.open()
+            try:
+                row = await store.get_node_stats(node_id)
+                return row["salience"] if row else None
+            finally:
+                await store.close()
+
+        return asyncio.run(_r())
+
+    def test_dry_run_reports_without_writing(self, test_config):
+        self._seed(test_config)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(test_config.storage.data_dir),
+                "recalibrate-salience",
+                "--floor",
+                "0.3",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "would lift 1" in result.output
+        assert self._salience(test_config, "cold") == pytest.approx(0.05)
+
+    def test_lifts_collapsed_rows(self, test_config):
+        self._seed(test_config)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(test_config.storage.data_dir),
+                "recalibrate-salience",
+                "--floor",
+                "0.3",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Lifted 1 rows" in result.output
+        assert self._salience(test_config, "cold") == pytest.approx(0.3)
+        assert self._salience(test_config, "hot") == pytest.approx(0.9)

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -859,6 +859,21 @@ class TestReinforceCited:
         # Default salience 0.5 + 0.02
         assert stats.salience == pytest.approx(0.52)
 
+    async def test_cited_boost_is_config_driven(
+        self,
+        memory_with_knowledge: CognitiveMemory,
+        knowledge_manager: KnowledgeManager,
+    ) -> None:
+        """The citation boost reads lcma.salience_cited_boost, not a hardcoded 0.02."""
+        nid = await _create_note(knowledge_manager, "Note B2")
+        memory_with_knowledge._config.lcma.salience_cited_boost = 0.1
+
+        await memory_with_knowledge.reinforce_cited([nid])
+
+        stats = await memory_with_knowledge.node_stats(nid)
+        assert isinstance(stats, NodeStats)
+        assert stats.salience == pytest.approx(0.6)  # 0.5 + custom 0.1, not 0.02
+
     async def test_bumps_spaced_rep_strength_by_0_05(
         self,
         memory_with_knowledge: CognitiveMemory,

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -560,6 +560,84 @@ class TestSalienceDecay:
         # last_decay_applied_at should be set
         assert stats_after["last_decay_applied_at"] is not None
 
+    async def test_decay_stops_at_floor(
+        self,
+        worker: EnrichWorker,
+        stats_store: StatsStore,
+    ) -> None:
+        """Time decay erodes toward the non-zero floor, never below it (task e7d8ef60)."""
+        import aiosqlite
+
+        node_id = "decay-floor-1"
+        await stats_store.increment_node_stats(node_id=node_id)  # salience 0.5
+        await stats_store.update_salience(node_id, -0.18)  # 0.32, just above floor
+        long_ago = (datetime.now(UTC) - timedelta(days=100)).isoformat()
+        async with aiosqlite.connect(stats_store.db_path) as db:
+            await db.execute(
+                "UPDATE node_stats SET last_used_at = ? WHERE node_id = ?",
+                (long_ago, node_id),
+            )
+            await db.commit()
+
+        await worker._enrich_node(node_id, [NOTE_UPDATED])
+
+        stats_after = await stats_store.get_node_stats(node_id)
+        assert stats_after is not None
+        # Only the 0.02 of headroom above the floor can decay away, despite 100 idle days.
+        assert stats_after["salience"] == pytest.approx(worker._config.salience_floor)
+
+    async def test_decay_leaves_below_floor_node_untouched(
+        self,
+        worker: EnrichWorker,
+        stats_store: StatsStore,
+    ) -> None:
+        """A node already below the floor (explicit feedback) is not touched by decay."""
+        import aiosqlite
+
+        node_id = "decay-floor-2"
+        await stats_store.increment_node_stats(node_id=node_id)
+        await stats_store.update_salience(node_id, -0.45)  # 0.05, below floor
+        long_ago = (datetime.now(UTC) - timedelta(days=100)).isoformat()
+        async with aiosqlite.connect(stats_store.db_path) as db:
+            await db.execute(
+                "UPDATE node_stats SET last_used_at = ? WHERE node_id = ?",
+                (long_ago, node_id),
+            )
+            await db.commit()
+
+        await worker._enrich_node(node_id, [NOTE_UPDATED])
+
+        stats_after = await stats_store.get_node_stats(node_id)
+        assert stats_after is not None
+        assert stats_after["salience"] == pytest.approx(0.05)
+
+    async def test_emit_salience_distribution_sets_gauges(
+        self,
+        worker: EnrichWorker,
+        stats_store: StatsStore,
+        monkeypatch,
+    ) -> None:
+        """The sweep snapshots the salience distribution into the OTEL gauges."""
+        from unittest.mock import MagicMock
+
+        import lithos.lcma.enrich as enrich_mod
+
+        await stats_store.update_salience("a", -0.4)  # 0.1 (floored bucket)
+        await stats_store.update_salience("b", 0.4)  # 0.9
+
+        metrics = MagicMock()
+        monkeypatch.setattr(enrich_mod, "_HAS_TELEMETRY", True)
+        monkeypatch.setattr(enrich_mod, "_lithos_metrics", metrics)
+
+        await worker._emit_salience_distribution()
+
+        metrics.lcma_salience_node_count.set.assert_called_once_with(2.0)
+        metrics.lcma_salience_mean.set.assert_called_once()
+        metrics.lcma_salience_fraction_floored.set.assert_called_once()
+        # Half the nodes are <= 0.30.
+        (floored_arg,) = metrics.lcma_salience_fraction_floored.set.call_args.args
+        assert floored_arg == pytest.approx(0.5)
+
     async def test_no_decay_within_inactive_days(
         self,
         worker: EnrichWorker,

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -618,11 +618,14 @@ class TestSalienceDecay:
         monkeypatch,
     ) -> None:
         """The sweep snapshots the salience distribution into the OTEL gauges."""
+        import sys
         from unittest.mock import MagicMock
 
-        import lithos.lcma.enrich as enrich_mod
+        # Resolve the already-imported module via sys.modules to avoid a second,
+        # mixed-style import of lithos.lcma.enrich in this file.
+        enrich_mod = sys.modules[EnrichWorker.__module__]
 
-        await stats_store.update_salience("a", -0.4)  # 0.1 (floored bucket)
+        await stats_store.update_salience("a", -0.4)  # 0.1 (below the 0.3 floor)
         await stats_store.update_salience("b", 0.4)  # 0.9
 
         metrics = MagicMock()
@@ -633,10 +636,45 @@ class TestSalienceDecay:
 
         metrics.lcma_salience_node_count.set.assert_called_once_with(2.0)
         metrics.lcma_salience_mean.set.assert_called_once()
-        metrics.lcma_salience_fraction_floored.set.assert_called_once()
-        # Half the nodes are <= 0.30.
-        (floored_arg,) = metrics.lcma_salience_fraction_floored.set.call_args.args
-        assert floored_arg == pytest.approx(0.5)
+        metrics.lcma_salience_fraction_below_floor.set.assert_called_once()
+        # One of two nodes (0.1) is strictly below the 0.3 floor.
+        (below_arg,) = metrics.lcma_salience_fraction_below_floor.set.call_args.args
+        assert below_arg == pytest.approx(0.5)
+
+    async def test_decay_floor_and_rate_are_config_driven(
+        self,
+        worker: EnrichWorker,
+        stats_store: StatsStore,
+        monkeypatch,
+    ) -> None:
+        """Decay reads floor / per_day / cap from config, not hardcoded constants."""
+        import aiosqlite
+
+        # Non-default floor (0.45) and rate (0.05/day, cap 0.5): endpoints must reflect them.
+        monkeypatch.setattr(
+            worker,
+            "_config",
+            LcmaConfig(
+                salience_floor=0.45,
+                salience_decay_per_day=0.05,
+                salience_decay_daily_cap=0.5,
+            ),
+        )
+        node_id = "decay-config"
+        await stats_store.increment_node_stats(node_id=node_id)  # 0.5
+        long_ago = (datetime.now(UTC) - timedelta(days=100)).isoformat()
+        async with aiosqlite.connect(stats_store.db_path) as db:
+            await db.execute(
+                "UPDATE node_stats SET last_used_at = ? WHERE node_id = ?", (long_ago, node_id)
+            )
+            await db.commit()
+
+        await worker._enrich_node(node_id, [NOTE_UPDATED])
+
+        stats_after = await stats_store.get_node_stats(node_id)
+        assert stats_after is not None
+        # 100*0.05=5 capped at 0.5, headroom 0.5-0.45=0.05 -> stops at the custom floor.
+        assert stats_after["salience"] == pytest.approx(0.45)
 
     async def test_no_decay_within_inactive_days(
         self,

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -522,6 +522,48 @@ class TestUsageSignalAffectsRetrieval:
         assert usage1 == pytest.approx(0.0)
 
 
+class TestConfigWiring:
+    """Newly-exposed LcmaConfig fields must actually change behaviour, not be ignored."""
+
+    def test_usage_from_stats_respects_recency_halflife(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from lithos.lcma.retrieve import _usage_from_stats
+
+        now = datetime(2026, 1, 20, tzinfo=UTC)
+        stats: dict[str, object] = {
+            "retrieval_count": 10,
+            "last_used_at": (now - timedelta(days=14)).isoformat(),
+        }
+        short_hl = LcmaConfig(usage_recency_halflife_days=1.0)
+        long_hl = LcmaConfig(usage_recency_halflife_days=1000.0)
+        # A longer half-life keeps a 14-day-old use fresher -> higher usage score.
+        assert _usage_from_stats(stats, now, long_hl) > _usage_from_stats(stats, now, short_hl)
+
+    def test_rerank_usage_weight_is_wired(self) -> None:
+        from lithos.lcma.retrieve import _rerank_fast
+        from lithos.lcma.utils import Candidate
+
+        class _StubKnowledge:
+            def get_cached_meta(self, node_id: str) -> None:
+                return None
+
+        cands = [
+            Candidate(node_id="a", score=0.5, reasons=[], scouts=["scout_vector"]),
+            Candidate(node_id="b", score=0.5, reasons=[], scouts=["scout_vector"]),
+        ]
+        salience = {"a": 0.5, "b": 0.5}
+        usage = {"a": 0.0, "b": 0.9}
+        stub = _StubKnowledge()
+
+        # Usage is the only differentiator: at weight 0.1, b (high usage) wins.
+        ranked = _rerank_fast(cands, LcmaConfig(rerank_usage_weight=0.1), stub, salience, usage)  # type: ignore[arg-type]
+        assert ranked[0].node_id == "b"
+        # At weight 0.0 the usage gap no longer moves anything; the tie is stable (a first).
+        tied = _rerank_fast(cands, LcmaConfig(rerank_usage_weight=0.0), stub, salience, usage)  # type: ignore[arg-type]
+        assert tied[0].node_id == "a"
+
+
 class TestRetrieveSnippetParity:
     """lithos_retrieve must produce snippets from the same string Tantivy
     indexes so title-only matches surface the matching term.

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -460,6 +460,68 @@ class TestStoredSalienceAffectsRetrieval:
         assert row["salience"] == pytest.approx(0.5, abs=1e-6)
 
 
+class TestUsageSignalAffectsRetrieval:
+    """The non-decaying usage signal (retrieval frequency/recency) feeds rerank.
+
+    Restores a spread even at equal/collapsed salience (task e7d8ef60).
+    """
+
+    @pytest.mark.asyncio
+    async def test_usage_breaks_ties_at_equal_salience(
+        self,
+        seeded_km: KnowledgeManager,
+        seeded_search: SearchEngine,
+        seeded_graph: KnowledgeGraph,
+        mock_coordination: AsyncMock,
+        edge_store: EdgeStore,
+        projection: ProvenanceProjection,
+        stats_store: StatsStore,
+    ) -> None:
+        """With identical salience and base scores, the node with a richer retrieval
+        history ranks higher and carries a higher emitted ``usage_score``."""
+        # Both nodes sit at the default salience 0.5; only _ID2 has usage history.
+        for _ in range(20):
+            await stats_store.increment_node_stats(node_id=_ID2)
+
+        from lithos.search import SearchResult
+
+        equal_results = [
+            SearchResult(
+                id=_ID1, score=0.5, title="Alpha Note", snippet="alpha", path="alpha-note.md"
+            ),
+            SearchResult(
+                id=_ID2, score=0.5, title="Beta Note", snippet="beta", path="beta-note.md"
+            ),
+        ]
+        with (
+            patch.object(seeded_search, "semantic_search", return_value=equal_results),
+            patch.object(seeded_search, "full_text_search", return_value=equal_results),
+        ):
+            result = await _run_retrieve_impl(
+                query="testing",
+                search=seeded_search,
+                knowledge=seeded_km,
+                graph=seeded_graph,
+                coordination=mock_coordination,
+                edge_store=edge_store,
+                projection=projection,
+                stats_store=stats_store,
+                lcma_config=LcmaConfig(),
+                limit=10,
+            )
+
+        result_ids = [r["id"] for r in result["results"]]
+        assert _ID1 in result_ids
+        assert _ID2 in result_ids
+        # _ID2's usage history lifts it above _ID1 despite equal salience + base score.
+        assert result_ids.index(_ID2) < result_ids.index(_ID1)
+
+        usage2 = next(r for r in result["results"] if r["id"] == _ID2)["usage_score"]
+        usage1 = next(r for r in result["results"] if r["id"] == _ID1)["usage_score"]
+        assert usage2 > usage1
+        assert usage1 == pytest.approx(0.0)
+
+
 class TestRetrieveSnippetParity:
     """lithos_retrieve must produce snippets from the same string Tantivy
     indexes so title-only matches surface the matching term.

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -540,6 +540,19 @@ class TestConfigWiring:
         # A longer half-life keeps a 14-day-old use fresher -> higher usage score.
         assert _usage_from_stats(stats, now, long_hl) > _usage_from_stats(stats, now, short_hl)
 
+        # A 'Z'-suffixed timestamp must parse (recent -> higher usage than long-ago),
+        # not silently drop the recency term.
+        cfg = LcmaConfig()
+        recent_z: dict[str, object] = {
+            "retrieval_count": 5,
+            "last_used_at": (now - timedelta(days=1)).isoformat().replace("+00:00", "Z"),
+        }
+        old_z: dict[str, object] = {
+            "retrieval_count": 5,
+            "last_used_at": (now - timedelta(days=400)).isoformat().replace("+00:00", "Z"),
+        }
+        assert _usage_from_stats(recent_z, now, cfg) > _usage_from_stats(old_z, now, cfg)
+
     def test_rerank_usage_weight_is_wired(self) -> None:
         from lithos.lcma.retrieve import _rerank_fast
         from lithos.lcma.utils import Candidate

--- a/tests/test_salience.py
+++ b/tests/test_salience.py
@@ -1,0 +1,90 @@
+"""Unit tests for the pure salience math (:mod:`lithos.lcma.salience`).
+
+These pin the two invariants the recalibration (task ``e7d8ef60``) depends on:
+decay erodes toward a non-zero floor rather than to zero, and the usage signal is a
+bounded, monotonic, non-decaying function of the live counters.
+"""
+
+import math
+
+import pytest
+
+from lithos.lcma.salience import DEFAULT_SALIENCE, decay_amount, usage_score
+
+# Representative decay params (mirror the LcmaConfig defaults).
+_DECAY = {"per_day": 0.005, "daily_cap": 0.1, "floor": 0.3}
+_USAGE = {
+    "freq_weight": 0.6,
+    "recency_weight": 0.4,
+    "recency_halflife_days": 14.0,
+    "freq_norm_k": 20.0,
+}
+
+
+class TestDecayAmount:
+    def test_linear_below_cap(self):
+        # 14 idle days * 0.005 = 0.07, below the 0.1 cap and within headroom.
+        assert decay_amount(0.5, 14, **_DECAY) == pytest.approx(0.07)
+
+    def test_capped_per_application(self):
+        # 100 idle days would be 0.5 linear, but the daily cap is 0.1 and headroom
+        # (0.5 - 0.3) is 0.2, so the cap binds.
+        assert decay_amount(0.5, 100, **_DECAY) == pytest.approx(0.1)
+
+    def test_never_decays_below_floor(self):
+        # A node just above the floor loses only the remaining headroom.
+        assert decay_amount(0.34, 100, **_DECAY) == pytest.approx(0.04)
+
+    def test_zero_at_floor(self):
+        assert decay_amount(0.3, 100, **_DECAY) == 0.0
+
+    def test_zero_below_floor(self):
+        # Already pushed below the floor by explicit feedback — decay adds nothing.
+        assert decay_amount(0.1, 100, **_DECAY) == 0.0
+
+    def test_headroom_binds_before_cap(self):
+        # 0.32 has only 0.02 of headroom; even a large idle count can't exceed it.
+        assert decay_amount(0.32, 50, **_DECAY) == pytest.approx(0.02)
+
+    def test_negative_days_clamped(self):
+        assert decay_amount(0.5, -3, **_DECAY) == 0.0
+
+
+class TestUsageScore:
+    def test_bounded_unit_interval(self):
+        for rc in (0, 1, 5, 50, 5000):
+            for d in (None, 0.0, 3.0, 100.0):
+                s = usage_score(rc, d, **_USAGE)
+                assert 0.0 <= s <= 1.0
+
+    def test_monotonic_in_retrieval_count(self):
+        prev = -1.0
+        for rc in (0, 1, 2, 5, 20, 100):
+            s = usage_score(rc, 0.0, **_USAGE)
+            assert s >= prev
+            prev = s
+
+    def test_decreasing_in_recency(self):
+        prev = 2.0
+        for d in (0.0, 7.0, 14.0, 28.0, 100.0):
+            s = usage_score(10, d, **_USAGE)
+            assert s <= prev
+            prev = s
+
+    def test_never_used_has_no_recency(self):
+        # None recency == same as an infinitely-old last use (recency term -> 0).
+        assert usage_score(10, None, **_USAGE) < usage_score(10, 0.0, **_USAGE)
+
+    def test_recency_halves_at_halflife(self):
+        # Pure recency contribution (zero frequency weight) halves at the half-life.
+        params = {**_USAGE, "freq_weight": 0.0, "recency_weight": 1.0}
+        at_zero = usage_score(0, 0.0, **params)
+        at_halflife = usage_score(0, 14.0, **params)
+        assert math.isclose(at_halflife, at_zero / 2, rel_tol=1e-9)
+
+    def test_zero_when_cold_and_unused(self):
+        assert usage_score(0, None, **_USAGE) == 0.0
+
+
+def test_default_salience_constant():
+    assert DEFAULT_SALIENCE == 0.5

--- a/tests/test_salience.py
+++ b/tests/test_salience.py
@@ -9,7 +9,12 @@ import math
 
 import pytest
 
-from lithos.lcma.salience import DEFAULT_SALIENCE, decay_amount, usage_score
+from lithos.lcma.salience import (
+    DEFAULT_SALIENCE,
+    decay_amount,
+    recalibration_eligible,
+    usage_score,
+)
 
 # Representative decay params (mirror the LcmaConfig defaults).
 _DECAY = {"per_day": 0.005, "daily_cap": 0.1, "floor": 0.3}
@@ -84,6 +89,36 @@ class TestUsageScore:
 
     def test_zero_when_cold_and_unused(self):
         assert usage_score(0, None, **_USAGE) == 0.0
+
+
+class TestRecalibrationEligible:
+    def test_below_floor_no_feedback_is_eligible(self):
+        assert recalibration_eligible(0.05, 0.3, misleading_count=0, ignored_count=0, cited_count=0)
+
+    def test_at_or_above_floor_not_eligible(self):
+        assert not recalibration_eligible(
+            0.3, 0.3, misleading_count=0, ignored_count=0, cited_count=0
+        )
+        assert not recalibration_eligible(
+            0.9, 0.3, misleading_count=0, ignored_count=0, cited_count=0
+        )
+
+    def test_misleading_is_protected(self):
+        assert not recalibration_eligible(
+            0.05, 0.3, misleading_count=1, ignored_count=0, cited_count=0
+        )
+
+    def test_chronic_ignored_is_protected(self):
+        assert not recalibration_eligible(
+            0.05, 0.3, misleading_count=0, ignored_count=6, cited_count=0
+        )
+
+    def test_light_ignore_is_eligible(self):
+        assert recalibration_eligible(0.05, 0.3, misleading_count=0, ignored_count=2, cited_count=0)
+
+    def test_ignored_but_more_cited_is_eligible(self):
+        # ignored 6 but cited 7 -> not chronic (ignored not > cited) -> still eligible.
+        assert recalibration_eligible(0.05, 0.3, misleading_count=0, ignored_count=6, cited_count=7)
 
 
 def test_default_salience_constant():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1234,19 +1234,47 @@ class TestSalienceDistribution:
     """Aggregate distribution stats used by the daily sweep gauge + recalibration CLI."""
 
     async def test_empty_table(self, stats_store: StatsStore) -> None:
-        dist = await stats_store.salience_distribution()
+        dist = await stats_store.salience_distribution(0.3)
         assert dist["count"] == 0.0
         assert dist["mean"] == 0.0
-        assert dist["fraction_le_030"] == 0.0
+        assert dist["fraction_below_floor"] == 0.0
 
     async def test_summarises_distribution(self, stats_store: StatsStore) -> None:
-        # Three nodes: 0.1, 0.3, 0.9  -> two of three are <= 0.30.
+        # Three nodes: 0.1, 0.3, 0.9. Strictly below floor 0.3 -> only 0.1.
         await stats_store.update_salience("a", -0.4)  # 0.1
-        await stats_store.update_salience("b", -0.2)  # 0.3
+        await stats_store.update_salience("b", -0.2)  # 0.3 (at floor, not below)
         await stats_store.update_salience("c", 0.4)  # 0.9
-        dist = await stats_store.salience_distribution()
+        dist = await stats_store.salience_distribution(0.3)
         assert dist["count"] == 3.0
         assert dist["mean"] == pytest.approx((0.1 + 0.3 + 0.9) / 3)
-        assert dist["fraction_le_030"] == pytest.approx(2 / 3)
-        assert 0.0 <= dist["p50"] <= 1.0
-        assert dist["p90"] >= dist["p50"]
+        assert dist["fraction_below_floor"] == pytest.approx(1 / 3)
+        # Nearest-rank percentiles over sorted [0.1, 0.3, 0.9].
+        assert dist["p50"] == pytest.approx(0.3)
+        assert dist["p90"] == pytest.approx(0.9)
+
+    async def test_fraction_below_floor_clears_after_backfill(
+        self, stats_store: StatsStore
+    ) -> None:
+        # The collapse marker must drop once the backfill lifts rows to the floor —
+        # a fixed <=0.30 threshold could not tell recovery from collapse.
+        for i in range(4):
+            await stats_store.update_salience(f"n{i}", -0.45)  # 0.05, collapsed
+        before = await stats_store.salience_distribution(0.3)
+        assert before["fraction_below_floor"] == pytest.approx(1.0)
+        await stats_store.recalibrate_salience_floor(0.3)
+        after = await stats_store.salience_distribution(0.3)
+        assert after["fraction_below_floor"] == pytest.approx(0.0)
+        assert after["mean"] == pytest.approx(0.3)
+
+    async def test_percentile_nearest_rank_small_table(self, stats_store: StatsStore) -> None:
+        # n=2: p50 must pick the lower value (nearest-rank), not the max.
+        await stats_store.update_salience("a", -0.3)  # 0.2
+        await stats_store.update_salience("b", 0.3)  # 0.8
+        dist = await stats_store.salience_distribution(0.3)
+        assert dist["p50"] == pytest.approx(0.2)
+        assert dist["p90"] == pytest.approx(0.8)
+
+    async def test_rejects_out_of_range_floor(self, stats_store: StatsStore) -> None:
+        for bad in (-0.1, 1.5, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="finite value in"):
+                await stats_store.recalibrate_salience_floor(bad)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1163,3 +1163,90 @@ class TestPersistentConnectionHardening:
         row = await stats_store.get_node_stats("node-1")
         assert row is not None
         assert row["retrieval_count"] == 1
+
+
+class TestRecalibrateSalienceFloor:
+    """One-time backfill that lifts decay-collapsed rows to the floor (task e7d8ef60)."""
+
+    async def _salience(self, store: StatsStore, node_id: str) -> float:
+        row = await store.get_node_stats(node_id)
+        assert row is not None
+        val = row["salience"]
+        assert isinstance(val, float)
+        return val
+
+    async def test_lifts_rows_below_floor(self, stats_store: StatsStore) -> None:
+        await stats_store.update_salience("cold", -0.45)  # 0.05
+        lifted = await stats_store.recalibrate_salience_floor(0.3)
+        assert lifted == 1
+        assert await self._salience(stats_store, "cold") == pytest.approx(0.3)
+
+    async def test_leaves_rows_at_or_above_floor(self, stats_store: StatsStore) -> None:
+        await stats_store.update_salience("hot", 0.4)  # 0.9
+        await stats_store.update_salience("edge", -0.2)  # 0.3 (== floor)
+        lifted = await stats_store.recalibrate_salience_floor(0.3)
+        assert lifted == 0
+        assert await self._salience(stats_store, "hot") == pytest.approx(0.9)
+        assert await self._salience(stats_store, "edge") == pytest.approx(0.3)
+
+    async def test_skips_misleading_nodes(self, stats_store: StatsStore) -> None:
+        # A node penalised below the floor by explicit misleading feedback must stay.
+        await stats_store.update_salience("bad", -0.45)  # 0.05
+        await stats_store.increment_misleading("bad")
+        lifted = await stats_store.recalibrate_salience_floor(0.3)
+        assert lifted == 0
+        assert await self._salience(stats_store, "bad") == pytest.approx(0.05)
+
+    async def test_skips_chronically_ignored_nodes(self, stats_store: StatsStore) -> None:
+        await stats_store.update_salience("ign", -0.45)  # 0.05
+        for _ in range(6):  # ignored_count 6 > 5 and > cited_count 0
+            await stats_store.increment_ignored("ign")
+        lifted = await stats_store.recalibrate_salience_floor(0.3)
+        assert lifted == 0
+        assert await self._salience(stats_store, "ign") == pytest.approx(0.05)
+
+    async def test_lifts_lightly_ignored_below_threshold(self, stats_store: StatsStore) -> None:
+        # Only chronic ignore (count > 5 and > cited) is a deliberate penalty; a couple
+        # of ignores is not, so such a node is still lifted.
+        await stats_store.update_salience("meh", -0.45)  # 0.05
+        for _ in range(2):
+            await stats_store.increment_ignored("meh")
+        lifted = await stats_store.recalibrate_salience_floor(0.3)
+        assert lifted == 1
+        assert await self._salience(stats_store, "meh") == pytest.approx(0.3)
+
+    async def test_idempotent(self, stats_store: StatsStore) -> None:
+        await stats_store.update_salience("cold", -0.45)
+        first = await stats_store.recalibrate_salience_floor(0.3)
+        second = await stats_store.recalibrate_salience_floor(0.3)
+        assert first == 1
+        assert second == 0
+
+    async def test_dry_run_counts_without_writing(self, stats_store: StatsStore) -> None:
+        await stats_store.update_salience("cold", -0.45)  # 0.05
+        would = await stats_store.recalibrate_salience_floor(0.3, dry_run=True)
+        assert would == 1
+        # Unchanged — dry run must not write.
+        assert await self._salience(stats_store, "cold") == pytest.approx(0.05)
+
+
+class TestSalienceDistribution:
+    """Aggregate distribution stats used by the daily sweep gauge + recalibration CLI."""
+
+    async def test_empty_table(self, stats_store: StatsStore) -> None:
+        dist = await stats_store.salience_distribution()
+        assert dist["count"] == 0.0
+        assert dist["mean"] == 0.0
+        assert dist["fraction_le_030"] == 0.0
+
+    async def test_summarises_distribution(self, stats_store: StatsStore) -> None:
+        # Three nodes: 0.1, 0.3, 0.9  -> two of three are <= 0.30.
+        await stats_store.update_salience("a", -0.4)  # 0.1
+        await stats_store.update_salience("b", -0.2)  # 0.3
+        await stats_store.update_salience("c", 0.4)  # 0.9
+        dist = await stats_store.salience_distribution()
+        assert dist["count"] == 3.0
+        assert dist["mean"] == pytest.approx((0.1 + 0.3 + 0.9) / 3)
+        assert dist["fraction_le_030"] == pytest.approx(2 / 3)
+        assert 0.0 <= dist["p50"] <= 1.0
+        assert dist["p90"] >= dist["p50"]


### PR DESCRIPTION
## What & why

Salience (LCMA per-node retrieval-utility signal) had **collapsed in prod**: avg **0.076**, **86% of ~1,981 nodes ≤ 0.30**. Root cause, confirmed in code:

- Every node starts at 0.5.
- A **floor-less daily sweep** decays untouched nodes linearly toward **zero** (`enrich.py` `_apply_decay` / `full_sweep`).
- The only forces that *raise* salience fire on actively cited/consolidated nodes — never the cold bulk corpus, and near-empty in prod.

So the rerank salience term (`+ salience*0.1`, raw/unnormalized) became a near-uniform ~0 penalty — degrading **all** `lithos_retrieve` ranking and blocking MVP-3 WS4 (concept damping via a salience ceiling) and WS6 (salience-weighted rerank), both of which assume a meaningful spread. Fixes tracker task `e7d8ef60` (the MVP-3 WS0 prerequisite gate).

## Approach

1. **Decay to a non-zero floor** — time decay stops at `lcma.salience_floor` (default 0.3); explicit negative feedback (misleading / chronic-ignored) may still go below. Math in a new pure module `lithos/lcma/salience.py`.
2. **Usage signal** — a new non-decaying `usage_score` rerank term (log-scaled retrieval frequency + exponential recency), computed from counters the rerank pre-fetch **already** reads (`get_node_stats_batch` does `SELECT *`) → **zero extra queries**. Separates learned *quality* (stored salience) from live *popularity* (usage) and cannot collapse. Emitted as a new result field.
3. **Config exposure** — the previously-hardcoded decay/reinforcement constants and the composite weights become `LcmaConfig` fields (also gives WS6 its tuning surface).
4. **One-time backfill** — `lithos recalibrate-salience` (idempotent, staging-first), routed through the `cognitive_memory` facade to respect the lcma import seam. Lifts collapsed rows to the floor; skips explicit-negative-feedback nodes.
5. **Observability** — the daily sweep snapshots the salience distribution (mean, fraction **strictly below the configured floor**, node count) to OTEL gauges so a re-collapse is alertable. The below-floor fraction is the collapse marker: it clears to ~0 once the backfill parks rows *at* the floor (nodes resting at the floor are healthy), which a fixed `≤ 0.30` threshold could not distinguish.
6. **Calibration harness** — `scripts/calibrate_salience.py`, an offline eval that replays a stats.db copy through the same pure helpers, reports distribution health + separation (citation/activity AUC), and ranks parameter sets. Sets the shipped defaults.

Shipped defaults are **provisional** pending calibration against a prod/staging stats.db copy and the operator backfill run.

## Decisions (agreed before implementation)

- Scope = floor **+** usage signal (floor-only leaves every cold node piled at the floor).
- Full calibration harness (feeds WS6 later).
- Backfill = operator-run CLI, staging-first (keeps stats.db migrations DDL-only; data mutation stays explicit).

## Test plan

- `make check` (lint + typecheck + unit) and `make test-integration` — **green**.
- New coverage: pure helpers + eligibility predicate (`test_salience.py`), decay-floor + config wiring + gauge emission (`test_enrich_worker.py`), usage-in-rerank + config wiring (`test_retrieve.py`), backfill + floor-aware distribution + percentile + floor validation (`test_stats.py`), cited-boost wiring (`test_cognitive_memory.py`), CLI (`test_cli.py`), harness incl. end-to-end receipt parsing + time-split (`test_calibrate_salience.py`). lcma import-seam guard still green.
- Operational, **post-merge**: run the harness against a stats.db copy to finalize the provisional defaults, then `recalibrate-salience` on **staging → prod**, watching the new distribution gauge.

## Not in scope

- Dropping the vestigial `decay_rate` column (a NOT-NULL rebuild on live prod stats.db + a `lithos_node_stats` surface change) — left as low-priority cleanup.