### PR TITLE
ci: publish only the agent-skill plugins touched by the push

### DIFF
--- a/.github/workflows/publish-agent-skills.yml
+++ b/.github/workflows/publish-agent-skills.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'agent-skills/**'
       - '.github/workflows/publish-agent-skills.yml'
-  workflow_dispatch:  # allow manual trigger from the GitHub UI
+  workflow_dispatch:  # manual trigger from the GitHub UI publishes ALL plugins
 
 permissions:
   id-token: write   # Required for OIDC repo linking
@@ -16,14 +16,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # the changed-plugin diff needs the pushed range
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       # Publishes the version committed in each plugin manifest verbatim.
       # Changing a plugin means bumping its manifest version in the same PR;
       # an already-published version fails loudly here as the reminder.
-      - name: Publish plugins
+      # Only plugins touched by the push are published, so an unchanged
+      # sibling plugin can never turn the run red. A workflow-file-only push
+      # publishes nothing. Manual workflow_dispatch publishes every plugin —
+      # the recovery path — and fails loudly on versions the registry
+      # already has.
+      - name: Determine changed plugins
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            plugins=$(ls -d agent-skills/plugins/*/ | xargs -n1 basename | sort | xargs)
+          else
+            base="${{ github.event.before }}"
+            # Guard the zero-sha of a first push and force-pushed-away bases.
+            if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+              base=$(git rev-parse "${{ github.sha }}^")
+            fi
+            plugins=$(git diff --name-only "$base" "${{ github.sha }}" -- 'agent-skills/plugins/' \
+              | cut -d/ -f3 | sort -u | xargs)
+          fi
+          echo "Changed plugins: ${plugins:-none}"
+          echo "plugins=$plugins" >> "$GITHUB_OUTPUT"
+      - name: Publish changed plugins
+        if: steps.changed.outputs.plugins != ''
         working-directory: agent-skills
         run: |
-          tessl plugin publish ./plugins/lithos
-          tessl plugin publish ./plugins/influx-inbox
+          for plugin in ${{ steps.changed.outputs.plugins }}; do
+            tessl plugin publish "./plugins/$plugin"
+          done


### PR DESCRIPTION
Fixes the red "Publish Agent Skills" run that #413 produced: the publish step ran **every** plugin verbatim, so the lithos-only skill change failed on the unchanged `influx-inbox` manifest ("agent-lore/influx-inbox@0.1.3 already exists") — after `agent-lore/lithos@0.3.0` had already published successfully.

## What changes

- **Push events publish only the plugins touched by the pushed range**: diff `github.event.before..github.sha` restricted to `agent-skills/plugins/`, take the plugin directory names. The base is guarded against the zero-sha of a first push and force-pushed-away commits (falls back to `HEAD^`). A workflow-file-only push publishes nothing.
- **`workflow_dispatch` still publishes all plugins** — the deliberate recovery path — and keeps failing loudly on versions the registry already has.
- The manifest-bump discipline is unchanged: a changed plugin whose version wasn't bumped still fails loudly, but now only on the PR that actually changed it.
- `fetch-depth: 0` added to checkout so the pushed range is diffable.

## Verification

- Diff logic sanity-checked locally against the real #413 merge range (`8ce96bd..97d81ae` → exactly `lithos`).
- YAML parse-checked. The loop is a plain `for` over space-separated directory basenames (no eval/expansion of untrusted input — names come from `git diff` paths under `agent-skills/plugins/`).
