### PR TITLE
docs(skill): short-id-prefix backstop; bump lithos skill to 0.3.0

### DIFF
--- a/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/lithos",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, model task dependencies with the task graph (blocking edges, subtasks/epics, gates), claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle and task graph, project conventions, and tagging.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/skills/lithos/SKILL.md
+++ b/agent-skills/plugins/lithos/skills/lithos/SKILL.md
@@ -98,6 +98,12 @@ Always set **both** `tags=["project:<slug>"]` and `metadata={"project": "<slug>"
 
 Use `lithos_retrieve` (not `lithos_search`) when quality matters — it runs multi-scout retrieval with reranking. Use `lithos_search` for quick exploration.
 
+## Short ID Prefixes
+
+Every task/note id parameter accepts an **unambiguous short prefix** (>= 6 chars, git-style): `lithos_task_get(task_id="83257ced")` just works. Task prefixes resolve against tasks, note prefixes against notes. An ambiguous prefix fails loudly with `ambiguous_id_prefix` listing candidate `{id, title}` pairs — retry with a longer prefix from the list. Mutating responses echo the resolved full id + title; check the echo to confirm you touched the right record.
+
+**Backstop: never reconstruct a full UUID from surrounding context.** Short ids in prose are prefixes — pass them as-is. A guessed UUID that happens to exist writes to the *wrong* record and reports success; the prefix path can only resolve correctly or fail loudly.
+
 ## Writing Knowledge: Key Decisions
 
 **What deserves a write:**
@@ -150,6 +156,7 @@ Run both task queries and union results — no single query covers all agents' c
 
 ## Pitfalls
 
+- **Don't reconstruct full UUIDs from context** — pass the short id as a prefix instead (see Short ID Prefixes). A fabricated UUID that happens to exist silently writes to the wrong record
 - **Don't skip the search step** — the most common mistake. Always `lithos_cache_lookup` or `lithos_search` before writing new knowledge
 - **Don't use `lithos_search` when quality matters** — it doesn't enforce access scopes or track salience. Use `lithos_retrieve` for actual work
 - **Don't set only tags OR only metadata on tasks** — set both. Loom queries by `metadata.project`; Agent Zero queries by tag

--- a/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/error-handling.md
@@ -22,6 +22,7 @@ always in the same shape; task-graph tools also emit `invalid_edge_type`,
 | Code | Meaning | Action |
 |------|---------|--------|
 | `invalid_input` | Field validation failed | Check error message for specifics |
+| `ambiguous_id_prefix` | A short id prefix matched more than one task/note; response carries `candidates: [{id, title}]` | Retry with a longer prefix or a full id from the candidates — never guess |
 | `invalid_metadata_key` | Task metadata contains `depends_on`/`blocked_on`, or note metadata collides with a reserved key | Use the `depends_on` param or task edges; rename the note key |
 | `content_too_large` | Content exceeds the size limit | Trim or split the document |
 | `doc_not_found` | ID doesn't exist | Verify the UUID |


### PR DESCRIPTION
Follow-up to #412 (task `83257ced`): the task called for a backstop line in the lithos skill documenting the invariant behind prefix resolution.

## What

- **SKILL.md**: new "Short ID Prefixes" section — every task/note id parameter accepts an unambiguous >= 6-char prefix, per-domain namespaces, `ambiguous_id_prefix` with candidates on collision, resolved id + title echoed on mutations. Plus the backstop itself, stated twice (section + Pitfalls): **never reconstruct a full UUID from surrounding context** — pass the short id as a prefix; a guessed UUID that happens to exist writes to the wrong record and reports success, while the prefix path can only resolve correctly or fail loudly.
- **references/error-handling.md**: `ambiguous_id_prefix` added to the error-code table (the file claims completeness).
- **plugin.json**: version 0.2.0 → 0.3.0.

Docs-only; no code paths touched. Both staging and prod already run the #412 behavior this documents.
