### PR TITLE
docs(skill): document task updated_at change detection; bump lithos skill to 0.3.1

### DIFF
--- a/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
+++ b/agent-skills/plugins/lithos/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lore/lithos",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Use when working with Lithos via MCP to search or write knowledge, create or coordinate tasks, model task dependencies with the task graph (blocking edges, subtasks/epics, gates), claim work before starting, post findings, or collaborate with other agents. Covers the full agent workflow: register, search-before-work, knowledge read/write, task lifecycle and task graph, project conventions, and tagging.",
   "private": true
 }

--- a/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
+++ b/agent-skills/plugins/lithos/skills/lithos/references/task-coordination.md
@@ -71,9 +71,19 @@ lithos_task_update(task_id="...", agent="<id>", title=..., description=..., tags
 
 - At least one of `title` / `description` / `tags` / `metadata` is required
 - Works on **terminal** tasks — annotate completed/cancelled tasks without reviving them
-- `metadata` is an additive per-key merge: a value overwrites that key, `null` deletes it, unmentioned keys are preserved, `{}` is a no-op
+- `metadata` is an additive per-key merge: a value overwrites that key, `null` deletes it, unmentioned keys are preserved, `{}` changes no keys (but still writes the row and bumps `updated_at`)
 - `tags` replaces the whole list
 - Same forbidden keys as create: `depends_on` / `blocked_on` → `invalid_metadata_key`
+
+---
+
+## Change Detection: `updated_at`
+
+Every task record carries `updated_at` — a last-modified stamp returned by `lithos_task_get` / `lithos_task_list` / `lithos_task_status` (and the ready/blocked/children views), carried in row-mutating event payloads, and echoed by every mutating tool response.
+
+- Bumped by every task-**row** write: create (`= created_at`), any `lithos_task_update` (even a `metadata={}` no-op merge), complete/cancel (`= resolved_at`), reopen
+- **Never** bumped by claim/renew/release — lease heartbeats don't count as edits
+- To detect "edited since I last looked", record the stamp (your own mutation's echo saves a racy re-read) and compare for **equality** — a differing stamp means someone wrote the row; don't rely on ordering
 
 ---
 


### PR DESCRIPTION
## Summary

The shipped lithos skill (0.3.0, #413) predates `updated_at` on task records (#415/#416). This adds the missing coverage:

- New **Change Detection: `updated_at`** section in `references/task-coordination.md` — what bumps the stamp (every task-row write: create/update/complete/cancel/reopen, including a `metadata={}` no-op merge) vs. what never does (claim/renew/release), where it surfaces (get/list/status + ready/blocked/children, row-mutating events, mutating-response echoes), and the record-the-echo / compare-for-equality detection pattern.
- Updated the `metadata={}` bullet in **Updating Tasks** to note the row write + stamp bump.
- Manifest bump `0.3.0 → 0.3.1` so the publish workflow ships the touched plugin (verbatim-version publishing, #376/#414).

Markdown + manifest only — no code changes.

## Test plan

- [x] Content cross-checked against `SPECIFICATION.md` §5.4 and the #415/#416 implementation (claim ops touch only the claims table; `updated_at` echoed on mutating responses)
- [ ] `Publish agent skills` workflow publishes `agent-lore/lithos@0.3.1` on merge (lithos plugin only, per #414 touched-plugin filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSmaazv8JXyoHGYUGUwii