### PR TITLE
feat(lcma): typed-edge inference wired into the enrich worker (WS1 PR2)

### DIFF
--- a/docs/generated/components/LCMA.md
+++ b/docs/generated/components/LCMA.md
@@ -12,6 +12,7 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
 | `lithos.lcma` | XS | 0 | 0 |
+| `lithos.lcma.edge_inference` | M | 3 | 4 |
 | `lithos.lcma.edge_reinforce` | XS | 0 | 1 |
 | `lithos.lcma.enrich` | L | 1 | 0 |
 | `lithos.lcma.entities` | M | 0 | 1 |
@@ -24,6 +25,15 @@ Lithos Cognitive Memory Architecture internals — scouts, retrieval, enrichment
 | `lithos.lcma.utils` | S | 1 | 1 |
 
 ## Public API
+
+### `lithos.lcma.edge_inference`
+- class `NeighbourInfo` — A semantic-search hit enriched with the metadata the pre-filter needs.
+- class `Adjudication` — One validated judgement from the LLM response.
+- def `prefilter_candidates` — Cheap, token-free candidate filter + ranking.
+- def `build_adjudication_prompt` — Build the two-message prompt: fixed system instruction + numbered candidates.
+- def `parse_adjudications` — Defensively parse the model's JSON; ``None`` means wholesale failure.
+- def `edge_endpoints` — Resolve ``(from_id, to_id)`` from the judged direction.
+- class `EdgeInferenceEngine` — Per-node orchestration: gates → neighbours → one LLM call → inferred edges.
 
 ### `lithos.lcma.edge_reinforce`
 - def `reinforce_related_edge` — Strengthen an existing ``related_to`` edge or create one.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -52,7 +52,7 @@
         "max_function": "lithos.knowledge.KnowledgeManager.update"
       },
       "LCMA": {
-        "functions_over_10": 16,
+        "functions_over_10": 18,
         "max_complexity": 41,
         "max_function": "lithos.lcma.retrieve._run_retrieve_impl"
       },
@@ -82,7 +82,7 @@
         "max_function": "lithos.telemetry.setup_telemetry"
       }
     },
-    "functions_over_10": 60,
+    "functions_over_10": 62,
     "top_functions": [
       {
         "complexity": 65,
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 762
+    "total_functions": 776
   },
   "domain": {
     "associations": 26,
@@ -217,7 +217,7 @@
       }
     },
     "cross_component_edges": 72,
-    "cross_component_module_edges": 155,
+    "cross_component_module_edges": 165,
     "longest_component_chain": 10,
     "module_cycle_count": 1,
     "module_cycles": [
@@ -258,6 +258,7 @@
       "lithos.knowledge -> lithos.graph.KnowledgeGraph._plan_reconcile_to",
       "lithos.knowledge -> lithos.provenance.ProvenanceProjection._apply_reconcile",
       "lithos.knowledge -> lithos.provenance.ProvenanceProjection._plan_reconcile_to",
+      "lithos.lcma.edge_inference -> lithos.telemetry._LithosMetrics",
       "lithos.lcma.enrich -> lithos.telemetry._LithosMetrics",
       "lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id",
       "lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics",
@@ -269,7 +270,7 @@
       "lithos.tools.notes -> lithos.knowledge._UNSET",
       "lithos.tools.notes -> lithos.knowledge._UnsetType"
     ],
-    "cross_module_private_refs": 29,
+    "cross_module_private_refs": 30,
     "tests_private_detail": [
       "tests/test_telemetry.py -> lithos.telemetry._reset_for_testing (x19)",
       "tests/test_telemetry.py -> lithos.telemetry._lcma_metrics_registered (x8)",
@@ -320,11 +321,11 @@
         "classes": 2,
         "functions": 31,
         "largest_module": "lithos.cognitive_memory",
-        "largest_module_lines": 1157,
-        "lines": 1157,
+        "largest_module_lines": 1158,
+        "lines": 1158,
         "modules": 1,
         "public_symbols": 3,
-        "sloc": 952
+        "sloc": 953
       },
       "Config": {
         "classes": 10,
@@ -390,11 +391,11 @@
         "classes": 8,
         "functions": 7,
         "largest_module": "lithos.intake",
-        "largest_module_lines": 630,
-        "lines": 630,
+        "largest_module_lines": 633,
+        "lines": 633,
         "modules": 1,
         "public_symbols": 8,
-        "sloc": 533
+        "sloc": 536
       },
       "Knowledge": {
         "classes": 9,
@@ -407,14 +408,14 @@
         "sloc": 1654
       },
       "LCMA": {
-        "classes": 10,
-        "functions": 144,
+        "classes": 13,
+        "functions": 158,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1253,
-        "lines": 4965,
-        "modules": 11,
-        "public_symbols": 29,
-        "sloc": 3992
+        "lines": 5478,
+        "modules": 12,
+        "public_symbols": 36,
+        "sloc": 4413
       },
       "Logging": {
         "classes": 1,
@@ -482,13 +483,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 24775,
-    "total_modules": 43,
-    "total_sloc": 19881
+    "total_lines": 25292,
+    "total_modules": 44,
+    "total_sloc": 20306
   },
   "tests": {
-    "ratio": 1.88,
-    "src_lines": 24775,
-    "test_lines": 46491
+    "ratio": 1.86,
+    "src_lines": 25292,
+    "test_lines": 47129
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -125,7 +125,7 @@
         "qualname": "lithos.search.TantivyIndex.search"
       }
     ],
-    "total_functions": 776
+    "total_functions": 778
   },
   "domain": {
     "associations": 26,
@@ -217,7 +217,7 @@
       }
     },
     "cross_component_edges": 72,
-    "cross_component_module_edges": 165,
+    "cross_component_module_edges": 164,
     "longest_component_chain": 10,
     "module_cycle_count": 1,
     "module_cycles": [
@@ -379,23 +379,23 @@
       },
       "Graph": {
         "classes": 8,
-        "functions": 46,
+        "functions": 47,
         "largest_module": "lithos.graph",
         "largest_module_lines": 954,
-        "lines": 1315,
+        "lines": 1384,
         "modules": 2,
         "public_symbols": 8,
-        "sloc": 1059
+        "sloc": 1126
       },
       "Intake": {
         "classes": 8,
-        "functions": 7,
+        "functions": 8,
         "largest_module": "lithos.intake",
-        "largest_module_lines": 633,
-        "lines": 633,
+        "largest_module_lines": 686,
+        "lines": 686,
         "modules": 1,
         "public_symbols": 8,
-        "sloc": 536
+        "sloc": 582
       },
       "Knowledge": {
         "classes": 9,
@@ -412,10 +412,10 @@
         "functions": 158,
         "largest_module": "lithos.lcma.stats",
         "largest_module_lines": 1253,
-        "lines": 5478,
+        "lines": 5553,
         "modules": 12,
         "public_symbols": 36,
-        "sloc": 4413
+        "sloc": 4479
       },
       "Logging": {
         "classes": 1,
@@ -483,13 +483,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 25292,
+    "total_lines": 25489,
     "total_modules": 44,
-    "total_sloc": 20306
+    "total_sloc": 20485
   },
   "tests": {
     "ratio": 1.86,
-    "src_lines": 25292,
-    "test_lines": 47129
+    "src_lines": 25489,
+    "test_lines": 47534
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -21,7 +21,7 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **72** (165 module-level)
+- Cross-component edges: **72** (164 module-level)
 - Component cycles: none
 - Module cycles: lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
@@ -41,10 +41,10 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Entrypoints | 13 | 5905 | 4737 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 233 | 168 | 8 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 350 | 281 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
-| Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
-| Intake | 1 | 633 | 536 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
+| Graph | 2 | 1384 | 1126 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
+| Intake | 1 | 686 | 582 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 12 | 5478 | 4413 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 18 |
+| LCMA | 12 | 5553 | 4479 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 18 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **44**, lines: **25292**, SLOC: **20306**
+- Modules: **44**, lines: **25489**, SLOC: **20485**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **776**, cyclomatic > 10: **62**
+- Functions: **778**, cyclomatic > 10: **62**
 
 Top 10 most complex functions:
 
@@ -151,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.86** (47129 test lines / 25292 source lines)
+- Test-to-source line ratio: **1.86** (47534 test lines / 25489 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -13,7 +13,7 @@ lower a budget after improving the code to lock in the gain.
 |---|---:|---:|---:|
 | `component_cycles` | 0 | 0 | 0 |
 | `cross_component_edges` | 72 | 72 | 0 |
-| `cross_module_private_refs` | 29 | 42 | 13 |
+| `cross_module_private_refs` | 30 | 42 | 12 |
 | `max_module_lines` | 2675 | 2800 | 125 |
 | `module_cycles` | 1 | 1 | 0 |
 | `modules_over_800_lines` | 11 | 11 | 0 |
@@ -21,7 +21,7 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **72** (155 module-level)
+- Cross-component edges: **72** (165 module-level)
 - Component cycles: none
 - Module cycles: lithos.server ↔ lithos.tools ↔ lithos.tools.agents ↔ lithos.tools.findings_stats ↔ lithos.tools.memory_edges ↔ lithos.tools.notes ↔ lithos.tools.read_search ↔ lithos.tools.tasks
 - Tier-skipping edges (Entrypoints → Foundation): 5 (Entrypoints -> Config, Entrypoints -> Errors, Entrypoints -> Events, Entrypoints -> Logging, Entrypoints -> Telemetry)
@@ -35,16 +35,16 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Component | Modules | Lines | SLOC | Fan-in | Fan-out | Instability | Max complexity | Functions > 10 |
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Codec | 1 | 777 | 583 | 7 | 0 | 0.00 | 14 (`lithos.frontmatter_codec.KnowledgeMetadata.from_dict`) | 3 |
-| CognitiveMemory | 1 | 1157 | 952 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
+| CognitiveMemory | 1 | 1158 | 953 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
 | Config | 1 | 536 | 377 | 11 | 1 | 0.08 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 13 | 5905 | 4737 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 233 | 168 | 8 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
 | Events | 1 | 350 | 281 | 4 | 2 | 0.33 | 7 (`lithos.events.EventBus.emit`) | 0 |
 | Graph | 2 | 1315 | 1059 | 7 | 4 | 0.36 | 12 (`lithos.graph.KnowledgeGraph._plan_reconcile_to`) | 3 |
-| Intake | 1 | 630 | 533 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
+| Intake | 1 | 633 | 536 | 3 | 8 | 0.73 | 21 (`lithos.intake.CorpusIntake.write`) | 1 |
 | Knowledge | 3 | 2067 | 1654 | 5 | 7 | 0.58 | 62 (`lithos.knowledge.KnowledgeManager.update`) | 7 |
-| LCMA | 11 | 4965 | 3992 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 16 |
+| LCMA | 12 | 5478 | 4413 | 1 | 12 | 0.92 | 41 (`lithos.lcma.retrieve._run_retrieve_impl`) | 18 |
 | Logging | 1 | 166 | 104 | 1 | 0 | 0.00 | 10 (`lithos.logging_config.setup_logging`) | 0 |
 | Provenance | 1 | 467 | 362 | 4 | 3 | 0.43 | 10 (`lithos.provenance.ProvenanceProjection._apply_reconcile`) | 0 |
 | Search | 1 | 1941 | 1576 | 5 | 4 | 0.44 | 33 (`lithos.search.SearchEngine.graph_search`) | 5 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **43**, lines: **24775**, SLOC: **19881**
+- Modules: **44**, lines: **25292**, SLOC: **20306**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **762**, cyclomatic > 10: **60**
+- Functions: **776**, cyclomatic > 10: **62**
 
 Top 10 most complex functions:
 
@@ -92,7 +92,7 @@ Top 10 most complex functions:
 Private-name reaches across module seams. Both counts can be pinned as
 `[budgets]` ratchets (`cross_module_private_refs`, `tests_private_imports`).
 
-- Cross-module private refs (src): **29**
+- Cross-module private refs (src): **30**
   - `lithos.tools.tasks -> lithos.server.LithosServer._emit (x8)`
   - `lithos.tools.findings_stats -> lithos.server.LithosServer._config (x2)`
   - `lithos.tools.read_search -> lithos.server.LithosServer._config (x2)`
@@ -103,6 +103,7 @@ Private-name reaches across module seams. Both counts can be pinned as
   - `lithos.knowledge -> lithos.graph.KnowledgeGraph._plan_reconcile_to`
   - `lithos.knowledge -> lithos.provenance.ProvenanceProjection._apply_reconcile`
   - `lithos.knowledge -> lithos.provenance.ProvenanceProjection._plan_reconcile_to`
+  - `lithos.lcma.edge_inference -> lithos.telemetry._LithosMetrics`
   - `lithos.lcma.enrich -> lithos.telemetry._LithosMetrics`
   - `lithos.lcma.retrieve -> lithos.lcma.stats._generate_receipt_id`
   - `lithos.lcma.retrieve -> lithos.telemetry._LithosMetrics`
@@ -150,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.88** (46491 test lines / 24775 source lines)
+- Test-to-source line ratio: **1.86** (47129 test lines / 25292 source lines)

--- a/docs/plans/lcma-checklist.md
+++ b/docs/plans/lcma-checklist.md
@@ -158,12 +158,16 @@ Exit criteria (all MVPs):
 
 **WS1 — LLM-synthesis backbone**
 
-- [ ] Optional LLM provider (nested `LithosConfig.lcma.llm` — one OpenAI-compatible endpoint, local or external; enabled iff `base_url` set, env `LITHOS_LCMA__LLM__BASE_URL`/`__MODEL`) wired into `lithos-enrich`; background, budget-bounded, provenance-stamped, idempotent
+- [x] Optional LLM provider wired into `lithos-enrich`; background, budget-bounded,
+      provenance-stamped, idempotent — DONE (slice 1): nested `LithosConfig.lcma.llm`
+      (OpenAI-compatible endpoint, replaces the never-read `llm_provider` string),
+      `lithos/lcma/llm.py` client, `llm_budget` daily-token + per-drain-call caps,
+      `edge_inference_log` idempotency, `origin=enrich` cascade guard on `assert_edge`
 
 **WS2 — Typed-edge inference**
 
-- [ ] Infer `supports`/`contradicts`/`refines`/`is_example_of`/`depends_on`/`analogy_to` over semantic-neighbour pairs (LLM-adjudicated), written to `edges.db` with `provenance_type=inferred`
-- [ ] Governance: inferred ≠ asserted, confidence floor, `contradicts` surfaced not auto-applied
+- [x] Infer `supports`/`contradicts`/`refines`/`is_example_of`/`depends_on`/`analogy_to` over semantic-neighbour pairs (LLM-adjudicated), written to `edges.db` with `provenance_type=inferred` — DONE (slice 1, drain-triggered on note create/update via `lithos/lcma/edge_inference.py`; full-corpus sweep backfill + re-inference policy = slice 2)
+- [x] Governance: inferred ≠ asserted, confidence floor, `contradicts` surfaced not auto-applied
 
 **WS3 — Coherence / temperature / exploration**
 

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -1569,8 +1569,12 @@ background worker as persistent artifacts (typed edges, concept notes, analogy f
 local Ollama/llama.cpp/vLLM `/v1` shims keep privacy-first deployments whole; hosted APIs work
 identically). Query-independent, background, budget-bounded (daily token ceiling + per-drain
 call cap in stats.db `llm_budget`); never on the retrieve hot path. Emits provenance-stamped,
-idempotent artifacts (`edge_inference_log` keyed on `(node_id, doc_version)`; edge writes flow
-through `intake.assert_edge` with `origin=enrich` so the worker drops its own events). Enables
+idempotent artifacts (`edge_inference_log` keyed on the identity triple `(node_id, doc_version,
+inference_version)` — a doc update or an `INFERENCE_VERSION` bump in `edge_inference.py`
+re-adjudicates; a model switch deliberately does not, with `purge_edge_inference_log` as the
+operator reset. Inferred-edge writes flow through `intake.assert_inferred_edge` with
+`origin=enrich` — the worker drops its own events, and the underlying `upsert_inferred`
+atomically refuses to displace asserted, legacy, or manually-resolved rows). Enables
 WS2/WS4/WS5. *Shipped 2026-07 as slice 1 together with the thin WS2 consumer below.*
 
 **WS2 — Typed-edge inference (top lever + Lens enabler).** For each node, take its top semantic

--- a/docs/plans/lcma-design.md
+++ b/docs/plans/lcma-design.md
@@ -1565,10 +1565,13 @@ background worker as persistent artifacts (typed edges, concept notes, analogy f
 ### Workstreams
 
 **WS1 — LLM-synthesis worker (backbone).** `lithos-enrich` gains an **optional** LLM provider
-(nested `LithosConfig.lcma.llm` — one OpenAI-compatible chat-completions endpoint, local or
-external; local Ollama/llama.cpp/vLLM `/v1` shims keep privacy-first deployments whole).
-Query-independent, background, budget-bounded; never on the retrieve hot path. Emits provenance-
-stamped, idempotent artifacts (the `enrich_queue` already sequences work). Enables WS2/WS4/WS5.
+(`LithosConfig.lcma.llm`, a nested config for one OpenAI-compatible chat-completions endpoint —
+local Ollama/llama.cpp/vLLM `/v1` shims keep privacy-first deployments whole; hosted APIs work
+identically). Query-independent, background, budget-bounded (daily token ceiling + per-drain
+call cap in stats.db `llm_budget`); never on the retrieve hot path. Emits provenance-stamped,
+idempotent artifacts (`edge_inference_log` keyed on `(node_id, doc_version)`; edge writes flow
+through `intake.assert_edge` with `origin=enrich` so the worker drops its own events). Enables
+WS2/WS4/WS5. *Shipped 2026-07 as slice 1 together with the thin WS2 consumer below.*
 
 **WS2 — Typed-edge inference (top lever + Lens enabler).** For each node, take its top semantic
 neighbours as candidate pairs, cheap-pre-filter (similarity + entity/tag overlap), then have WS1
@@ -1578,7 +1581,9 @@ columns** (no migration): `provenance_type="inferred"`, `provenance_actor="litho
 `weight=confidence`, `evidence={rationale, model, confidence}`. Lifts coverage from 17% with *real*
 semantic types and — because `lithos_related` already surfaces `edges.db` — feeds Lens for free.
 Governance: inferred ≠ asserted (marked + filterable); confidence floor; `contradicts` is surfaced,
-never auto-mutating.
+never auto-mutating. *Slice 1 shipped 2026-07: drain-triggered inference on note create/update
+(`lithos/lcma/edge_inference.py` — one LLM call per node over top-K pre-filtered semantic
+neighbours). Slice 2 remains: full-corpus sweep backfill + neighbourhood-drift re-inference.*
 
 **WS3 — Embedding-based coherence + temperature + exploration.** Edge-based coherence is dead (17%
 coverage); redefine **coherence = 1 − normalised semantic dispersion** of the top candidates
@@ -1747,7 +1752,7 @@ LCMA is also compatible with cross-plan metadata additions: `source_url`, `deriv
 
 ### LLM integration scope
 
-Background LLM synthesis (the `should_enrich_with_llm()` policy and `llm_interpretive_synthesize()` worker in §5.4/§5.12) requires an LLM provider and is not available in MVP 1 or MVP 2. `lithos_retrieve` always terminates at Terrace 1 — no local model is bundled and no LLM call ever happens on the retrieve path. LLM synthesis ships in MVP 3 as part of `lithos-enrich`, configured via the nested `LithosConfig.lcma.llm` block (OpenAI-compatible endpoint; disabled unless `base_url` is set).
+Background LLM synthesis (the `should_enrich_with_llm()` policy and `llm_interpretive_synthesize()` worker in §5.4/§5.12) requires an LLM provider and is not available in MVP 1 or MVP 2. `lithos_retrieve` always terminates at Terrace 1 — no local model is bundled and no LLM call ever happens on the retrieve path. LLM synthesis shipped with MVP 3 WS1 as part of `lithos-enrich`, configured via the nested `LithosConfig.lcma.llm` block (OpenAI-compatible endpoint; disabled unless `base_url` is set). The §5.4 temperature-based `should_enrich_with_llm()` gate is superseded in slice 1 by a deterministic trigger-type + budget + op-log gate (temperature is inert until WS3).
 
 ### 7.z `LcmaConfig` Schema (Draft)
 

--- a/src/lithos/cognitive_memory.py
+++ b/src/lithos/cognitive_memory.py
@@ -232,6 +232,7 @@ class CognitiveMemory:
                 knowledge=self._knowledge,
                 coordination=self._coordination,
                 intake=self._intake,
+                search=self._search,
             )
             await self._enrich_worker.start()
         self._started = True

--- a/src/lithos/edge_store.py
+++ b/src/lithos/edge_store.py
@@ -178,6 +178,75 @@ CREATE INDEX IF NOT EXISTS idx_edges_namespace ON edges(namespace);
                 )
         return edge_id
 
+    async def upsert_inferred(
+        self,
+        *,
+        from_id: str,
+        to_id: str,
+        edge_type: str,
+        weight: float,
+        namespace: str,
+        provenance_actor: str,
+        evidence: str | None = None,
+    ) -> str | None:
+        """Upsert an LLM-inferred edge without ever displacing authoritative rows.
+
+        The write proceeds only when no row exists for the natural key, or the
+        existing row is itself ``provenance_type='inferred'`` with no
+        ``conflict_state`` — asserted rows, legacy NULL-provenance rows,
+        projection-owned rows, and manually resolved conflicts are all left
+        untouched (inferred ≠ asserted is a one-way boundary). Returns the
+        ``edge_id`` when written, ``None`` when the existing row wins. The
+        SELECT-then-act pair is atomic inside the transactional
+        :meth:`_session` (same serialisation contract as :meth:`upsert`).
+        """
+        now = datetime.now(UTC).isoformat()
+        async with self._session(transactional=True) as db:
+            cursor = await db.execute(
+                "SELECT edge_id, provenance_type, conflict_state FROM edges "
+                "WHERE from_id = ? AND to_id = ? AND type = ? AND namespace = ?",
+                (from_id, to_id, edge_type, namespace),
+            )
+            row = await cursor.fetchone()
+            if row is not None:
+                edge_id: str = row[0]
+                if row[1] != "inferred" or row[2] is not None:
+                    logger.debug(
+                        "inferred upsert blocked by existing row: edge_id=%s "
+                        "provenance_type=%s conflict_state=%s",
+                        edge_id,
+                        row[1],
+                        row[2],
+                    )
+                    return None
+                await db.execute(
+                    "UPDATE edges SET weight = ?, updated_at = ?, "
+                    "provenance_actor = ?, evidence = ? WHERE edge_id = ?",
+                    (weight, now, provenance_actor, evidence, edge_id),
+                )
+                return edge_id
+            edge_id = _generate_edge_id()
+            await db.execute(
+                "INSERT INTO edges "
+                "(edge_id, from_id, to_id, type, weight, namespace, "
+                "created_at, updated_at, provenance_actor, provenance_type, "
+                "evidence, conflict_state) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'inferred', ?, NULL)",
+                (
+                    edge_id,
+                    from_id,
+                    to_id,
+                    edge_type,
+                    weight,
+                    namespace,
+                    now,
+                    now,
+                    provenance_actor,
+                    evidence,
+                ),
+            )
+            return edge_id
+
     async def get_edge(self, edge_id: str) -> dict[str, object] | None:
         """Return a single edge by its ID, or ``None`` if not found."""
         async with self._session() as db:

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -558,7 +558,9 @@ class CorpusIntake:
                 warnings=list(result.warnings),
             )
 
-    async def assert_edge(self, agent: str, request: EdgeRequest) -> EdgeOutcome:
+    async def assert_edge(
+        self, agent: str, request: EdgeRequest, *, origin: str = ""
+    ) -> EdgeOutcome:
         """Assert an edge into the Corpus (ADR-0006 Slice 1).
 
         Four-step pipeline modelled on :meth:`delete` / :meth:`write`:
@@ -613,6 +615,7 @@ class CorpusIntake:
                     edge_type=request.edge_type,
                     namespace=request.namespace,
                     conflict_state=request.conflict_state,
+                    origin=origin,
                 )
             )
 

--- a/src/lithos/intake.py
+++ b/src/lithos/intake.py
@@ -621,6 +621,59 @@ class CorpusIntake:
 
             return EdgeOutcome(edge_id=edge_id, status="ok")
 
+    async def assert_inferred_edge(
+        self, agent: str, request: EdgeRequest, *, origin: str = ""
+    ) -> EdgeOutcome | None:
+        """:meth:`assert_edge` variant for LLM-inferred edges (WS1/WS2).
+
+        Same four-step pipeline, but the store write is
+        :meth:`EdgeStore.upsert_inferred`: it atomically refuses to displace
+        any row that is not itself an unconflicted inferred edge (asserted,
+        legacy NULL-provenance, projection-owned, or manually resolved rows
+        all win). When the write is blocked, returns ``None`` and emits no
+        event — the graph did not change.
+        """
+        tracer = get_tracer()
+        with tracer.start_as_current_span("lithos.intake.assert_inferred_edge") as span:
+            span.set_attribute("lithos.intake.op", "assert_inferred_edge")
+            span.set_attribute("lithos.agent", agent)
+            span.set_attribute("lithos.edge.from_id", request.from_id)
+            span.set_attribute("lithos.edge.to_id", request.to_id)
+            span.set_attribute("lithos.edge.type", request.edge_type)
+            span.set_attribute("lithos.edge.namespace", request.namespace)
+
+            await self._coordination.ensure_agent_known(agent)
+
+            edge_id = await self._edge_store.upsert_inferred(
+                from_id=request.from_id,
+                to_id=request.to_id,
+                edge_type=request.edge_type,
+                weight=request.weight,
+                namespace=request.namespace,
+                provenance_actor=request.provenance_actor or agent,
+                evidence=request.evidence,
+            )
+            if edge_id is None:
+                span.set_attribute("lithos.edge.blocked", True)
+                return None
+
+            span.set_attribute("lithos.edge.edge_id", edge_id)
+
+            await self._emit(
+                make_edge_upserted_event(
+                    agent=agent,
+                    edge_id=edge_id,
+                    from_id=request.from_id,
+                    to_id=request.to_id,
+                    edge_type=request.edge_type,
+                    namespace=request.namespace,
+                    conflict_state=None,
+                    origin=origin,
+                )
+            )
+
+            return EdgeOutcome(edge_id=edge_id, status="ok")
+
     async def _emit(self, event: LithosEvent) -> None:
         """Emit an event, logging any failure without propagating.
 

--- a/src/lithos/lcma/edge_inference.py
+++ b/src/lithos/lcma/edge_inference.py
@@ -18,10 +18,22 @@ Safety properties (see the WS1 plan):
 - **Budget-bounded** — a UTC-day token ceiling (``llm_budget`` ledger in stats.db)
   plus a per-drain-cycle call cap; exhaustion skips inference observably, never
   blocks the rest of enrichment.
-- **Idempotent** — ``edge_inference_log`` keyed on ``(node_id, doc_version,
-  inference_version)``; edges are written before the log row (edge upserts are
-  idempotent by natural key, so at-least-once is safe). See
-  :data:`INFERENCE_VERSION` for the invalidation policy.
+- **Idempotent & re-inferable** — ``edge_inference_log`` keyed on ``(node_id,
+  doc_version, inference_version)``; edges are written before the log row
+  (inferred upserts are idempotent by natural key, so at-least-once is safe).
+  A document update, an :data:`INFERENCE_VERSION` bump, or an operator ledger
+  purge each genuinely re-adjudicates: candidate pairs already carrying an
+  inferred edge are NOT excluded — re-adjudication refreshes their weight,
+  rationale, and model attribution in place.
+- **Non-destructive** — inferred writes go through
+  ``CorpusIntake.assert_inferred_edge`` → ``EdgeStore.upsert_inferred``, which
+  atomically refuses to displace any row that is not itself an unconflicted
+  inferred edge. Asserted edges, legacy rows, and manually resolved conflicts
+  always win; a blocked write is counted, not silently absorbed.
+- **Stale-proof** — after the LLM call returns, the focus document's version is
+  re-read; if the note changed mid-flight, neither edges nor the op-log row are
+  written (spend is still recorded), so the queued newer version re-runs
+  against fresh content.
 - **Cascade-proof** — edge writes go through ``CorpusIntake.assert_edge`` with
   ``origin=EVENT_ORIGIN_ENRICH`` so the worker drops its own ``edge.upserted``
   events; inference additionally only ever fires on note create/update triggers,
@@ -48,7 +60,6 @@ from lithos.lcma.llm import ChatMessage, LlmClient
 
 if TYPE_CHECKING:
     from lithos.config import LlmConfig
-    from lithos.edge_store import EdgeStore
     from lithos.frontmatter_codec import KnowledgeDocument
     from lithos.intake import CorpusIntake
     from lithos.knowledge import KnowledgeManager
@@ -124,8 +135,6 @@ class NeighbourInfo:
     namespace: str
     entities: frozenset[str]
     tags: frozenset[str]
-    #: True when an inferred edge already exists between focus and this node.
-    already_inferred: bool
 
 
 @dataclass(frozen=True)
@@ -152,16 +161,19 @@ def prefilter_candidates(
 ) -> list[NeighbourInfo]:
     """Cheap, token-free candidate filter + ranking.
 
-    Drops self, cross-namespace hits, pairs outside the similarity band
+    Drops self, cross-namespace hits, and pairs outside the similarity band
     (too-similar ≈ near-duplicate — ``related_to``'s job; too-distant wastes
-    adjudication tokens) and pairs already adjudicated (inferred edge exists).
-    Existing ``related_to`` edges do NOT exclude a pair — typed relations are
-    additive semantics. Survivors are ranked by similarity plus a small
-    entity/tag-overlap boost; the top *k* go to the LLM.
+    adjudication tokens). Pairs that already carry edges — ``related_to`` or
+    previously inferred — are deliberately NOT excluded: typed relations are
+    additive semantics, and re-adjudication is the mechanism by which a
+    document/policy-version change refreshes existing inferred edges (the
+    protected inferred-only upsert makes rewrites safe). Survivors are ranked
+    by similarity plus a small entity/tag-overlap boost; the top *k* go to
+    the LLM.
     """
     scored: list[tuple[float, NeighbourInfo]] = []
     for n in neighbours:
-        if n.node_id == focus_id or n.already_inferred:
+        if n.node_id == focus_id:
             continue
         if n.namespace != focus_namespace:
             continue
@@ -201,13 +213,24 @@ def build_adjudication_prompt(
     ]
 
 
-def parse_adjudications(text: str, n_candidates: int) -> list[Adjudication] | None:
+def parse_adjudications(text: str, n_candidates: int) -> tuple[list[Adjudication], int] | None:
     """Defensively parse the model's JSON; ``None`` means wholesale failure.
 
-    Individually invalid entries (unknown relation — including the deliberate
-    ``none`` —, out-of-range candidate index, bad confidence) are dropped;
-    only an unparseable body returns ``None`` so the caller can distinguish
-    "model answered, nothing qualified" from "model cannot follow the schema".
+    Returns ``(adjudications, problems)``. *problems* counts response-contract
+    violations that still allowed partial use: invalid entries, duplicate
+    candidate indexes (first judgement wins), and candidates the response
+    never covered — the prompt demands every candidate exactly once, and a
+    ``none`` answer covers its candidate without producing an edge. The caller
+    reports ``problems > 0`` observably (a "partial" outcome) instead of
+    silently treating malformed output as success.
+
+    Strictness rules (review round 1):
+
+    - candidate indexes must be genuine non-boolean integers — ``1.9`` is a
+      contract violation, never candidate 1;
+    - direction is never invented: a directional relation missing a valid
+      direction is dropped (an inverted edge is worse than no edge);
+      symmetric relations ignore direction entirely.
     """
     cleaned = text.strip()
     if cleaned.startswith("```"):
@@ -224,25 +247,49 @@ def parse_adjudications(text: str, n_candidates: int) -> list[Adjudication] | No
         return None
 
     out: list[Adjudication] = []
+    problems = 0
+    covered: set[int] = set()
     for entry in entries:
         if not isinstance(entry, dict):
+            problems += 1
+            continue
+        index = entry.get("candidate")
+        if (
+            isinstance(index, bool)
+            or not isinstance(index, int)
+            or not (1 <= index <= n_candidates)
+        ):
+            problems += 1
+            continue
+        if index in covered:
+            problems += 1  # duplicate judgement for one candidate
             continue
         relation = entry.get("relation")
+        if relation == "none":
+            covered.add(index)  # a valid answer, just not an edge
+            continue
         if relation not in RELATION_VOCAB:
-            continue  # includes the deliberate "none"
+            problems += 1
+            continue
         try:
-            index = int(entry.get("candidate", 0))
             confidence = float(entry.get("confidence", 0.0))
         except (TypeError, ValueError):
+            problems += 1
             continue
-        if not (1 <= index <= n_candidates) or not (0.0 <= confidence <= 1.0):
+        if not (0.0 <= confidence <= 1.0):
+            problems += 1
             continue
         direction = entry.get("direction")
-        if direction not in _DIRECTIONS:
-            direction = "focus_to_candidate"
+        if relation in SYMMETRIC_RELATIONS:
+            direction = "focus_to_candidate"  # placeholder; endpoints canonicalize
+        elif direction not in _DIRECTIONS:
+            problems += 1
+            continue
+        covered.add(index)
         rationale = str(entry.get("rationale", ""))[:300]
         out.append(Adjudication(index, str(relation), str(direction), confidence, rationale))
-    return out
+    problems += n_candidates - len(covered)
+    return out, problems
 
 
 def edge_endpoints(focus_id: str, candidate_id: str, adjudication: Adjudication) -> tuple[str, str]:
@@ -275,7 +322,6 @@ class EdgeInferenceEngine:
         knowledge: KnowledgeManager,
         search: SearchEngine,
         intake: CorpusIntake,
-        edge_store: EdgeStore,
         agent: str,
     ) -> None:
         self._config = config
@@ -284,7 +330,6 @@ class EdgeInferenceEngine:
         self._knowledge = knowledge
         self._search = search
         self._intake = intake
-        self._edge_store = edge_store
         self._agent = agent
         self._calls_this_drain = 0
 
@@ -359,8 +404,8 @@ class EdgeInferenceEngine:
                 result.total_tokens, {"estimated": str(result.estimated).lower()}
             )
 
-        adjudications = parse_adjudications(result.text, len(candidates))
-        if adjudications is None:
+        parsed = parse_adjudications(result.text, len(candidates))
+        if parsed is None:
             # Tokens were genuinely spent — record the op-log row so a
             # schema-incapable model can't re-burn the budget every drain.
             logger.warning(
@@ -371,15 +416,34 @@ class EdgeInferenceEngine:
             )
             self._count_call("parse_error", started)
             return
+        adjudications, problems = parsed
+        if problems:
+            logger.warning(
+                "LLM adjudication for %s violated the response contract "
+                "(%d bad/duplicate/missing entries; using %d valid judgements)",
+                node_id,
+                problems,
+                len(adjudications),
+            )
+
+        # Staleness guard: the note may have changed during the (long) LLM
+        # call. Spend is already recorded — the tokens are burned either way —
+        # but stale judgements must not become edges, and no op-log row is
+        # written so the queued newer version re-runs against fresh content.
+        if await self._current_version(node_id) != version:
+            self._skip("stale_version")
+            self._count_call("stale", started)
+            return
 
         namespace = self._namespace_of(node_id)
         written = 0
+        blocked = 0
         for adjudication in adjudications:
             if adjudication.confidence < self._config.confidence_floor:
                 continue
             candidate = candidates[adjudication.candidate_index - 1]
             from_id, to_id = edge_endpoints(node_id, candidate.node_id, adjudication)
-            await self._intake.assert_edge(
+            outcome = await self._intake.assert_inferred_edge(
                 self._agent,
                 EdgeRequest(
                     from_id=from_id,
@@ -399,6 +463,12 @@ class EdgeInferenceEngine:
                 ),
                 origin=EVENT_ORIGIN_ENRICH,
             )
+            if outcome is None:
+                # An asserted / resolved / legacy row holds this key — the
+                # judgement is discarded, observably. Inferred never wins.
+                blocked += 1
+                self._skip("asserted_exists")
+                continue
             written += 1
             if _HAS_TELEMETRY and _lithos_metrics is not None:
                 _lithos_metrics.lcma_inferred_edges_written.add(
@@ -408,17 +478,23 @@ class EdgeInferenceEngine:
         await self._stats_store.record_edge_inference(
             node_id, version, INFERENCE_VERSION, model=self._config.model, edges_written=written
         )
-        self._count_call("ok", started)
+        self._count_call("partial" if problems else "ok", started)
         logger.info(
-            "Edge inference for %s: %d/%d judgements written (version=%d)",
+            "Edge inference for %s: %d/%d judgements written, %d blocked (version=%d)",
             node_id,
             written,
             len(adjudications),
+            blocked,
             version,
         )
 
     async def _gather_candidates(self, node_id: str, doc: KnowledgeDocument) -> list[NeighbourInfo]:
-        """Semantic k-NN → NeighbourInfo (cached meta + inferred-edge lookups) → pre-filter."""
+        """Semantic k-NN → NeighbourInfo (cached meta) → pre-filter.
+
+        ``threshold`` is passed explicitly so the LCMA similarity band is
+        self-contained: without it, the global ``SearchConfig.semantic_threshold``
+        would silently pre-narrow the configured ``min_similarity`` floor.
+        """
         focus_meta = self._knowledge.get_cached_meta(node_id)
         if focus_meta is None:
             return []
@@ -427,6 +503,7 @@ class EdgeInferenceEngine:
             self._search.semantic_search,
             query=f"{doc.title}\n{doc.content[:1000]}",
             limit=self._config.neighbour_k * 3,
+            threshold=self._config.min_similarity,
         )
 
         neighbours: list[NeighbourInfo] = []
@@ -443,7 +520,6 @@ class EdgeInferenceEngine:
                     namespace=meta.namespace,
                     entities=frozenset(meta.entities),
                     tags=frozenset(meta.tags),
-                    already_inferred=await self._has_inferred_edge(node_id, r.id),
                 )
             )
 
@@ -458,13 +534,13 @@ class EdgeInferenceEngine:
             k=self._config.neighbour_k,
         )
 
-    async def _has_inferred_edge(self, a: str, b: str) -> bool:
-        """True when an inferred-provenance edge already links *a* and *b* (either way)."""
-        for from_id, to_id in ((a, b), (b, a)):
-            for edge in await self._edge_store.list_edges(from_id=from_id, to_id=to_id):
-                if edge.get("provenance_type") == "inferred":
-                    return True
-        return False
+    async def _current_version(self, node_id: str) -> int | None:
+        """Fresh read of the focus document's version; ``None`` if it vanished."""
+        try:
+            doc, _ = await self._knowledge.read(id=node_id)
+        except FileNotFoundError:
+            return None
+        return doc.metadata.version
 
     def _namespace_of(self, node_id: str) -> str:
         meta = self._knowledge.get_cached_meta(node_id)

--- a/src/lithos/lcma/edge_inference.py
+++ b/src/lithos/lcma/edge_inference.py
@@ -1,0 +1,483 @@
+"""LLM-adjudicated typed-edge inference (WS1 slice 1 — the front edge of WS2).
+
+The measured 2026-07 substrate found the typed-edge graph semantically empty: 88% of
+edges are weight-≤0.05 mechanical ``related_to``, with only two genuine relation types
+across the corpus. This module densifies it: for a freshly created/updated note, take
+its top semantic neighbours, cheaply pre-filter, then have the configured LLM
+adjudicate a relation type + direction + confidence per pair in a **single** call.
+Qualifying judgements are written to ``edges.db`` as ``provenance_type="inferred"``
+edges (inferred ≠ asserted — marked and filterable; ``contradicts`` is surfaced by
+retrieval, never auto-applied).
+
+Layout mirrors :mod:`lithos.lcma.salience`: pure, trivially-testable functions
+(pre-filter, prompt build, response parse) up top; the I/O orchestration lives in
+:class:`EdgeInferenceEngine`, driven per-node by the enrich worker's drain loop.
+
+Safety properties (see the WS1 plan):
+
+- **Budget-bounded** — a UTC-day token ceiling (``llm_budget`` ledger in stats.db)
+  plus a per-drain-cycle call cap; exhaustion skips inference observably, never
+  blocks the rest of enrichment.
+- **Idempotent** — ``edge_inference_log`` keyed on ``(node_id, doc_version,
+  inference_version)``; edges are written before the log row (edge upserts are
+  idempotent by natural key, so at-least-once is safe). See
+  :data:`INFERENCE_VERSION` for the invalidation policy.
+- **Cascade-proof** — edge writes go through ``CorpusIntake.assert_edge`` with
+  ``origin=EVENT_ORIGIN_ENRICH`` so the worker drops its own ``edge.upserted``
+  events; inference additionally only ever fires on note create/update triggers,
+  and the op-log makes any residual re-drain a no-op.
+- **Failure-isolated** — an LLM outage completes the enrich item without
+  synthesis (no requeue churn); a parse failure records the op-log row so a
+  schema-incapable model cannot silently re-burn the budget every drain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from lithos.errors import LlmError
+from lithos.events import EVENT_ORIGIN_ENRICH, NOTE_CREATED, NOTE_UPDATED
+from lithos.intake import EdgeRequest
+from lithos.lcma.llm import ChatMessage, LlmClient
+
+if TYPE_CHECKING:
+    from lithos.config import LlmConfig
+    from lithos.edge_store import EdgeStore
+    from lithos.frontmatter_codec import KnowledgeDocument
+    from lithos.intake import CorpusIntake
+    from lithos.knowledge import KnowledgeManager
+    from lithos.lcma.stats import StatsStore
+    from lithos.search import SearchEngine
+    from lithos.telemetry import _LithosMetrics
+
+_lithos_metrics: _LithosMetrics | None = None
+try:
+    from lithos.telemetry import lithos_metrics as _lithos_metrics
+
+    _HAS_TELEMETRY = True
+except Exception:
+    _HAS_TELEMETRY = False
+
+logger = logging.getLogger(__name__)
+
+#: Policy fingerprint for the ``edge_inference_log`` identity triple
+#: ``(node_id, doc_version, inference_version)``. BUMP THIS when the prompt
+#: schema, relation vocabulary, or parse semantics change — a bump invalidates
+#: every prior run so unchanged notes are reprocessed under the new policy.
+#: A *model/config* switch deliberately does NOT invalidate (it must not
+#: silently re-burn the corpus budget); the operator reset for that is
+#: ``StatsStore.purge_edge_inference_log(model=...)``.
+INFERENCE_VERSION = 1
+
+#: Relation types the adjudicator may assign (design doc WS2). ``none`` is a valid
+#: model answer but never a written edge — the parser drops it with the invalid.
+RELATION_VOCAB = frozenset(
+    {"supports", "contradicts", "refines", "is_example_of", "depends_on", "analogy_to"}
+)
+
+#: Relations with no meaningful direction; endpoints are canonicalized
+#: ``from_id <= to_id`` (consolidation precedent) so A/B and B/A dedupe.
+SYMMETRIC_RELATIONS = frozenset({"contradicts", "analogy_to"})
+
+_DIRECTIONS = frozenset({"focus_to_candidate", "candidate_to_focus"})
+
+#: Rank-score boosts for entity/tag overlap on top of raw similarity (design §WS2:
+#: "cheap-pre-filter (similarity + entity/tag overlap)").
+_ENTITY_OVERLAP_BOOST = 0.02
+_TAG_OVERLAP_BOOST = 0.01
+
+_SYSTEM_PROMPT = """\
+You classify the relationship between a FOCUS note and each CANDIDATE note from a \
+shared knowledge base. For each candidate, choose exactly one relation:
+
+- supports: A gives evidence for B
+- contradicts: A and B make incompatible claims
+- refines: A sharpens, narrows, or corrects a detail of B
+- is_example_of: A is a concrete instance of the general idea B
+- depends_on: A relies on B being true or in place
+- analogy_to: A and B are structurally parallel solutions in different domains
+- none: no relation clearly holds (use this freely; most pairs are unrelated)
+
+Reply with ONLY a JSON object, no prose:
+{"judgements": [{"candidate": <number>, "relation": "<relation>", \
+"direction": "focus_to_candidate" | "candidate_to_focus", \
+"confidence": <0.0-1.0>, "rationale": "<max 25 words>"}]}
+
+direction reads left-to-right through the relation: focus_to_candidate means \
+"FOCUS <relation> CANDIDATE". Include every candidate exactly once."""
+
+
+@dataclass(frozen=True)
+class NeighbourInfo:
+    """A semantic-search hit enriched with the metadata the pre-filter needs."""
+
+    node_id: str
+    title: str
+    snippet: str
+    similarity: float
+    namespace: str
+    entities: frozenset[str]
+    tags: frozenset[str]
+    #: True when an inferred edge already exists between focus and this node.
+    already_inferred: bool
+
+
+@dataclass(frozen=True)
+class Adjudication:
+    """One validated judgement from the LLM response."""
+
+    candidate_index: int  # 1-based, as numbered in the prompt
+    relation: str
+    direction: str
+    confidence: float
+    rationale: str
+
+
+def prefilter_candidates(
+    neighbours: list[NeighbourInfo],
+    *,
+    focus_id: str,
+    focus_namespace: str,
+    focus_entities: frozenset[str],
+    focus_tags: frozenset[str],
+    min_similarity: float,
+    max_similarity: float,
+    k: int,
+) -> list[NeighbourInfo]:
+    """Cheap, token-free candidate filter + ranking.
+
+    Drops self, cross-namespace hits, pairs outside the similarity band
+    (too-similar ≈ near-duplicate — ``related_to``'s job; too-distant wastes
+    adjudication tokens) and pairs already adjudicated (inferred edge exists).
+    Existing ``related_to`` edges do NOT exclude a pair — typed relations are
+    additive semantics. Survivors are ranked by similarity plus a small
+    entity/tag-overlap boost; the top *k* go to the LLM.
+    """
+    scored: list[tuple[float, NeighbourInfo]] = []
+    for n in neighbours:
+        if n.node_id == focus_id or n.already_inferred:
+            continue
+        if n.namespace != focus_namespace:
+            continue
+        if not (min_similarity <= n.similarity <= max_similarity):
+            continue
+        score = (
+            n.similarity
+            + _ENTITY_OVERLAP_BOOST * len(focus_entities & n.entities)
+            + _TAG_OVERLAP_BOOST * len(focus_tags & n.tags)
+        )
+        scored.append((score, n))
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [n for _, n in scored[:k]]
+
+
+def build_adjudication_prompt(
+    focus_title: str,
+    focus_content: str,
+    candidates: list[NeighbourInfo],
+    *,
+    snippet_chars: int,
+) -> list[ChatMessage]:
+    """Build the two-message prompt: fixed system instruction + numbered candidates."""
+    lines = [
+        "FOCUS NOTE",
+        f"Title: {focus_title}",
+        f"Content: {focus_content[:snippet_chars]}",
+        "",
+        "CANDIDATES",
+    ]
+    for i, c in enumerate(candidates, start=1):
+        lines.append(f"[{i}] Title: {c.title}")
+        lines.append(f"    Snippet: {c.snippet[:snippet_chars]}")
+    return [
+        ChatMessage("system", _SYSTEM_PROMPT),
+        ChatMessage("user", "\n".join(lines)),
+    ]
+
+
+def parse_adjudications(text: str, n_candidates: int) -> list[Adjudication] | None:
+    """Defensively parse the model's JSON; ``None`` means wholesale failure.
+
+    Individually invalid entries (unknown relation — including the deliberate
+    ``none`` —, out-of-range candidate index, bad confidence) are dropped;
+    only an unparseable body returns ``None`` so the caller can distinguish
+    "model answered, nothing qualified" from "model cannot follow the schema".
+    """
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.startswith("json"):
+            cleaned = cleaned[4:]
+    try:
+        payload = json.loads(cleaned)
+    except ValueError:
+        return None
+
+    entries = payload.get("judgements") if isinstance(payload, dict) else payload
+    if not isinstance(entries, list):
+        return None
+
+    out: list[Adjudication] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        relation = entry.get("relation")
+        if relation not in RELATION_VOCAB:
+            continue  # includes the deliberate "none"
+        try:
+            index = int(entry.get("candidate", 0))
+            confidence = float(entry.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if not (1 <= index <= n_candidates) or not (0.0 <= confidence <= 1.0):
+            continue
+        direction = entry.get("direction")
+        if direction not in _DIRECTIONS:
+            direction = "focus_to_candidate"
+        rationale = str(entry.get("rationale", ""))[:300]
+        out.append(Adjudication(index, str(relation), str(direction), confidence, rationale))
+    return out
+
+
+def edge_endpoints(focus_id: str, candidate_id: str, adjudication: Adjudication) -> tuple[str, str]:
+    """Resolve ``(from_id, to_id)`` from the judged direction.
+
+    Symmetric relations canonicalize to ``from_id <= to_id`` so the natural
+    upsert key dedupes A→B and B→A.
+    """
+    if adjudication.relation in SYMMETRIC_RELATIONS:
+        return (focus_id, candidate_id) if focus_id <= candidate_id else (candidate_id, focus_id)
+    if adjudication.direction == "candidate_to_focus":
+        return candidate_id, focus_id
+    return focus_id, candidate_id
+
+
+class EdgeInferenceEngine:
+    """Per-node orchestration: gates → neighbours → one LLM call → inferred edges.
+
+    Constructed by :class:`~lithos.lcma.enrich.EnrichWorker` only when
+    ``lcma.llm`` is enabled. :meth:`maybe_infer` never raises — every failure
+    path logs, counts, and returns so the surrounding enrich item completes.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: LlmConfig,
+        client: LlmClient,
+        stats_store: StatsStore,
+        knowledge: KnowledgeManager,
+        search: SearchEngine,
+        intake: CorpusIntake,
+        edge_store: EdgeStore,
+        agent: str,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._stats_store = stats_store
+        self._knowledge = knowledge
+        self._search = search
+        self._intake = intake
+        self._edge_store = edge_store
+        self._agent = agent
+        self._calls_this_drain = 0
+
+    def reset_drain_counter(self) -> None:
+        """Called by the worker at the top of each drain cycle."""
+        self._calls_this_drain = 0
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    async def maybe_infer(self, node_id: str, trigger_types: object) -> None:
+        """Run typed-edge inference for *node_id* if every gate passes."""
+        try:
+            await self._maybe_infer(node_id, trigger_types)
+        except Exception:
+            # Inference is strictly additive; never let it fail the enrich item.
+            logger.exception("Edge inference failed unexpectedly for %s", node_id)
+
+    async def _maybe_infer(self, node_id: str, trigger_types: object) -> None:
+        if not isinstance(trigger_types, (list, set, tuple)) or not (
+            NOTE_CREATED in trigger_types or NOTE_UPDATED in trigger_types
+        ):
+            return  # cascade guard #2: edge-triggered drains never infer
+        if not self._knowledge.has_document(node_id):
+            return
+
+        try:
+            doc, _ = await self._knowledge.read(id=node_id)
+        except FileNotFoundError:
+            return
+        version = doc.metadata.version
+
+        if await self._stats_store.has_edge_inference(node_id, version, INFERENCE_VERSION):
+            self._skip("op_log")
+            return
+        if self._calls_this_drain >= self._config.max_calls_per_drain:
+            self._skip("call_cap")
+            return
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        tokens_spent, _calls = await self._stats_store.get_llm_spend(day)
+        if tokens_spent >= self._config.daily_token_budget:
+            self._skip("budget")
+            return
+
+        candidates = await self._gather_candidates(node_id, doc)
+        if not candidates:
+            # Neighbourhood evaluated and found empty at this content version —
+            # no token spend, no re-check until the note changes.
+            await self._stats_store.record_edge_inference(
+                node_id, version, INFERENCE_VERSION, model=self._config.model, edges_written=0
+            )
+            self._skip("no_candidates")
+            return
+
+        self._calls_this_drain += 1
+        messages = build_adjudication_prompt(
+            doc.title, doc.content, candidates, snippet_chars=self._config.snippet_chars
+        )
+        started = time.monotonic()
+        try:
+            result = await self._client.chat(messages)
+        except LlmError as exc:
+            # Outage semantics: complete the item without synthesis; the op-log
+            # stays absent so the node's next create/update retries.
+            logger.warning("LLM adjudication failed for %s: %s", node_id, exc)
+            self._count_call("error", started)
+            return
+
+        await self._stats_store.record_llm_spend(day, result.total_tokens)
+        if _HAS_TELEMETRY and _lithos_metrics is not None:
+            _lithos_metrics.lcma_llm_tokens.add(
+                result.total_tokens, {"estimated": str(result.estimated).lower()}
+            )
+
+        adjudications = parse_adjudications(result.text, len(candidates))
+        if adjudications is None:
+            # Tokens were genuinely spent — record the op-log row so a
+            # schema-incapable model can't re-burn the budget every drain.
+            logger.warning(
+                "Unparseable LLM adjudication for %s (model=%s)", node_id, self._config.model
+            )
+            await self._stats_store.record_edge_inference(
+                node_id, version, INFERENCE_VERSION, model=self._config.model, edges_written=0
+            )
+            self._count_call("parse_error", started)
+            return
+
+        namespace = self._namespace_of(node_id)
+        written = 0
+        for adjudication in adjudications:
+            if adjudication.confidence < self._config.confidence_floor:
+                continue
+            candidate = candidates[adjudication.candidate_index - 1]
+            from_id, to_id = edge_endpoints(node_id, candidate.node_id, adjudication)
+            await self._intake.assert_edge(
+                self._agent,
+                EdgeRequest(
+                    from_id=from_id,
+                    to_id=to_id,
+                    edge_type=adjudication.relation,
+                    weight=adjudication.confidence,
+                    namespace=namespace,
+                    provenance_actor=self._agent,
+                    provenance_type="inferred",
+                    evidence=json.dumps(
+                        {
+                            "rationale": adjudication.rationale,
+                            "model": self._config.model,
+                            "confidence": adjudication.confidence,
+                        }
+                    ),
+                ),
+                origin=EVENT_ORIGIN_ENRICH,
+            )
+            written += 1
+            if _HAS_TELEMETRY and _lithos_metrics is not None:
+                _lithos_metrics.lcma_inferred_edges_written.add(
+                    1, {"relation": adjudication.relation}
+                )
+
+        await self._stats_store.record_edge_inference(
+            node_id, version, INFERENCE_VERSION, model=self._config.model, edges_written=written
+        )
+        self._count_call("ok", started)
+        logger.info(
+            "Edge inference for %s: %d/%d judgements written (version=%d)",
+            node_id,
+            written,
+            len(adjudications),
+            version,
+        )
+
+    async def _gather_candidates(self, node_id: str, doc: KnowledgeDocument) -> list[NeighbourInfo]:
+        """Semantic k-NN → NeighbourInfo (cached meta + inferred-edge lookups) → pre-filter."""
+        focus_meta = self._knowledge.get_cached_meta(node_id)
+        if focus_meta is None:
+            return []
+
+        results = await asyncio.to_thread(
+            self._search.semantic_search,
+            query=f"{doc.title}\n{doc.content[:1000]}",
+            limit=self._config.neighbour_k * 3,
+        )
+
+        neighbours: list[NeighbourInfo] = []
+        for r in results:
+            meta = self._knowledge.get_cached_meta(r.id)
+            if meta is None:
+                continue
+            neighbours.append(
+                NeighbourInfo(
+                    node_id=r.id,
+                    title=r.title,
+                    snippet=r.snippet,
+                    similarity=r.similarity,
+                    namespace=meta.namespace,
+                    entities=frozenset(meta.entities),
+                    tags=frozenset(meta.tags),
+                    already_inferred=await self._has_inferred_edge(node_id, r.id),
+                )
+            )
+
+        return prefilter_candidates(
+            neighbours,
+            focus_id=node_id,
+            focus_namespace=focus_meta.namespace,
+            focus_entities=frozenset(focus_meta.entities),
+            focus_tags=frozenset(focus_meta.tags),
+            min_similarity=self._config.min_similarity,
+            max_similarity=self._config.max_similarity,
+            k=self._config.neighbour_k,
+        )
+
+    async def _has_inferred_edge(self, a: str, b: str) -> bool:
+        """True when an inferred-provenance edge already links *a* and *b* (either way)."""
+        for from_id, to_id in ((a, b), (b, a)):
+            for edge in await self._edge_store.list_edges(from_id=from_id, to_id=to_id):
+                if edge.get("provenance_type") == "inferred":
+                    return True
+        return False
+
+    def _namespace_of(self, node_id: str) -> str:
+        meta = self._knowledge.get_cached_meta(node_id)
+        return meta.namespace if meta is not None else "default"
+
+    def _skip(self, reason: str) -> None:
+        if _HAS_TELEMETRY and _lithos_metrics is not None:
+            _lithos_metrics.lcma_edge_inference_skips.add(1, {"reason": reason})
+        logger.debug("Edge inference skipped (%s)", reason)
+
+    def _count_call(self, outcome: str, started: float) -> None:
+        if _HAS_TELEMETRY and _lithos_metrics is not None:
+            _lithos_metrics.lcma_llm_calls.add(1, {"outcome": outcome})
+            _lithos_metrics.lcma_llm_call_duration.record(
+                (time.monotonic() - started) * 1000.0, {"outcome": outcome}
+            )

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -25,8 +25,10 @@ from lithos.events import (
     TASK_COMPLETED,
     LithosEvent,
 )
+from lithos.lcma.edge_inference import EdgeInferenceEngine
 from lithos.lcma.edge_reinforce import reinforce_related_edge
 from lithos.lcma.entities import ENTITY_EXTRACTOR_VERSION, extract_entities
+from lithos.lcma.llm import LlmClient
 from lithos.lcma.salience import DEFAULT_SALIENCE
 from lithos.lcma.salience import decay_amount as compute_decay_amount
 
@@ -39,6 +41,7 @@ if TYPE_CHECKING:
     from lithos.knowledge import KnowledgeManager
     from lithos.lcma.stats import StatsStore
     from lithos.provenance import ProvenanceProjection
+    from lithos.search import SearchEngine
     from lithos.telemetry import _LithosMetrics
 
 _lithos_metrics: _LithosMetrics | None = None
@@ -137,6 +140,7 @@ class EnrichWorker:
         knowledge: KnowledgeManager,
         coordination: CoordinationService,
         intake: CorpusIntake,
+        search: SearchEngine,
     ) -> None:
         self._config = config
         self._event_bus = event_bus
@@ -145,6 +149,21 @@ class EnrichWorker:
         self._knowledge = knowledge
         self._coordination = coordination
         self._intake = intake
+
+        # Typed-edge inference (WS1) — constructed only when an LLM endpoint is
+        # configured; None keeps the whole synthesis path a no-op.
+        self._edge_inference: EdgeInferenceEngine | None = None
+        if config.llm.enabled:
+            self._edge_inference = EdgeInferenceEngine(
+                config=config.llm,
+                client=LlmClient(config.llm),
+                stats_store=stats_store,
+                knowledge=knowledge,
+                search=search,
+                intake=intake,
+                edge_store=projection.edge_store,
+                agent=ENRICH_AGENT,
+            )
 
         self._queue: asyncio.Queue[LithosEvent] | None = None
         self._consumer_task: asyncio.Task[None] | None = None
@@ -182,6 +201,10 @@ class EnrichWorker:
         self._consumer_task = None
         self._drain_task = None
         self._sweep_task = None
+
+        if self._edge_inference is not None:
+            await self._edge_inference.close()
+
         logger.info("EnrichWorker stopped")
 
     # ------------------------------------------------------------------
@@ -289,6 +312,8 @@ class EnrichWorker:
     async def drain(self) -> None:
         """Process pending nodes and tasks from enrich_queue."""
         max_attempts = self._config.max_enrich_attempts
+        if self._edge_inference is not None:
+            self._edge_inference.reset_drain_counter()
 
         # --- Node-level enrichment ---
         node_entries = await self._stats_store.drain_pending_nodes(max_attempts=max_attempts)
@@ -450,6 +475,11 @@ class EnrichWorker:
             NOTE_CREATED in trigger_types or NOTE_UPDATED in trigger_types
         ):
             await self._extract_entities(node_id)
+
+        # --- Typed-edge inference (WS1; engine gates on trigger type, op-log,
+        # call cap, and daily token budget internally and never raises) ---
+        if self._edge_inference is not None:
+            await self._edge_inference.maybe_infer(node_id, trigger_types)
 
         logger.debug(
             "EnrichWorker: node enrichment complete",

--- a/src/lithos/lcma/enrich.py
+++ b/src/lithos/lcma/enrich.py
@@ -161,7 +161,6 @@ class EnrichWorker:
                 knowledge=knowledge,
                 search=search,
                 intake=intake,
-                edge_store=projection.edge_store,
                 agent=ENRICH_AGENT,
             )
 

--- a/tests/test_edge_inference.py
+++ b/tests/test_edge_inference.py
@@ -5,6 +5,9 @@ The EdgeInferenceEngine is tested over a real StatsStore/EdgeStore/CorpusIntake 
 temp dirs with an LlmClient backed by httpx.MockTransport — no network, no model.
 The cascade-regression tests prove the origin-stamp guard: an inferred-edge write
 must never re-enqueue its endpoints through the enrich worker's event handler.
+The authority-boundary tests prove inferred writes can never displace asserted
+rows or manually resolved conflicts, and that document/policy/purge resets
+genuinely re-adjudicate.
 """
 
 from __future__ import annotations
@@ -51,7 +54,6 @@ def _neighbour(node_id: str = "n1", **overrides: Any) -> NeighbourInfo:
         "namespace": "default",
         "entities": frozenset(),
         "tags": frozenset(),
-        "already_inferred": False,
     }
     defaults.update(overrides)
     return NeighbourInfo(**defaults)
@@ -72,12 +74,11 @@ def _prefilter(neighbours: list[NeighbourInfo], **overrides: Any) -> list[Neighb
 
 
 class TestPrefilterCandidates:
-    def test_drops_self_cross_namespace_and_already_inferred(self) -> None:
+    def test_drops_self_and_cross_namespace(self) -> None:
         kept = _prefilter(
             [
                 _neighbour("focus"),  # self
                 _neighbour("other-ns", namespace="projects"),
-                _neighbour("done", already_inferred=True),
                 _neighbour("ok"),
             ]
         )
@@ -146,31 +147,106 @@ class TestParseAdjudications:
                 ]
             }
         )
-        parsed = parse_adjudications(text, 2)
-        assert parsed == [Adjudication(1, "supports", "candidate_to_focus", 0.8, "because")]
+        parsed = parse_adjudications(text, 1)
+        assert parsed == ([Adjudication(1, "supports", "candidate_to_focus", 0.8, "because")], 0)
 
     def test_fenced_and_bare_list_accepted(self) -> None:
-        entry = {"candidate": 1, "relation": "refines", "confidence": 0.7}
+        entry = {
+            "candidate": 1,
+            "relation": "refines",
+            "direction": "focus_to_candidate",
+            "confidence": 0.7,
+        }
         fenced = f"```json\n{json.dumps({'judgements': [entry]})}\n```"
         assert parse_adjudications(fenced, 1) is not None
         bare = json.dumps([entry])
         parsed = parse_adjudications(bare, 1)
-        assert parsed is not None and parsed[0].relation == "refines"
-        # Missing/invalid direction defaults to focus_to_candidate.
-        assert parsed[0].direction == "focus_to_candidate"
+        assert parsed is not None
+        adjudications, problems = parsed
+        assert adjudications[0].relation == "refines"
+        assert problems == 0
+
+    def test_directional_relation_without_direction_is_dropped(self) -> None:
+        """Round-1 review: direction is never invented — an inverted supports/
+        depends_on edge is worse than no edge."""
+        entries = [
+            {"candidate": 1, "relation": "refines", "confidence": 0.7},  # no direction
+            {"candidate": 2, "relation": "supports", "direction": "sideways", "confidence": 0.8},
+        ]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 2)
+        assert parsed == ([], 4)  # 2 dropped entries + 2 uncovered candidates
+
+    def test_symmetric_relation_ignores_direction(self) -> None:
+        entries = [{"candidate": 1, "relation": "contradicts", "confidence": 0.9}]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 1)
+        assert parsed is not None
+        adjudications, problems = parsed
+        assert adjudications[0].relation == "contradicts"
+        assert problems == 0
+
+    def test_fractional_and_boolean_indexes_rejected(self) -> None:
+        """1.9 must not silently become candidate 1; True must not become 1."""
+        entries = [
+            {
+                "candidate": 1.9,
+                "relation": "supports",
+                "direction": "focus_to_candidate",
+                "confidence": 0.8,
+            },
+            {
+                "candidate": True,
+                "relation": "supports",
+                "direction": "focus_to_candidate",
+                "confidence": 0.8,
+            },
+        ]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 2)
+        assert parsed == ([], 4)  # 2 bad indexes + 2 uncovered candidates
+
+    def test_duplicate_candidate_keeps_first_and_counts_problem(self) -> None:
+        entries = [
+            {
+                "candidate": 1,
+                "relation": "supports",
+                "direction": "focus_to_candidate",
+                "confidence": 0.8,
+            },
+            {"candidate": 1, "relation": "contradicts", "confidence": 0.9},  # duplicate
+        ]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 1)
+        assert parsed is not None
+        adjudications, problems = parsed
+        assert len(adjudications) == 1 and adjudications[0].relation == "supports"
+        assert problems == 1
+
+    def test_missing_coverage_counts_problems(self) -> None:
+        """The prompt demands every candidate exactly once; silence is a
+        contract violation, while an explicit "none" covers its candidate."""
+        entries = [
+            {"candidate": 1, "relation": "none", "confidence": 0.9},
+        ]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 3)
+        assert parsed == ([], 2)  # candidates 2 and 3 never covered
 
     def test_invalid_entries_dropped_individually(self) -> None:
         entries = [
-            {"candidate": 1, "relation": "none", "confidence": 0.9},  # deliberate none
-            {"candidate": 1, "relation": "made_up", "confidence": 0.9},  # unknown vocab
+            {"candidate": 1, "relation": "none", "confidence": 0.9},  # deliberate none: covers 1
+            {"candidate": 2, "relation": "made_up", "confidence": 0.9},  # unknown vocab
             {"candidate": 99, "relation": "supports", "confidence": 0.9},  # bad index
-            {"candidate": 1, "relation": "supports", "confidence": 1.7},  # bad confidence
-            {"candidate": 1, "relation": "supports", "confidence": "high"},  # non-numeric
-            {"candidate": 2, "relation": "depends_on", "confidence": 0.75},  # valid
+            {"candidate": 2, "relation": "supports", "confidence": 1.7},  # bad confidence
+            {
+                "candidate": 3,
+                "relation": "depends_on",
+                "direction": "focus_to_candidate",
+                "confidence": 0.75,
+            },  # valid
         ]
-        parsed = parse_adjudications(json.dumps({"judgements": entries}), 2)
-        assert parsed is not None and len(parsed) == 1
-        assert parsed[0].relation == "depends_on"
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 3)
+        assert parsed is not None
+        adjudications, problems = parsed
+        assert len(adjudications) == 1
+        assert adjudications[0].relation == "depends_on"
+        assert problems == 4  # made_up + bad index + bad confidence + candidate 2 uncovered
 
     def test_garbage_returns_none(self) -> None:
         assert parse_adjudications("I think these notes are related!", 2) is None
@@ -306,7 +382,6 @@ class _EngineHarness:
                 search_results if search_results is not None else [_semantic_hit("cand")]
             ),
             intake=self.intake,
-            edge_store=edge_store,
             agent="lithos-enrich",
         )
 
@@ -508,6 +583,267 @@ class TestEdgeInferenceEngine:
             await harness.close()
         assert await edge_store.list_edges(from_id="focus") == []
         assert await stats_store.has_edge_inference("focus", 1, 1)
+
+
+class TestAuthorityBoundary:
+    """Round-1 review finding 1: inferred writes must never displace asserted
+    rows or manually resolved conflicts — provenance is a one-way boundary."""
+
+    async def test_asserted_edge_survives_inference(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        from lithos.intake import EdgeRequest
+
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        await harness.intake.assert_edge(
+            "human-reviewer",
+            EdgeRequest(
+                from_id="focus",
+                to_id="cand",
+                edge_type="supports",
+                weight=1.0,
+                namespace="default",
+                provenance_actor="human-reviewer",
+                provenance_type="asserted",
+                evidence="manual",
+            ),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert len(edges) == 1
+        edge = edges[0]
+        # Every authoritative column untouched by the blocked inferred write.
+        assert edge["provenance_type"] == "asserted"
+        assert edge["provenance_actor"] == "human-reviewer"
+        assert edge["evidence"] == "manual"
+        assert edge["weight"] == pytest.approx(1.0)
+        # The run itself completed: op-log recorded with nothing written.
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+
+    async def test_resolved_conflict_survives_reinference(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        """A manually resolved inferred contradiction keeps its resolution."""
+        contradiction = {
+            "candidate": 1,
+            "relation": "contradicts",
+            "confidence": 0.95,
+            "rationale": "still contradicts",
+        }
+        # Canonical symmetric endpoints for (focus, cand): "cand" <= "focus".
+        await edge_store.upsert(
+            from_id="cand",
+            to_id="focus",
+            edge_type="contradicts",
+            weight=0.9,
+            namespace="default",
+            provenance_actor="human-reviewer",
+            provenance_type="inferred",
+            evidence="original rationale",
+            conflict_state="resolved",
+        )
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([contradiction])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+
+        edges = await edge_store.list_edges(from_id="cand", to_id="focus")
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge["conflict_state"] == "resolved"
+        assert edge["provenance_actor"] == "human-reviewer"
+        assert edge["evidence"] == "original rationale"
+        assert edge["weight"] == pytest.approx(0.9)
+
+
+class TestReinference:
+    """Round-1 review finding 2: document/policy/purge resets must genuinely
+    re-adjudicate — existing inferred pairs are refreshed, not excluded."""
+
+    @staticmethod
+    def _mutable_handler(judgement: dict[str, Any]):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_adjudication_body([dict(judgement)]))
+
+        return handler
+
+    async def test_document_version_bump_readjudicates_and_refreshes(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        judgement = dict(_GOOD_JUDGEMENT)
+        harness = _EngineHarness(
+            test_config, stats_store, edge_store, handler=self._mutable_handler(judgement)
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            assert harness.calls["n"] == 1
+
+            # The note changes: version 2, and the model now judges differently.
+            harness.knowledge.read = AsyncMock(return_value=(_doc("focus", version=2), False))
+            judgement["confidence"] = 0.9
+            judgement["rationale"] = "updated evidence"
+            await harness.engine.maybe_infer("focus", [NOTE_UPDATED])
+            assert harness.calls["n"] == 2  # genuinely re-adjudicated
+        finally:
+            await harness.close()
+
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert len(edges) == 1  # refreshed in place, not duplicated
+        assert edges[0]["weight"] == pytest.approx(0.9)
+        assert json.loads(str(edges[0]["evidence"]))["rationale"] == "updated evidence"
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+        assert await stats_store.has_edge_inference("focus", 2, 1)
+
+    async def test_ledger_purge_enables_actual_readjudication(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            assert harness.calls["n"] == 1
+            purged = await stats_store.purge_edge_inference_log()
+            assert purged == 1
+            await harness.engine.maybe_infer("focus", [NOTE_UPDATED])
+            assert harness.calls["n"] == 2  # operator reset re-adjudicates
+        finally:
+            await harness.close()
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert len(edges) == 1  # same pair refreshed via the inferred upsert
+
+    async def test_inference_version_bump_readjudicates(
+        self,
+        test_config: LithosConfig,
+        stats_store: StatsStore,
+        edge_store: EdgeStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            assert harness.calls["n"] == 1
+            monkeypatch.setattr("lithos.lcma.edge_inference.INFERENCE_VERSION", 2)
+            await harness.engine.maybe_infer("focus", [NOTE_UPDATED])
+            assert harness.calls["n"] == 2  # policy bump re-adjudicates
+        finally:
+            await harness.close()
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+        assert await stats_store.has_edge_inference("focus", 1, 2)
+
+    async def test_changed_relation_accumulates_new_edge(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        """A re-adjudication that changes relation type keys a NEW edge; the
+        old one remains (additive semantics — reconciliation of superseded
+        inferred edges is slice-2 sweep scope, per the PR1 review record)."""
+        judgement = dict(_GOOD_JUDGEMENT)
+        harness = _EngineHarness(
+            test_config, stats_store, edge_store, handler=self._mutable_handler(judgement)
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            harness.knowledge.read = AsyncMock(return_value=(_doc("focus", version=2), False))
+            judgement["relation"] = "refines"
+            await harness.engine.maybe_infer("focus", [NOTE_UPDATED])
+        finally:
+            await harness.close()
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert {e["type"] for e in edges} == {"supports", "refines"}
+
+    async def test_stale_version_discards_results(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        """Round-1 review finding 4: a note updated mid-LLM-call must not get
+        stale edges or a stale completion marker; spend is still recorded."""
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        # First read (prompt build) sees v1; the post-call staleness re-read
+        # sees v2 — the note changed while the LLM call was in flight.
+        harness.knowledge.read = AsyncMock(
+            side_effect=[(_doc("focus", version=1), False), (_doc("focus", version=2), False)]
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+
+        assert harness.calls["n"] == 1  # tokens were spent...
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert (await stats_store.get_llm_spend(day))[0] == 250  # ...and recorded
+        assert await edge_store.list_edges(from_id="focus") == []  # no stale edges
+        # No completion marker for either version: the queued v2 drain re-runs.
+        assert not await stats_store.has_edge_inference("focus", 1, 1)
+        assert not await stats_store.has_edge_inference("focus", 2, 1)
+
+
+class TestWorkerLifecycle:
+    """Production construction: engine exists iff llm enabled; stop() closes it."""
+
+    async def test_enabled_worker_builds_engine_and_stop_closes_it(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        from lithos.lcma.enrich import EnrichWorker
+
+        test_config.lcma.llm = LlmConfig(base_url="http://ollama:11434/v1", model="m")
+        worker = EnrichWorker(
+            config=test_config.lcma,
+            event_bus=EventBus(test_config.events),
+            stats_store=stats_store,
+            projection=MagicMock(edge_store=edge_store),
+            knowledge=MagicMock(),
+            coordination=AsyncMock(),
+            intake=MagicMock(),
+            search=MagicMock(),
+        )
+        assert worker._edge_inference is not None
+        await worker.stop()  # must close the engine's httpx client without error
+
+    async def test_disabled_worker_has_no_engine(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        from lithos.lcma.enrich import EnrichWorker
+
+        test_config.lcma.llm = LlmConfig()
+        worker = EnrichWorker(
+            config=test_config.lcma,
+            event_bus=EventBus(test_config.events),
+            stats_store=stats_store,
+            projection=MagicMock(edge_store=edge_store),
+            knowledge=MagicMock(),
+            coordination=AsyncMock(),
+            intake=MagicMock(),
+            search=MagicMock(),
+        )
+        assert worker._edge_inference is None
+        await worker.stop()
 
 
 class TestCascadeGuard:

--- a/tests/test_edge_inference.py
+++ b/tests/test_edge_inference.py
@@ -1,0 +1,625 @@
+"""Tests for LLM-adjudicated typed-edge inference (WS1 slice 1).
+
+Pure functions (pre-filter, prompt, parse, endpoint resolution) are tested directly.
+The EdgeInferenceEngine is tested over a real StatsStore/EdgeStore/CorpusIntake on
+temp dirs with an LlmClient backed by httpx.MockTransport — no network, no model.
+The cascade-regression tests prove the origin-stamp guard: an inferred-edge write
+must never re-enqueue its endpoints through the enrich worker's event handler.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from lithos.config import LithosConfig, LlmConfig
+from lithos.corpus_index import CachedMeta
+from lithos.edge_store import EdgeStore
+from lithos.events import EDGE_UPSERTED, NOTE_CREATED, NOTE_UPDATED, EventBus
+from lithos.frontmatter_codec import KnowledgeDocument, KnowledgeMetadata
+from lithos.intake import CorpusIntake
+from lithos.lcma.edge_inference import (
+    Adjudication,
+    EdgeInferenceEngine,
+    NeighbourInfo,
+    build_adjudication_prompt,
+    edge_endpoints,
+    parse_adjudications,
+    prefilter_candidates,
+)
+from lithos.lcma.llm import LlmClient
+from lithos.lcma.stats import StatsStore
+from lithos.search import SemanticResult
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def _neighbour(node_id: str = "n1", **overrides: Any) -> NeighbourInfo:
+    defaults: dict[str, Any] = {
+        "node_id": node_id,
+        "title": f"Note {node_id}",
+        "snippet": "snippet",
+        "similarity": 0.6,
+        "namespace": "default",
+        "entities": frozenset(),
+        "tags": frozenset(),
+        "already_inferred": False,
+    }
+    defaults.update(overrides)
+    return NeighbourInfo(**defaults)
+
+
+def _prefilter(neighbours: list[NeighbourInfo], **overrides: Any) -> list[NeighbourInfo]:
+    defaults: dict[str, Any] = {
+        "focus_id": "focus",
+        "focus_namespace": "default",
+        "focus_entities": frozenset(),
+        "focus_tags": frozenset(),
+        "min_similarity": 0.35,
+        "max_similarity": 0.92,
+        "k": 5,
+    }
+    defaults.update(overrides)
+    return prefilter_candidates(neighbours, **defaults)
+
+
+class TestPrefilterCandidates:
+    def test_drops_self_cross_namespace_and_already_inferred(self) -> None:
+        kept = _prefilter(
+            [
+                _neighbour("focus"),  # self
+                _neighbour("other-ns", namespace="projects"),
+                _neighbour("done", already_inferred=True),
+                _neighbour("ok"),
+            ]
+        )
+        assert [n.node_id for n in kept] == ["ok"]
+
+    def test_similarity_band_is_inclusive(self) -> None:
+        kept = _prefilter(
+            [
+                _neighbour("too-far", similarity=0.34),
+                _neighbour("low-edge", similarity=0.35),
+                _neighbour("high-edge", similarity=0.92),
+                _neighbour("near-dup", similarity=0.93),
+            ]
+        )
+        assert {n.node_id for n in kept} == {"low-edge", "high-edge"}
+
+    def test_entity_and_tag_overlap_boost_ranking(self) -> None:
+        # Same similarity; entity overlap must outrank tag overlap outrank none.
+        kept = _prefilter(
+            [
+                _neighbour("plain", similarity=0.6),
+                _neighbour("tagged", similarity=0.6, tags=frozenset({"t"})),
+                _neighbour("entity", similarity=0.6, entities=frozenset({"E"})),
+            ],
+            focus_entities=frozenset({"E"}),
+            focus_tags=frozenset({"t"}),
+        )
+        assert [n.node_id for n in kept] == ["entity", "tagged", "plain"]
+
+    def test_k_caps_survivors(self) -> None:
+        many = [_neighbour(f"n{i}", similarity=0.5 + i * 0.01) for i in range(10)]
+        kept = _prefilter(many, k=3)
+        assert len(kept) == 3
+        assert kept[0].similarity > kept[-1].similarity
+
+
+class TestBuildAdjudicationPrompt:
+    def test_numbers_candidates_and_truncates(self) -> None:
+        messages = build_adjudication_prompt(
+            "Focus title",
+            "X" * 2000,
+            [_neighbour("a", snippet="Y" * 2000), _neighbour("b")],
+            snippet_chars=100,
+        )
+        assert messages[0].role == "system"
+        user = messages[1].content
+        assert "Focus title" in user
+        assert "X" * 100 in user and "X" * 101 not in user
+        assert "[1] Title: Note a" in user
+        assert "[2] Title: Note b" in user
+        assert "Y" * 100 in user and "Y" * 101 not in user
+
+
+class TestParseAdjudications:
+    def test_valid_envelope(self) -> None:
+        text = json.dumps(
+            {
+                "judgements": [
+                    {
+                        "candidate": 1,
+                        "relation": "supports",
+                        "direction": "candidate_to_focus",
+                        "confidence": 0.8,
+                        "rationale": "because",
+                    }
+                ]
+            }
+        )
+        parsed = parse_adjudications(text, 2)
+        assert parsed == [Adjudication(1, "supports", "candidate_to_focus", 0.8, "because")]
+
+    def test_fenced_and_bare_list_accepted(self) -> None:
+        entry = {"candidate": 1, "relation": "refines", "confidence": 0.7}
+        fenced = f"```json\n{json.dumps({'judgements': [entry]})}\n```"
+        assert parse_adjudications(fenced, 1) is not None
+        bare = json.dumps([entry])
+        parsed = parse_adjudications(bare, 1)
+        assert parsed is not None and parsed[0].relation == "refines"
+        # Missing/invalid direction defaults to focus_to_candidate.
+        assert parsed[0].direction == "focus_to_candidate"
+
+    def test_invalid_entries_dropped_individually(self) -> None:
+        entries = [
+            {"candidate": 1, "relation": "none", "confidence": 0.9},  # deliberate none
+            {"candidate": 1, "relation": "made_up", "confidence": 0.9},  # unknown vocab
+            {"candidate": 99, "relation": "supports", "confidence": 0.9},  # bad index
+            {"candidate": 1, "relation": "supports", "confidence": 1.7},  # bad confidence
+            {"candidate": 1, "relation": "supports", "confidence": "high"},  # non-numeric
+            {"candidate": 2, "relation": "depends_on", "confidence": 0.75},  # valid
+        ]
+        parsed = parse_adjudications(json.dumps({"judgements": entries}), 2)
+        assert parsed is not None and len(parsed) == 1
+        assert parsed[0].relation == "depends_on"
+
+    def test_garbage_returns_none(self) -> None:
+        assert parse_adjudications("I think these notes are related!", 2) is None
+        assert parse_adjudications('{"judgements": "nope"}', 2) is None
+
+
+class TestEdgeEndpoints:
+    def test_directed_follows_judged_direction(self) -> None:
+        fwd = Adjudication(1, "supports", "focus_to_candidate", 0.8, "")
+        rev = Adjudication(1, "supports", "candidate_to_focus", 0.8, "")
+        assert edge_endpoints("f", "c", fwd) == ("f", "c")
+        assert edge_endpoints("f", "c", rev) == ("c", "f")
+
+    def test_symmetric_canonicalizes(self) -> None:
+        adj = Adjudication(1, "contradicts", "candidate_to_focus", 0.8, "")
+        assert edge_endpoints("b-focus", "a-cand", adj) == ("a-cand", "b-focus")
+        assert edge_endpoints("a-focus", "b-cand", adj) == ("a-focus", "b-cand")
+
+
+# ---------------------------------------------------------------------------
+# EdgeInferenceEngine over real stores + MockTransport
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 7, 25, tzinfo=UTC)
+
+
+def _doc(node_id: str, *, version: int = 1) -> KnowledgeDocument:
+    metadata = KnowledgeMetadata(
+        id=node_id,
+        title=f"Note {node_id}",
+        author="tester",
+        created_at=NOW,
+        updated_at=NOW,
+        version=version,
+    )
+    return KnowledgeDocument(
+        id=node_id,
+        title=metadata.title,
+        content="Some content about caching strategies.",
+        metadata=metadata,
+        path=Path(f"{node_id}.md"),
+    )
+
+
+def _cached_meta(namespace: str = "default") -> CachedMeta:
+    return CachedMeta(
+        title="t",
+        author="tester",
+        tags=[],
+        updated_at=NOW,
+        path=Path("x.md"),
+        namespace=namespace,
+    )
+
+
+def _mock_knowledge(doc: KnowledgeDocument) -> MagicMock:
+    km = MagicMock()
+    km.has_document = MagicMock(return_value=True)
+    km.read = AsyncMock(return_value=(doc, False))
+    km.get_cached_meta = MagicMock(return_value=_cached_meta())
+    return km
+
+
+def _mock_search(results: list[SemanticResult]) -> MagicMock:
+    search = MagicMock()
+    search.semantic_search = MagicMock(return_value=results)
+    return search
+
+
+def _semantic_hit(node_id: str, similarity: float = 0.6) -> SemanticResult:
+    return SemanticResult(
+        id=node_id,
+        title=f"Note {node_id}",
+        snippet="neighbour snippet",
+        similarity=similarity,
+        path=f"{node_id}.md",
+    )
+
+
+def _adjudication_body(judgements: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "choices": [
+            {"message": {"role": "assistant", "content": json.dumps({"judgements": judgements})}}
+        ],
+        "usage": {"prompt_tokens": 200, "completion_tokens": 50},
+    }
+
+
+class _EngineHarness:
+    """Real StatsStore/EdgeStore/intake + mocked knowledge/search + MockTransport LLM."""
+
+    def __init__(
+        self,
+        test_config: LithosConfig,
+        stats_store: StatsStore,
+        edge_store: EdgeStore,
+        *,
+        handler: Any,
+        llm_overrides: dict[str, Any] | None = None,
+        search_results: list[SemanticResult] | None = None,
+        doc: KnowledgeDocument | None = None,
+    ) -> None:
+        self.calls = {"n": 0}
+
+        def counting_handler(request: httpx.Request) -> httpx.Response:
+            self.calls["n"] += 1
+            return handler(request)
+
+        llm_config = LlmConfig(
+            base_url="http://ollama:11434/v1",
+            model="test-model",
+            **(llm_overrides or {}),
+        )
+        self.doc = doc or _doc("focus")
+        self.knowledge = _mock_knowledge(self.doc)
+        self.event_bus = EventBus(test_config.events)
+        self.intake = CorpusIntake(
+            knowledge=self.knowledge,
+            search=MagicMock(),
+            graph=MagicMock(),
+            coordination=AsyncMock(),
+            event_bus=self.event_bus,
+            edge_store=edge_store,
+        )
+        self.edge_store = edge_store
+        self.stats_store = stats_store
+        self.engine = EdgeInferenceEngine(
+            config=llm_config,
+            client=LlmClient(llm_config, transport=httpx.MockTransport(counting_handler)),
+            stats_store=stats_store,
+            knowledge=self.knowledge,
+            search=_mock_search(
+                search_results if search_results is not None else [_semantic_hit("cand")]
+            ),
+            intake=self.intake,
+            edge_store=edge_store,
+            agent="lithos-enrich",
+        )
+
+    async def close(self) -> None:
+        await self.engine.close()
+
+
+@pytest.fixture
+async def stats_store(test_config: LithosConfig):
+    store = StatsStore(test_config)
+    await store.open()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest.fixture
+async def edge_store(test_config: LithosConfig):
+    store = EdgeStore(test_config)
+    await store.open()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+_GOOD_JUDGEMENT = {
+    "candidate": 1,
+    "relation": "supports",
+    "direction": "focus_to_candidate",
+    "confidence": 0.8,
+    "rationale": "focus provides evidence",
+}
+
+
+class TestEdgeInferenceEngine:
+    async def test_happy_path_writes_inferred_edge_and_ledgers(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge["type"] == "supports"
+        assert edge["weight"] == pytest.approx(0.8)
+        assert edge["provenance_type"] == "inferred"
+        assert edge["provenance_actor"] == "lithos-enrich"
+        evidence = json.loads(str(edge["evidence"]))
+        assert evidence["model"] == "test-model"
+        assert evidence["rationale"] == "focus provides evidence"
+
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert await stats_store.get_llm_spend(day) == (250, 1)
+
+    async def test_op_log_short_circuits_second_run(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            await harness.engine.maybe_infer("focus", [NOTE_UPDATED])
+        finally:
+            await harness.close()
+        assert harness.calls["n"] == 1  # second run skipped via op-log
+
+    async def test_edge_triggers_never_infer(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [EDGE_UPSERTED])
+            await harness.engine.maybe_infer("focus", "note.created")  # non-collection shape
+        finally:
+            await harness.close()
+        assert harness.calls["n"] == 0
+        assert not await stats_store.has_edge_inference("focus", 1, 1)
+
+    async def test_budget_exhausted_skips_without_op_log(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        await stats_store.record_llm_spend(day, 999_999)
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+        assert harness.calls["n"] == 0
+        # No op-log: the node retries once budget frees up (next create/update).
+        assert not await stats_store.has_edge_inference("focus", 1, 1)
+
+    async def test_call_cap_skips_and_reset_reopens(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+            llm_overrides={"max_calls_per_drain": 0},
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            assert harness.calls["n"] == 0
+        finally:
+            await harness.close()
+
+    async def test_llm_error_completes_without_op_log(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("endpoint down")
+
+        harness = _EngineHarness(test_config, stats_store, edge_store, handler=handler)
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])  # must not raise
+        finally:
+            await harness.close()
+        assert not await stats_store.has_edge_inference("focus", 1, 1)
+        assert await edge_store.list_edges(from_id="focus") == []
+
+    async def test_parse_failure_records_op_log(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        body = {
+            "choices": [{"message": {"role": "assistant", "content": "not json at all"}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 10},
+        }
+        harness = _EngineHarness(
+            test_config, stats_store, edge_store, handler=lambda req: httpx.Response(200, json=body)
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+        # Tokens were spent -> op-log recorded so the budget can't be re-burned.
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert (await stats_store.get_llm_spend(day))[0] == 110
+        assert await edge_store.list_edges(from_id="focus") == []
+
+    async def test_no_candidates_records_op_log_without_call(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([])),
+            search_results=[],
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+        assert harness.calls["n"] == 0
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+
+    async def test_confidence_floor_filters_judgements(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        weak = dict(_GOOD_JUDGEMENT, confidence=0.4)
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([weak])),
+        )
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+        finally:
+            await harness.close()
+        assert await edge_store.list_edges(from_id="focus") == []
+        assert await stats_store.has_edge_inference("focus", 1, 1)
+
+
+class TestCascadeGuard:
+    """The origin stamp must stop inferred-edge events from re-enqueuing endpoints."""
+
+    async def test_inferred_edge_event_is_origin_stamped_and_dropped(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        from lithos.lcma.enrich import EnrichWorker
+
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        worker = EnrichWorker(
+            config=test_config.lcma,
+            event_bus=harness.event_bus,
+            stats_store=stats_store,
+            projection=MagicMock(edge_store=edge_store),
+            knowledge=harness.knowledge,
+            coordination=AsyncMock(),
+            intake=harness.intake,
+            search=MagicMock(),
+        )
+        queue = harness.event_bus.subscribe(event_types=[EDGE_UPSERTED])
+        try:
+            await harness.engine.maybe_infer("focus", [NOTE_CREATED])
+            event = queue.get_nowait()
+            assert event.origin == "enrich"
+
+            before = await stats_store.drain_pending_nodes(max_attempts=3)
+            assert before == []  # clean slate
+            await worker._handle_event(event)
+            after = await stats_store.drain_pending_nodes(max_attempts=3)
+            assert after == []  # origin-stamped event re-enqueued nothing
+        finally:
+            harness.event_bus.unsubscribe(queue)
+            await harness.close()
+
+    async def test_unstamped_edge_event_would_reenqueue(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        """Counterfactual proving the guard is load-bearing: the same event without
+        the origin stamp re-enqueues both endpoints."""
+        from lithos.events import make_edge_upserted_event
+        from lithos.lcma.enrich import EnrichWorker
+
+        km = MagicMock()
+        km.has_document = MagicMock(return_value=True)
+        worker = EnrichWorker(
+            config=test_config.lcma,
+            event_bus=EventBus(test_config.events),
+            stats_store=stats_store,
+            projection=MagicMock(edge_store=edge_store),
+            knowledge=km,
+            coordination=AsyncMock(),
+            intake=MagicMock(),
+            search=MagicMock(),
+        )
+        event = make_edge_upserted_event(
+            agent="someone",
+            edge_id="e1",
+            from_id="focus",
+            to_id="cand",
+            edge_type="supports",
+            namespace="default",
+        )
+        await worker._handle_event(event)
+        entries = await stats_store.drain_pending_nodes(max_attempts=3)
+        assert {e["node_id"] for e in entries} == {"focus", "cand"}
+
+
+class TestDrainPathWiring:
+    """End-to-end through the worker's drain loop: enqueue -> drain -> inferred edge."""
+
+    async def test_drain_runs_inference_and_resets_call_counter(
+        self, test_config: LithosConfig, stats_store: StatsStore, edge_store: EdgeStore
+    ) -> None:
+        from lithos.lcma.enrich import EnrichWorker
+
+        harness = _EngineHarness(
+            test_config,
+            stats_store,
+            edge_store,
+            handler=lambda req: httpx.Response(200, json=_adjudication_body([_GOOD_JUDGEMENT])),
+        )
+        harness.knowledge.get_doc_sources = MagicMock(return_value=[])
+        worker = EnrichWorker(
+            config=test_config.lcma,
+            event_bus=harness.event_bus,
+            stats_store=stats_store,
+            projection=MagicMock(edge_store=edge_store, reconcile_node=AsyncMock()),
+            knowledge=harness.knowledge,
+            coordination=AsyncMock(),
+            intake=harness.intake,
+            search=MagicMock(),
+        )
+        # Inject the MockTransport-backed engine (production wiring builds its own
+        # client; tests need the seam) and pre-spend the drain counter to prove
+        # drain() resets it before processing.
+        worker._edge_inference = harness.engine
+        harness.engine._calls_this_drain = 999
+        worker._extract_entities = AsyncMock()  # keep spaCy out of this test
+
+        await stats_store.enqueue(NOTE_CREATED, node_id="focus")
+        try:
+            await worker.drain()
+        finally:
+            await harness.close()
+
+        edges = await edge_store.list_edges(from_id="focus", to_id="cand")
+        assert len(edges) == 1 and edges[0]["provenance_type"] == "inferred"
+        assert await stats_store.has_edge_inference("focus", 1, 1)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import sqlite3
+from typing import ClassVar
 
 import pytest
 import pytest_asyncio
@@ -268,6 +269,74 @@ class TestUpsertAndList:
         assert await edge_store.count() == 1
         assert await edge_store.count(namespace="ns") == 1
         assert await edge_store.count(namespace="other") == 0
+
+
+class TestUpsertInferred:
+    """upsert_inferred (WS1 PR2): the one-way authority boundary at the store."""
+
+    _KEY: ClassVar[dict[str, str]] = {
+        "from_id": "a",
+        "to_id": "b",
+        "edge_type": "supports",
+        "namespace": "default",
+    }
+
+    async def _seed(self, edge_store, *, provenance_type, conflict_state=None):
+        return await edge_store.upsert(
+            **self._KEY,
+            weight=1.0,
+            provenance_actor="human",
+            provenance_type=provenance_type,
+            evidence="manual",
+            conflict_state=conflict_state,
+        )
+
+    async def _inferred(self, edge_store):
+        return await edge_store.upsert_inferred(
+            **self._KEY, weight=0.7, provenance_actor="lithos-enrich", evidence="llm"
+        )
+
+    async def test_inserts_fresh_row_as_inferred(self, edge_store) -> None:
+        edge_id = await self._inferred(edge_store)
+        assert edge_id is not None
+        edge = await edge_store.get_edge(edge_id)
+        assert edge is not None
+        assert edge["provenance_type"] == "inferred"
+        assert edge["conflict_state"] is None
+
+    async def test_refreshes_existing_inferred_row(self, edge_store) -> None:
+        first = await self._inferred(edge_store)
+        second = await edge_store.upsert_inferred(
+            **self._KEY, weight=0.9, provenance_actor="lithos-enrich", evidence="llm-v2"
+        )
+        assert second == first  # same row updated, not duplicated
+        edge = await edge_store.get_edge(str(first))
+        assert edge is not None
+        assert edge["weight"] == pytest.approx(0.9)
+        assert edge["evidence"] == "llm-v2"
+
+    @pytest.mark.parametrize("provenance_type", ["asserted", "projection", None])
+    async def test_blocked_by_non_inferred_rows(self, edge_store, provenance_type) -> None:
+        """Asserted, projection-owned, and legacy NULL-provenance rows all win."""
+        edge_id = await self._seed(edge_store, provenance_type=provenance_type)
+        assert await self._inferred(edge_store) is None
+        edge = await edge_store.get_edge(edge_id)
+        assert edge is not None
+        assert edge["provenance_type"] == provenance_type
+        assert edge["provenance_actor"] == "human"
+        assert edge["evidence"] == "manual"
+        assert edge["weight"] == pytest.approx(1.0)
+
+    async def test_blocked_by_resolved_inferred_row(self, edge_store) -> None:
+        """A manually resolved conflict on an inferred edge is authoritative."""
+        edge_id = await self._seed(
+            edge_store, provenance_type="inferred", conflict_state="resolved"
+        )
+        assert await self._inferred(edge_store) is None
+        edge = await edge_store.get_edge(edge_id)
+        assert edge is not None
+        assert edge["conflict_state"] == "resolved"
+        assert edge["evidence"] == "manual"
 
 
 class TestUpdateConflictResolution:

--- a/tests/test_enrich_worker.py
+++ b/tests/test_enrich_worker.py
@@ -128,6 +128,7 @@ async def worker(
         knowledge=mock_knowledge,
         coordination=mock_coordination,
         intake=_make_intake(mock_knowledge, event_bus, edge_store, mock_coordination),
+        search=MagicMock(),
     )
 
 
@@ -833,6 +834,7 @@ class TestEnrichNodeProvenanceHandoff:
             knowledge=km,
             coordination=coord,
             intake=_make_intake(km, event_bus, edge_store, coord),
+            search=MagicMock(),
         )
         return worker, km
 
@@ -1294,6 +1296,7 @@ class TestSelfOriginatedEventFilter:
             knowledge=km,
             coordination=mock_coordination,
             intake=intake,
+            search=MagicMock(),
         )
 
         await worker._extract_entities(doc_id)
@@ -1350,6 +1353,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=_make_intake(km, event_bus, edge_store, mock_coordination),
+            search=MagicMock(),
         )
 
         await worker._extract_entities(doc_id)
@@ -1403,6 +1407,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=intake,
+            search=MagicMock(),
         )
 
         await worker._extract_entities(doc_id)
@@ -1433,6 +1438,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=_make_intake(km, event_bus, edge_store, mock_coordination),
+            search=MagicMock(),
         )
 
     async def test_stale_marker_entities_reextracted(
@@ -1579,6 +1585,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=coord,
             intake=_make_intake(km, event_bus, edge_store, coord),
+            search=MagicMock(),
         )
         await worker.full_sweep()
 
@@ -1621,6 +1628,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=_make_intake(km, event_bus, edge_store, mock_coordination),
+            search=MagicMock(),
         )
 
         await worker._extract_entities(doc_id)
@@ -1658,6 +1666,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=_make_intake(km, event_bus, edge_store, mock_coordination),
+            search=MagicMock(),
         )
 
         # Call with edge.upserted trigger — should NOT extract entities
@@ -1708,6 +1717,7 @@ class TestExtractEntities:
             knowledge=km,
             coordination=mock_coordination,
             intake=_make_intake(km, event_bus, edge_store, mock_coordination),
+            search=MagicMock(),
         )
 
         await worker._extract_entities(doc_id)
@@ -1750,6 +1760,7 @@ class TestFullSweep:
             knowledge=km,
             coordination=coord,
             intake=_make_intake(km, event_bus, edge_store, coord),
+            search=MagicMock(),
         )
 
         # Create node_stats with last_used_at 14 days ago (will decay)
@@ -1812,6 +1823,7 @@ class TestFullSweep:
             knowledge=km,
             coordination=coord,
             intake=_make_intake(km, event_bus, edge_store, coord),
+            search=MagicMock(),
         )
 
         # Create two notes: source-note and derived-note
@@ -1895,6 +1907,7 @@ class TestFullSweep:
             knowledge=km,
             coordination=coord,
             intake=_make_intake(km, event_bus, edge_store, coord),
+            search=MagicMock(),
         )
 
         source = await km.create(title="Source", content="src", agent="test-agent")


### PR DESCRIPTION
## What & why

Second of two PRs delivering **MVP-3 WS1 slice 1** (tracker `7387506b`, epic `d921d168`). **#405 (the substrate) is merged**; this PR is rebased onto `main` and targets it directly. Together they take the semantically-empty typed-edge graph (17% coverage, 2 genuine relation types in the 2026-07 audit) and start densifying it with LLM-adjudicated `supports/contradicts/refines/is_example_of/depends_on/analogy_to` edges.

## Pipeline (per node, drain-triggered on note create/update)

policy gate → top-K semantic neighbours (`asyncio.to_thread(semantic_search)`, scout pattern) → pure pre-filter (similarity band 0.35–0.92, same namespace, entity/tag-overlap ranking, already-inferred pairs skipped; `related_to` does NOT skip — typed relations are additive) → **one** LLM call adjudicating all K candidates (`json_object` format, defensively parsed) → judgements ≥ confidence floor written via `intake.assert_edge` as `provenance_type="inferred"`, `weight=confidence`, `evidence={rationale, model, confidence}`. Symmetric relations canonicalize endpoints; `contradicts` is surfaced by existing conflict machinery, never auto-applied.

## Safety properties

- **Cascade-proof (the flagged risk)**: `assert_edge` gains `origin` (exact mirror of `note_update`); inference writes stamp `origin=enrich` → the worker drops its own `edge.upserted` events at the existing loop-break. Defense in depth: trigger gate (edge-triggered drains never infer) + op-log (edge writes don't bump doc version). **Regression-tested both ways**: stamped event re-enqueues nothing; the unstamped counterfactual proves it would re-enqueue both endpoints.
- **Budget/idempotency/re-inference**: gates on the PR1 ledgers — per-drain call cap (reset each `drain()`), daily token budget, and the `(node_id, doc_version, inference_version)` op-log. A doc update, `INFERENCE_VERSION` bump, or operator ledger purge genuinely re-adjudicates: already-inferred pairs are NOT excluded — re-runs refresh the inferred edge in place. Skips are observable (`lcma_edge_inference_skips{reason}`, incl. `asserted_exists` and `stale_version`).
- **Authority boundary (review round 1)**: inferred writes go through `assert_inferred_edge` → `EdgeStore.upsert_inferred`, which atomically refuses to displace asserted, legacy NULL-provenance, projection-owned, or manually-resolved rows — inferred ≠ asserted is one-way. Blocked judgements are counted, not silent.
- **Stale guard (review round 1)**: after the LLM call the focus version is re-read; a mid-flight note change discards the results (no edges, no op-log; spend recorded) so the queued newer version re-runs.
- **Strict parser (review round 1)**: non-boolean integer candidate indexes only; duplicates keep-first-and-count; direction is never invented (directional relations without a valid direction are dropped; symmetric ignore it). Partial/malformed-but-usable responses are flagged as `outcome="partial"`, never silently ok.
- **Failure-isolated**: LLM outage → item completes, no op-log row, no requeue churn (retries on the node's next update; slice-2 sweep closes the tail). Parse failure → op-log recorded (tokens were spent; a schema-incapable model must not re-burn the budget invisibly every drain).
- **Kill switch**: unset `LITHOS_LCMA__LLM__BASE_URL` — engine is only constructed when set; default config is a strict no-op (all 60 pre-existing enrich tests pass unchanged).

## Test plan

- `make check` **1776 passed** (was 1712 pre-review); `make test-integration` **463 passed**.
- 46 new tests (`test_edge_inference.py` + `test_edges.py`): pure prefilter/prompt/parse/endpoints incl. strict-index/direction/duplicate/coverage rules; engine over real StatsStore/EdgeStore/CorpusIntake + `httpx.MockTransport` (happy path incl. evidence payload; op-log short-circuit; trigger gate; budget/call-cap skips; outage vs parse-failure vs stale-version semantics; confidence floor; no-candidates fast path); authority boundary (asserted edge + resolved conflict survive inference; store-level asserted/projection/legacy-NULL blocks); re-inference (doc-version bump, ledger purge, INFERENCE_VERSION bump, changed-relation accumulation); worker lifecycle enabled/disabled; cascade guard both directions; drain-path end-to-end.
- Docs: WS1/WS2 checklist + design-doc updates (slice-2 remainder noted); `docs/generated/` regenerated. No tool-surface change — inferred edges are already visible through `lithos_related` / `lithos_edge_list`.

## Rollout (operator, post-merge)

Staging: `LITHOS_LCMA__LLM__BASE_URL=http://<ollama-host>:11434/v1` + `LITHOS_LCMA__LLM__MODEL=<model>`; watch `lcma_llm_calls/tokens`, `lcma_inferred_edges_written{relation}`, `lcma_edge_inference_skips`; spot-check edge quality via `lithos_edge_list` (provenance_type=inferred) and read the rationales; then prod. Defaults: 250k tokens/day, 10 calls/drain, floor 0.6, K=5.
