### PR TITLE
fix(docker): pass LITHOS_LCMA__LLM__* env vars through to the container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       - LITHOS_OTEL_ENABLED=${LITHOS_OTEL_ENABLED:-true}
       - LITHOS_ENVIRONMENT=${LITHOS_ENVIRONMENT:-dev}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://host.docker.internal:4318}
+      # WS1 LLM synthesis (optional): empty values normalise to disabled, so
+      # environments that omit these in .env.<env> keep synthesis off.
+      - LITHOS_LCMA__LLM__BASE_URL=${LITHOS_LCMA__LLM__BASE_URL:-}
+      - LITHOS_LCMA__LLM__MODEL=${LITHOS_LCMA__LLM__MODEL:-}
+      - LITHOS_LCMA__LLM__API_KEY=${LITHOS_LCMA__LLM__API_KEY:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8765/health"]
       interval: 10s


### PR DESCRIPTION
## What & why

Staging rollout of WS1 (#405/#406) found the compose `environment:` whitelist never forwards the new `LITHOS_LCMA__LLM__*` vars — `docker compose --env-file` only feeds compose-file interpolation, so OpenRouter/Ollama config in `.env.<env>` silently left synthesis disabled (`llm.enabled == False` in the container).

Adds the three pass-through lines with empty defaults. Empty values normalise to disabled (blank `base_url`/`api_key` → `None` per the #405 config hardening), so `prod`/`fuzz` env files that omit them are behaviourally unchanged.

## Test plan
- `docker compose -p lithos-staging --env-file .env.staging config` renders all three vars; with an env file omitting them, they render empty → disabled (verified locally).
- No Python changes; guardrails pass (48).