### PR TITLE
docs(lcma): mark WS0 salience-recalibration prerequisite done (e7d8ef60)

### DIFF
--- a/docs/plans/lcma-checklist.md
+++ b/docs/plans/lcma-checklist.md
@@ -151,7 +151,8 @@ Exit criteria (all MVPs):
 
 **Gated prerequisites (separate tasks, not MVP-3 work):**
 
-- [ ] Salience recalibration — task `e7d8ef60` (HIGH; `blocks` this epic)
+- [x] Salience recalibration — task `e7d8ef60` — DONE 2026-07-24 (PR #402 + operator backfill
+      staging/prod; defaults calibration-confirmed; record: KB note `9f5e6737`)
 - [ ] Feedback capture — task `fc4b0669`
 - [ ] (operational) Semantic-index coverage reconcile — task `97cd00bb`
 


### PR DESCRIPTION
## What

One-line checklist update: ticks the MVP-3 WS0 `e7d8ef60` salience-recalibration prerequisite in `docs/plans/lcma-checklist.md`.

## Why

The fix shipped in #402 and the operator backfill ran on staging and prod on 2026-07-24:

- Calibration harness (offline, on stats.db snapshots) **confirmed the shipped defaults** — future-retrieval AUC 0.931 (prod) vs 0.936 best across the 36-config sweep; bounded influence, no saturation.
- Backfill (dry-run first, idempotency verified): staging 3,054/3,346 rows lifted (mean 0.050→0.318), prod 1,857/2,152 (mean 0.076→0.328, below_floor 86.3%→0%, p90 0.460 preserved).
- Gauge pipeline verified end-to-end; tracker task completed with outcome; MVP-3 epic `d921d168` auto-unblocked.
- Full record: Lithos KB note `9f5e6737` (`analysis/lcma-salience-recalibration-2026-07.md`).

## Test plan

- [x] `make check` green (1668 passed); docs-only diff, no generated-doc drift.