### PR TITLE
fix(lcma): raise max_output_tokens default for reasoning models; pass all LLM tunables through compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,11 +20,21 @@ services:
       - LITHOS_OTEL_ENABLED=${LITHOS_OTEL_ENABLED:-true}
       - LITHOS_ENVIRONMENT=${LITHOS_ENVIRONMENT:-dev}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://host.docker.internal:4318}
-      # WS1 LLM synthesis (optional): empty values normalise to disabled, so
-      # environments that omit these in .env.<env> keep synthesis off.
+      # WS1 LLM synthesis (optional): empty values are treated as unset
+      # (env_ignore_empty) so environments that omit these in .env.<env>
+      # keep synthesis off / config defaults.
       - LITHOS_LCMA__LLM__BASE_URL=${LITHOS_LCMA__LLM__BASE_URL:-}
       - LITHOS_LCMA__LLM__MODEL=${LITHOS_LCMA__LLM__MODEL:-}
       - LITHOS_LCMA__LLM__API_KEY=${LITHOS_LCMA__LLM__API_KEY:-}
+      - LITHOS_LCMA__LLM__MAX_OUTPUT_TOKENS=${LITHOS_LCMA__LLM__MAX_OUTPUT_TOKENS:-}
+      - LITHOS_LCMA__LLM__TIMEOUT_SECONDS=${LITHOS_LCMA__LLM__TIMEOUT_SECONDS:-}
+      - LITHOS_LCMA__LLM__DAILY_TOKEN_BUDGET=${LITHOS_LCMA__LLM__DAILY_TOKEN_BUDGET:-}
+      - LITHOS_LCMA__LLM__MAX_CALLS_PER_DRAIN=${LITHOS_LCMA__LLM__MAX_CALLS_PER_DRAIN:-}
+      - LITHOS_LCMA__LLM__CONFIDENCE_FLOOR=${LITHOS_LCMA__LLM__CONFIDENCE_FLOOR:-}
+      - LITHOS_LCMA__LLM__NEIGHBOUR_K=${LITHOS_LCMA__LLM__NEIGHBOUR_K:-}
+      - LITHOS_LCMA__LLM__MIN_SIMILARITY=${LITHOS_LCMA__LLM__MIN_SIMILARITY:-}
+      - LITHOS_LCMA__LLM__MAX_SIMILARITY=${LITHOS_LCMA__LLM__MAX_SIMILARITY:-}
+      - LITHOS_LCMA__LLM__SNIPPET_CHARS=${LITHOS_LCMA__LLM__SNIPPET_CHARS:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8765/health"]
       interval: 10s

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -331,11 +331,11 @@
         "classes": 10,
         "functions": 23,
         "largest_module": "lithos.config",
-        "largest_module_lines": 536,
-        "lines": 536,
+        "largest_module_lines": 546,
+        "lines": 546,
         "modules": 1,
         "public_symbols": 13,
-        "sloc": 377
+        "sloc": 378
       },
       "Coordination": {
         "classes": 8,
@@ -483,13 +483,13 @@
       "lithos.telemetry",
       "lithos.tools.tasks"
     ],
-    "total_lines": 25489,
+    "total_lines": 25499,
     "total_modules": 44,
-    "total_sloc": 20485
+    "total_sloc": 20486
   },
   "tests": {
     "ratio": 1.86,
-    "src_lines": 25489,
-    "test_lines": 47534
+    "src_lines": 25499,
+    "test_lines": 47547
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -36,7 +36,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Codec | 1 | 777 | 583 | 7 | 0 | 0.00 | 14 (`lithos.frontmatter_codec.KnowledgeMetadata.from_dict`) | 3 |
 | CognitiveMemory | 1 | 1158 | 953 | 1 | 12 | 0.92 | 26 (`lithos.cognitive_memory.CognitiveMemory.validate_task_feedback`) | 3 |
-| Config | 1 | 536 | 377 | 11 | 1 | 0.08 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
+| Config | 1 | 546 | 378 | 11 | 1 | 0.08 | 14 (`lithos.config.LithosConfig._apply_backward_compat_env_overrides`) | 1 |
 | Coordination | 1 | 2675 | 2256 | 4 | 4 | 0.50 | 20 (`lithos.coordination.CoordinationService.create_task`) | 5 |
 | Entrypoints | 13 | 5905 | 4737 | 0 | 13 | 1.00 | 65 (`lithos.tools.notes.register.lithos_write`) | 15 |
 | Errors | 2 | 233 | 168 | 8 | 0 | 0.00 | 2 (`lithos.envelopes.error_envelope`) | 0 |
@@ -53,7 +53,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **44**, lines: **25489**, SLOC: **20485**
+- Modules: **44**, lines: **25499**, SLOC: **20486**
 - Largest module: `lithos.coordination` (2675 lines)
 - Modules over 800 lines: **11**
   - `lithos.cli`
@@ -151,4 +151,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 
 - Domain models: **44** (26 associations, 0 without docstrings)
 - MCP tools: **37** (0 without docstrings)
-- Test-to-source line ratio: **1.86** (47534 test lines / 25489 source lines)
+- Test-to-source line ratio: **1.86** (47547 test lines / 25499 source lines)

--- a/src/lithos/config.py
+++ b/src/lithos/config.py
@@ -196,7 +196,13 @@ class LlmConfig(BaseModel):
     model: str = Field(default="", validate_default=True)
     api_key: SecretStr | None = None
     timeout_seconds: float = Field(default=120.0, gt=0.0)
-    max_output_tokens: int = Field(default=1024, gt=0)
+    # Cap on completion tokens per call. Reasoning models (gpt-5 family etc.)
+    # spend completion budget on hidden reasoning BEFORE emitting text — a tight
+    # cap truncates them into null/cut-off content (observed on gpt-5-mini at
+    # 1024 with production prompts: 979/1024 spent). The cap is protective, not
+    # a spend target, so a generous default costs nothing on non-reasoning
+    # models.
+    max_output_tokens: int = Field(default=4096, gt=0)
     # Budget bounds: a UTC-day *soft* token ceiling plus a per-drain-cycle call
     # cap. Admission is check-before-call with the actual spend recorded after
     # the call, so the ledger can overshoot the ceiling by at most the final
@@ -395,11 +401,15 @@ class LithosConfig(BaseSettings):
     # validating model, so the root settings class must hide raw input or a
     # failed validation anywhere in the tree echoes sibling values — including
     # unwrapped secrets like lcma.llm.api_key — into logs/CI output.
+    # env_ignore_empty: deployment tooling (docker compose pass-through with
+    # empty defaults) exports blank env vars for unset settings; treat them as
+    # unset instead of failing int/float parsing on "".
     model_config = SettingsConfigDict(
         env_prefix="LITHOS_",
         env_nested_delimiter="__",
         extra="ignore",
         hide_input_in_errors=True,
+        env_ignore_empty=True,
     )
 
     server: ServerConfig = Field(default_factory=ServerConfig)

--- a/tests/test_lcma_config.py
+++ b/tests/test_lcma_config.py
@@ -402,6 +402,19 @@ class TestLlmConfigHardening:
         for surface in (str(excinfo.value), repr(excinfo.value)):
             assert "sk-topsecret" not in surface
 
+    def test_empty_env_vars_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Compose pass-through exports blank env vars for unset settings;
+        env_ignore_empty must keep them from failing int/float parsing."""
+        monkeypatch.setenv("LITHOS_LCMA__LLM__BASE_URL", "")
+        monkeypatch.setenv("LITHOS_LCMA__LLM__MODEL", "")
+        monkeypatch.setenv("LITHOS_LCMA__LLM__API_KEY", "")
+        monkeypatch.setenv("LITHOS_LCMA__LLM__MAX_OUTPUT_TOKENS", "")
+        monkeypatch.setenv("LITHOS_LCMA__LLM__CONFIDENCE_FLOOR", "")
+        cfg = LithosConfig()
+        assert not cfg.lcma.llm.enabled
+        assert cfg.lcma.llm.max_output_tokens == 4096  # default, not ValidationError
+        assert cfg.lcma.llm.confidence_floor == 0.6
+
     def test_base_url_whitespace_padding_stripped(self) -> None:
         cfg = LlmConfig(base_url="  http://ollama:11434/v1  ", model="m")
         assert cfg.base_url == "http://ollama:11434/v1"


### PR DESCRIPTION
## What & why

The staging soak surfaced two issues when the model was switched to `openai/gpt-5-mini`:

1. **20 of 23 calls failed** (`outcome=error` ×14 null content, `parse_error` ×6 truncated JSON). Root cause reproduced in the container: reasoning models spend completion budget on hidden reasoning before emitting text — a production-shaped 5-candidate prompt consumed **979 of the 1024-token cap**, so most real calls tip over. Default `max_output_tokens` is now **4096** with a comment explaining why; the cap is protective, not a spend target, so it costs nothing on non-reasoning models. (Direction quality, the thing the model switch was testing, is meanwhile confirmed good under mini — all sampled edges agree with their rationales.)
2. **The tunables were unreachable**: #409 only forwarded `base_url`/`model`/`api_key` through compose, so `LITHOS_LCMA__LLM__MAX_OUTPUT_TOKENS` in an env file went nowhere. Compose now passes the whole `LITHOS_LCMA__LLM__*` family. That requires `env_ignore_empty=True` on `LithosConfig` — blank pass-through defaults (`${VAR:-}`) would otherwise fail int/float parsing — which also matches the existing blank-env normalisation philosophy for `base_url`/`api_key`.

## Test plan
- `make check` green — **1777 passed** (new regression test: blank `LITHOS_LCMA__LLM__*` env vars for int/float fields are treated as unset, not a ValidationError).
- `docker compose --env-file .env.staging config` renders all 12 LLM vars; envs omitting them get defaults (verified locally).
- Staging validation after merge: rebuild + restart, confirm `lcma_llm_calls{outcome="ok"}` dominates and error/parse_error stop accumulating under gpt-5-mini.